### PR TITLE
Uplift vendored CharLS 2.4.2 -> 2.4.4 (security fix GHSA-mqrg-gfc8-73ff)

### DIFF
--- a/Native/Common/CharLS/charls/public_types.h
+++ b/Native/Common/CharLS/charls/public_types.h
@@ -921,12 +921,12 @@ struct charls_spiff_header CHARLS_FINAL
 struct charls_frame_info CHARLS_FINAL
 {
     /// <summary>
-    /// Width of the image, range [1, 65535].
+    /// Width of the image, range [1, 100000].
     /// </summary>
     uint32_t width;
 
     /// <summary>
-    /// Height of the image, range [1, 65535].
+    /// Height of the image, range [1, 100000].
     /// </summary>
     uint32_t height;
 

--- a/Native/Common/CharLS/charls/version.h
+++ b/Native/Common/CharLS/charls/version.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define CHARLS_VERSION_MAJOR 2
 #define CHARLS_VERSION_MINOR 4
-#define CHARLS_VERSION_PATCH 2
+#define CHARLS_VERSION_PATCH 4
 
 /// <summary>
 /// Returns the version of CharLS in the semver format "major.minor.patch" or "major.minor.patch-pre_release"

--- a/Native/Common/CharLS/charls_jpegls_encoder.cpp
+++ b/Native/Common/CharLS/charls_jpegls_encoder.cpp
@@ -37,8 +37,8 @@ struct charls_jpegls_encoder final
 
     void frame_info(const charls_frame_info& frame_info)
     {
-        check_argument(frame_info.width > 0, jpegls_errc::invalid_argument_width);
-        check_argument(frame_info.height > 0, jpegls_errc::invalid_argument_height);
+        check_argument(frame_info.width > 0 && frame_info.width <= maximum_width, jpegls_errc::invalid_argument_width);
+        check_argument(frame_info.height > 0 && frame_info.height <= maximum_height, jpegls_errc::invalid_argument_height);
         check_argument(frame_info.bits_per_sample >= minimum_bits_per_sample &&
                            frame_info.bits_per_sample <= maximum_bits_per_sample,
                        jpegls_errc::invalid_argument_bits_per_sample);
@@ -99,8 +99,8 @@ struct charls_jpegls_encoder final
 
     void write_spiff_header(const spiff_header& spiff_header)
     {
-        check_argument(spiff_header.height > 0, jpegls_errc::invalid_argument_height);
-        check_argument(spiff_header.width > 0, jpegls_errc::invalid_argument_width);
+        check_argument(spiff_header.height > 0 && spiff_header.height <= maximum_height, jpegls_errc::invalid_argument_height);
+        check_argument(spiff_header.width > 0 && spiff_header.width <= maximum_width, jpegls_errc::invalid_argument_width);
         check_operation(state_ == state::destination_set);
 
         writer_.write_start_of_image();
@@ -288,7 +288,8 @@ private:
         // Stride parameter defines the number of bytes on a scan line.
         if (interleave_mode_ == charls::interleave_mode::none)
         {
-            const size_t minimum_source_size{stride * frame_info_.component_count * frame_info_.height - (stride - minimum_stride)};
+            const size_t minimum_source_size{stride * frame_info_.component_count * frame_info_.height -
+                                             (stride - minimum_stride)};
             if (UNLIKELY(source_size < minimum_source_size))
                 throw_jpegls_error(jpegls_errc::invalid_argument_stride);
         }

--- a/Native/Common/CharLS/constants.h
+++ b/Native/Common/CharLS/constants.h
@@ -22,6 +22,8 @@ constexpr int maximum_component_count{255};
 constexpr int minimum_bits_per_sample{2};
 constexpr int maximum_bits_per_sample{16};
 constexpr int maximum_near_lossless{255};
+constexpr uint32_t maximum_width{100'000};  // Implementation limitation.
+constexpr uint32_t maximum_height{100'000}; // Implementation limitation.
 constexpr int32_t minimum_application_data_id{0};
 constexpr int32_t maximum_application_data_id{15};
 

--- a/Native/Common/CharLS/jpeg_stream_reader.cpp
+++ b/Native/Common/CharLS/jpeg_stream_reader.cpp
@@ -112,7 +112,7 @@ void jpeg_stream_reader::decode(byte_span destination, size_t stride)
     const uint32_t width{rect_.Width != 0 ? static_cast<uint32_t>(rect_.Width) : frame_info_.width};
     const size_t components_in_plane_count{
         parameters_.interleave_mode == interleave_mode::none ? 1U : static_cast<size_t>(frame_info_.component_count)};
-    const size_t minimum_stride{components_in_plane_count * width * bit_to_byte_count(frame_info_.bits_per_sample)};
+    const size_t minimum_stride{checked_mul(components_in_plane_count * bit_to_byte_count(frame_info_.bits_per_sample), width)};
 
     if (stride == auto_calculate_stride)
     {
@@ -127,7 +127,7 @@ void jpeg_stream_reader::decode(byte_span destination, size_t stride)
     // Compute the layout of the destination buffer.
     const size_t bytes_per_plane{stride * rect_.Height};
     const size_t plane_count{parameters_.interleave_mode == interleave_mode::none ? frame_info_.component_count : 1U};
-    const size_t minimum_destination_size = bytes_per_plane * plane_count - (stride - minimum_stride);
+    const size_t minimum_destination_size = checked_mul(bytes_per_plane, plane_count) - (stride - minimum_stride);
     if (UNLIKELY(destination.size < minimum_destination_size))
         throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
 
@@ -142,7 +142,8 @@ void jpeg_stream_reader::decode(byte_span destination, size_t stride)
         const unique_ptr<decoder_strategy> codec{jls_codec_factory<decoder_strategy>().create_codec(
             frame_info_, parameters_, get_validated_preset_coding_parameters())};
         unique_ptr<process_line> process_line(codec->create_process_line(destination, stride));
-        const size_t bytes_read{codec->decode_scan(std::move(process_line), rect_, const_byte_span{position_, end_position_})};
+        const size_t bytes_read{
+            codec->decode_scan(std::move(process_line), rect_, const_byte_span{position_, end_position_})};
         advance_position(bytes_read);
         state_ = state::scan_section;
     }
@@ -153,8 +154,14 @@ void jpeg_stream_reader::read_end_of_image()
 {
     ASSERT(state_ == state::scan_section);
 
-    const jpeg_marker_code marker_code{read_next_marker_code()};
-    if (UNLIKELY(marker_code != jpeg_marker_code::end_of_image))
+    auto start_byte{read_byte_checked()};
+
+    // Some legacy JPEG encoders write a padding zero byte after the pixel data, which is not compliant but supported.
+    if (UNLIKELY(start_byte == 0))
+    {
+        start_byte = read_byte_checked();
+    }
+    if (UNLIKELY(start_byte != jpeg_marker_start_byte || read_marker_code() != jpeg_marker_code::end_of_image))
         throw_jpegls_error(jpegls_errc::end_of_image_marker_not_found);
 
 #ifndef NDEBUG
@@ -181,17 +188,25 @@ void jpeg_stream_reader::read_next_start_of_scan()
 
 USE_DECL_ANNOTATIONS jpeg_marker_code jpeg_stream_reader::read_next_marker_code()
 {
-    auto byte{read_byte_checked()};
+    const auto byte{read_byte_checked()};
     if (UNLIKELY(byte != jpeg_marker_start_byte))
         throw_jpegls_error(jpegls_errc::jpeg_marker_start_byte_not_found);
 
-    // Read all preceding 0xFF fill values until a non 0xFF value has been found. (see ISO/IEC 10918-1, B.1.1.2)
-    do
-    {
-        byte = read_byte_checked();
-    } while (byte == jpeg_marker_start_byte);
+    return read_marker_code();
+}
 
-    return static_cast<jpeg_marker_code>(byte);
+
+USE_DECL_ANNOTATIONS jpeg_marker_code jpeg_stream_reader::read_marker_code()
+{
+    auto marker_code{read_byte_checked()};
+
+    // Read all preceding 0xFF fill values until a non 0xFF value has been found. (see ISO/IEC 10918-1, B.1.1.2)
+    while (marker_code == jpeg_marker_start_byte)
+    {
+        marker_code = read_byte_checked();
+    }
+
+    return static_cast<jpeg_marker_code>(marker_code);
 }
 
 
@@ -781,10 +796,10 @@ void jpeg_stream_reader::skip_remaining_segment_data() noexcept
 
 void jpeg_stream_reader::check_frame_info() const
 {
-    if (UNLIKELY(frame_info_.height < 1))
-        throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
+    if (UNLIKELY(frame_info_.height < 1 || frame_info_.height > maximum_height))
+        throw_jpegls_error(jpegls_errc::invalid_parameter_height);
 
-    if (UNLIKELY(frame_info_.width < 1))
+    if (UNLIKELY(frame_info_.width < 1 || frame_info_.width > maximum_width))
         throw_jpegls_error(jpegls_errc::invalid_parameter_width);
 }
 

--- a/Native/Common/CharLS/jpeg_stream_reader.h
+++ b/Native/Common/CharLS/jpeg_stream_reader.h
@@ -96,6 +96,7 @@ private:
     void check_segment_size(size_t expected_size) const;
     void read_next_start_of_scan();
     CHARLS_CHECK_RETURN jpeg_marker_code read_next_marker_code();
+    CHARLS_CHECK_RETURN jpeg_marker_code read_marker_code();
     void validate_marker_code(jpeg_marker_code marker_code) const;
     CHARLS_CHECK_RETURN jpegls_pc_parameters get_validated_preset_coding_parameters() const;
     void read_marker_segment(jpeg_marker_code marker_code, spiff_header* header = nullptr,

--- a/Native/Common/CharLS/util.h
+++ b/Native/Common/CharLS/util.h
@@ -52,8 +52,8 @@
 #define MSVC_WARNING_UNSUPPRESS() __pragma(warning(pop))
 
 #define MSVC_WARNING_SUPPRESS_NEXT_LINE(x) \
-    __pragma(warning(suppress \
-                     : x)) // NOLINT(misc-macro-parentheses, bugprone-macro-parentheses, cppcoreguidelines-macro-usage)
+    __pragma( \
+        warning(suppress : x)) // NOLINT(misc-macro-parentheses, bugprone-macro-parentheses, cppcoreguidelines-macro-usage)
 
 // Helper macro for SAL annotations.
 #define USE_DECL_ANNOTATIONS _Use_decl_annotations_
@@ -504,21 +504,33 @@ auto countl_zero(const T value) noexcept -> std::enable_if_t<is_uint_v<32, T>, i
 
 #endif
 
-
-#if INTPTR_MAX == INT64_MAX
-constexpr size_t checked_mul(const size_t a, const size_t b) noexcept
-{
-    return a * b;
-}
-#elif INTPTR_MAX == INT32_MAX
 inline size_t checked_mul(const size_t a, const size_t b)
 {
-    const size_t result{a * b};
-    if (UNLIKELY(result < a || result < b)) // check for unsigned integer overflow.
+#ifdef _MSC_VER
+#ifdef _M_X64
+    unsigned __int64 high_bits{}; // NOLINT
+    const size_t result{_umul128(a, b, &high_bits)};
+    if (high_bits != 0)
         impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
     return result;
-}
+#elif _M_ARM64
+    if (__umulh(a, b) > 0)
+        impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
+    return a * b;
+#else
+    const unsigned __int64 high_result{static_cast<unsigned __int64>(a) * b}; // NOLINT
+    if (high_result > std::numeric_limits<size_t>::max())
+        impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
+    return static_cast<size_t>(high_result);
 #endif
-
+#elif __GNUC__
+    size_t result;
+    if (UNLIKELY(__builtin_mul_overflow(a, b, &result)))
+        impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
+    return result;
+#else
+#error "Unknown compiler"
+#endif
+}
 
 } // namespace charls


### PR DESCRIPTION
The vendored CharLS under `Native/Common/CharLS` is pinned at **2.4.2**, which is affected by security advisory [**GHSA-mqrg-gfc8-73ff**](https://github.com/team-charls/charls/security/advisories/GHSA-mqrg-gfc8-73ff) (affects 2.3.0-2.4.3; fixed in **2.4.4** by capping max width/height at 100000). 2.4.4 also rolls up the 2.4.3 fix for non-conforming padding before EOI ([charls#365](https://github.com/team-charls/charls/issues/365)).

This is a clean drop-in source refresh:

- The vendored 2.4.2 copy was **byte-for-byte pristine** vs the official `team-charls/charls` 2.4.2 release (verified by hash).
- 2.4.2 -> 2.4.4 touches only **7 files** (5 `src` + 2 public headers under `charls/`), with **no added/removed files**, so no `vcxproj` / `CMakeLists` file-list changes are required.
- After the swap the vendored tree matches the official **CharLS 2.4.4** release exactly (verified by hash).

Files updated: `charls_jpegls_encoder.cpp`, `constants.h`, `util.h`, `jpeg_stream_reader.cpp`, `jpeg_stream_reader.h`, `charls/version.h`, `charls/public_types.h`.

### Validation

Built `Dicom.Native` with the uplifted CharLS on **all six** target platforms (green): win-x64, win-arm64, linux-x64, linux-arm64, osx-x64, osx-arm64. (Native compile only; the signing/managed-test steps need the repo's `STRONG_NAME_KEY` secret, which a fork can't access.)

Part of a small supply-chain-hygiene series. Please also disclose these as vendored so compliance automations can check for security issues.