### PR TITLE
Preserve MONOCHROME Photometric Interpretation in JpegLossless compression

### DIFF
--- a/Codec/DicomJpegCodec.cs
+++ b/Codec/DicomJpegCodec.cs
@@ -1912,13 +1912,17 @@ namespace FellowOakDicom.Imaging.NativeCodec
                             jpeg_destroy_compress_16_MacOS(ref cinfo);
                         }
 
-                        if (jpegParams.SampleFactor == DicomJpegSampleFactor.SF422)
+                        if (oldPixelData.PhotometricInterpretation == PhotometricInterpretation.Rgb
+                            && cinfo.jpeg_color_space == J_COLOR_SPACE.JCS_YCbCr)
                         {
-                            newPixelData.PhotometricInterpretation = PhotometricInterpretation.YbrFull422;
-                        }
-                        else
-                        {
-                            newPixelData.PhotometricInterpretation = PhotometricInterpretation.YbrFull;
+                            if (jpegParams.SampleFactor == DicomJpegSampleFactor.SF422)
+                            {
+                                newPixelData.PhotometricInterpretation = PhotometricInterpretation.YbrFull422;
+                            }
+                            else
+                            {
+                                newPixelData.PhotometricInterpretation = PhotometricInterpretation.YbrFull;
+                            }
                         }
 
                         IByteBuffer buffer;


### PR DESCRIPTION
see #13
Currently DicomJpegCodec ALWAYS updates PhotometricInterpretation to at least YbrFull. But in case of JpegLossess with monochrome input this breaks the image.
So the DicomJpegCodec shall only update the PhotometricInterpretation if the pixel data is actually converted in color space. The same issue has been discussed in old desktop codec project. There is already a condition that worked fine so far, so I replicate this condition here.