### PR TITLE
Issue #133: Fix duplicate Return on SharedArrayPool

### DIFF
--- a/Codec/DicomJpegLsCodec.cs
+++ b/Codec/DicomJpegLsCodec.cs
@@ -290,7 +290,6 @@ namespace FellowOakDicom.Imaging.NativeCodec
 
                             newJpegData = pool.Rent((int)jpegDataSize);
                             Array.Copy(jpegData, newJpegData, newJpegData.Length);
-                            pool.Return(jpegData);
 
                             IByteBuffer buffer;
 


### PR DESCRIPTION
I think I have found the root cause for issue #133 in \Codec\DicomJpegLsCodec.cs, DicomJpegLsNativeCodec.Encode. The "jpegData" is returned twice to the SharedArrayPool.
I removed the line with the first Return (line 293), so that Return happens only in the finally block.
I found the same pattern in other codecs.

With this change I was not able to reproduce the issue anymore.
Returning twice is not valid according to documentation, and you can also find discussions on this pitfall (e.g. https://github.com/dotnet/runtime/issues/33767).


> The reference returned from a given call to System.Buffers.ArrayPool1.Rent(System.Int32) must only be returned via System.Buffers.ArrayPool1.Return(`0[],System.Boolean) once.


