### PR TITLE
Updated Platform.cs to identify arm64 windows architecture.

### DIFF
--- a/Codec/Platform.cs
+++ b/Codec/Platform.cs
@@ -60,6 +60,10 @@ namespace FellowOakDicom.Imaging.NativeCodec
                 {
                     return Type.osx_arm64;
                 }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return Type.win_arm64;
+                }
             }
 
             return Type.unsupported;


### PR DESCRIPTION
 Cloning a Dataset returns "Unsupported OS Platform."  Type.win_arm64 is defined in Platform.cs, but is unreferenced. Added response to return Type.win_arm64 when this architecture is found.