### PR TITLE
Fix integer overflow in JPEG 2000 encode output buffer sizing

### DIFF
--- a/Codec/DicomJpeg2000Codec.cs
+++ b/Codec/DicomJpeg2000Codec.cs
@@ -859,14 +859,15 @@ namespace FellowOakDicom.Imaging.NativeCodec
                                         throw new DicomCodecException("JPEG 2000 codec only supports Bits Allocated == 8 or 16");
                                 }
 
-                                uint img_size = 0;
+                                ulong img_size = 0;
                                 for (int i = 0; i < image->numcomps; i++)
                                 {
-                                    img_size += image->comps[i].w * image->comps[i].h * image->comps[i].prec;
+                                    img_size += (ulong)image->comps[i].w * image->comps[i].h * image->comps[i].prec;
                                 }
 
-                                var outlen = (uint)(0.1625 * img_size + 2000); /* 0.1625 = 1.3/8 and 2000 bytes as a minimum for headers */
-                                cbuf = pool.Rent((int)outlen);
+                                const int maxArrayLength = 0x7FFFFFC7;
+                                var outlen = (ulong)(0.1625 * img_size + 2000); /* 0.1625 = 1.3/8 and 2000 bytes as a minimum for headers */
+                                cbuf = pool.Rent(outlen > maxArrayLength ? maxArrayLength : (int)outlen);
 
                                 fixed (byte * buf = cbuf)
                                 {


### PR DESCRIPTION
img_size was accumulated in a uint, which overflows for images where width * height * precision * components exceeds 2^32 bits (e.g. RGB 8-bit images larger than ~179 megapixels). The wrapped value produced an output buffer roughly one tenth of the required size, causing opj_encode to fail with "Unable to JPEG 2000 encode image".

Accumulate in ulong instead and clamp the requested buffer length to the maximum array length.