### PR TITLE
Add cgmanifest.json to track vendored native codec libraries (libijg, OpenJPEG, CharLS, OpenJPH)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "version": 1,
+  "registrations": [
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "libijg",
+          "version": "6b",
+          "downloadUrl": "https://www.ijg.org/files/jpegsrc.v6b.tar.gz"
+        }
+      },
+      "developmentDependency": false
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/uclouvain/openjpeg",
+          "commitHash": "v2.5.4"
+        }
+      },
+      "developmentDependency": false
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/team-charls/charls",
+          "commitHash": "2.4.2"
+        }
+      },
+      "developmentDependency": false
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/aous72/OpenJPH",
+          "commitHash": "0.21.2"
+        }
+      },
+      "developmentDependency": false
+    }
+  ]
+}


### PR DESCRIPTION
The native codecs under `Native/Common/` (libijg 6b, OpenJPEG 2.5.4, CharLS 2.4.2, OpenJPH 0.21.2) are vendored C/C++ sources with no submodule/component-governance tracking, so consumers can't tell which upstream versions are statically linked into `Dicom.Native` and can't be alerted to advisories against them.

This PR adds a root `cgmanifest.json` registering the four libraries at their currently-vendored versions. No source or build change -- purely metadata so Microsoft Component Governance / dependency scanners can track versions and advisories.

Versions were read from the vendored headers on `master`:
- libijg `6b` (`Native/Common/libijg{8,12,16}/jversion*.h` -> JVERSION \6b  27-Mar-1998\)
- OpenJPEG `2.5.4` (`OPJ_PACKAGE_VERSION`)
- CharLS `2.4.2` (`CHARLS_VERSION_MAJOR/MINOR/PATCH`)
- OpenJPH `0.21.2` (`OPENJPH_VERSION_MAJOR/MINOR/PATCH`)

Possible follow-ups (separate issues): refresh libijg 6b (1998) to libjpeg-turbo or a current DCMTK IJG snapshot, and uplift OpenJPEG / CharLS / OpenJPH to current releases.