### PR TITLE
Uplift OpenJPH 0.21.2 -> 0.29.0

### DIFF
--- a/Native/Common/OpenJPH/codestream/ojph_bitbuffer_read.h
+++ b/Native/Common/OpenJPH/codestream/ojph_bitbuffer_read.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,22 +35,23 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_BITBUFFER_READ_H
 #define OJPH_BITBUFFER_READ_H
 
 #include "ojph_defs.h"
+#include "ojph_arch.h"
 #include "ojph_file.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class mem_elastic_allocator;
   struct coded_lists;
 
-  namespace local
-  {
+  namespace local {
+
 
     //////////////////////////////////////////////////////////////////////////
     struct bit_read_buf
@@ -63,7 +64,8 @@ namespace ojph
     };
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void bb_init(bit_read_buf *bbp, ui32 bytes_left, infile_base *file)
+    static inline
+    void bb_init(bit_read_buf *bbp, ui32 bytes_left, infile_base* file)
     {
       bbp->avail_bits = 0;
       bbp->file = file;
@@ -73,11 +75,12 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////////
-    static inline bool bb_read(bit_read_buf *bbp)
+    static inline
+    bool bb_read(bit_read_buf *bbp)
     {
       if (bbp->bytes_left > 0)
       {
-        ui32 t = 0;
+        ui8 t = 0;
         if (bbp->file->read(&t, 1) != 1)
           throw "error reading from file";
         bbp->tmp = t;
@@ -96,7 +99,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline bool bb_read_bit(bit_read_buf *bbp, ui32 &bit)
+    static inline
+    bool bb_read_bit(bit_read_buf *bbp, ui32& bit)
     {
       bool result = true;
       if (bbp->avail_bits == 0)
@@ -106,14 +110,14 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline bool bb_read_bits(bit_read_buf *bbp, int num_bits, ui32 &bits)
+    static inline
+    bool bb_read_bits(bit_read_buf *bbp, int num_bits, ui32& bits)
     {
       assert(num_bits <= 32);
 
       bits = 0;
       bool result = true;
-      while (num_bits)
-      {
+      while (num_bits) {
         if (bbp->avail_bits == 0)
           result = bb_read(bbp);
         int tx_bits = ojph_min(bbp->avail_bits, num_bits);
@@ -126,25 +130,28 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline bool bb_read_chunk(bit_read_buf *bbp, ui32 num_bytes,
-                                     coded_lists *&cur_coded_list,
-                                     mem_elastic_allocator *elastic)
+    static inline
+    bool bb_read_chunk(bit_read_buf *bbp, ui32 num_bytes,
+                       coded_lists*& cur_coded_list,
+                       mem_elastic_allocator *elastic)
     {
       assert(bbp->avail_bits == 0 && bbp->unstuff == false);
-      elastic->get_buffer(num_bytes + coded_cb_header::prefix_buf_size + coded_cb_header::suffix_buf_size, cur_coded_list);
+      elastic->get_buffer(num_bytes + coded_cb_header::prefix_buf_size
+        + coded_cb_header::suffix_buf_size, cur_coded_list);
       ui32 bytes = ojph_min(num_bytes, bbp->bytes_left);
       ui32 bytes_read = (ui32)bbp->file->read(
-          cur_coded_list->buf + coded_cb_header::prefix_buf_size, bytes);
+        cur_coded_list->buf + coded_cb_header::prefix_buf_size, bytes);
       if (num_bytes > bytes_read)
         memset(
-            cur_coded_list->buf + coded_cb_header::prefix_buf_size + bytes_read,
-            0, num_bytes - bytes_read);
+          cur_coded_list->buf + coded_cb_header::prefix_buf_size + bytes_read,
+          0, num_bytes - bytes_read);
       bbp->bytes_left -= bytes_read;
       return bytes_read == bytes;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void bb_skip_eph(bit_read_buf *bbp)
+    static inline
+    void bb_skip_eph(bit_read_buf *bbp)
     {
       if (bbp->bytes_left >= 2)
       {
@@ -158,7 +165,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline bool bb_terminate(bit_read_buf *bbp, bool uses_eph)
+    static inline
+    bool bb_terminate(bit_read_buf *bbp, bool uses_eph)
     {
       bool result = true;
       if (bbp->unstuff)
@@ -172,7 +180,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline bool bb_skip_sop(bit_read_buf *bbp)
+    static inline
+    bool bb_skip_sop(bit_read_buf *bbp)
     {
       if (bbp->bytes_left >= 2)
       {
@@ -187,11 +196,11 @@ namespace ojph
             ui16 com_len;
             if (bbp->file->read(&com_len, 2) != 2)
               throw "error reading from file";
-            com_len = swap_byte(com_len);
+            com_len = swap_bytes_if_le(com_len);
             if (com_len != 4)
               throw "something is wrong with SOP length";
-            int result =
-                bbp->file->seek(com_len - 2, infile_base::OJPH_SEEK_CUR);
+            int result = 
+              bbp->file->seek(com_len - 2, infile_base::OJPH_SEEK_CUR);
             if (result != 0)
               throw "error seeking file";
             bbp->bytes_left -= com_len;
@@ -202,7 +211,7 @@ namespace ojph
         }
         else
         {
-          // put the bytes back
+          //put the bytes back
           if (bbp->file->seek(-2, infile_base::OJPH_SEEK_CUR) != 0)
             throw "error seeking file";
           return false;

--- a/Native/Common/OpenJPH/codestream/ojph_bitbuffer_write.h
+++ b/Native/Common/OpenJPH/codestream/ojph_bitbuffer_write.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,35 +35,29 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_BITBUFFER_WRITE_H
 #define OJPH_BITBUFFER_WRITE_H
 
 #include "ojph_defs.h"
 #include "ojph_file.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class mem_elastic_allocator;
   struct coded_lists;
 
-  namespace local
-  {
+  namespace local {
 
-    //////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
     struct bit_write_buf
     {
       static const int needed;
 
-      bit_write_buf()
-      {
-        ccl = NULL;
-        avail_bits = 0;
-        tmp = 0;
-      }
-      coded_lists *ccl;
+      bit_write_buf() { ccl = NULL; avail_bits = 0; tmp = 0; }
+      coded_lists* ccl;
       int avail_bits;
       ui64 tmp;
     };
@@ -72,8 +66,9 @@ namespace ojph
     const int bit_write_buf::needed = 512;
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void bb_expand_buf(bit_write_buf *bbp, mem_elastic_allocator *elastic,
-                                     coded_lists *&cur_coded_list)
+    static inline
+    void bb_expand_buf(bit_write_buf *bbp, mem_elastic_allocator *elastic,
+                       coded_lists*& cur_coded_list)
     {
       assert(cur_coded_list == NULL);
       elastic->get_buffer(bit_write_buf::needed, cur_coded_list);
@@ -82,17 +77,19 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void bb_init(bit_write_buf *bbp, mem_elastic_allocator *elastic,
-                               coded_lists *&cur_coded_list)
+    static inline
+    void bb_init(bit_write_buf *bbp, mem_elastic_allocator *elastic,
+                 coded_lists*& cur_coded_list)
     {
       bb_expand_buf(bbp, elastic, cur_coded_list);
       bbp->avail_bits = 8;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void bb_put_bit(bit_write_buf *bbp, ui32 bit,
-                                  mem_elastic_allocator *elastic,
-                                  coded_lists *&cur_coded_list, ui32 &ph_bytes)
+    static inline
+    void bb_put_bit(bit_write_buf *bbp, ui32 bit,
+                    mem_elastic_allocator *elastic,
+                    coded_lists*& cur_coded_list, ui32& ph_bytes)
     {
       --bbp->avail_bits;
       bbp->tmp |= (bit & 1) << bbp->avail_bits;
@@ -100,7 +97,7 @@ namespace ojph
       {
         bbp->avail_bits = 8 - (bbp->tmp != 0xFF ? 0 : 1);
         bbp->ccl->buf[bbp->ccl->buf_size - bbp->ccl->avail_size] =
-            (ui8)(bbp->tmp & 0xFF);
+          (ui8)(bbp->tmp & 0xFF);
         bbp->tmp = 0;
         --bbp->ccl->avail_size;
         if (bbp->ccl->avail_size == 0)
@@ -113,28 +110,31 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void bb_put_zeros(bit_write_buf *bbp, int num_zeros,
-                                    mem_elastic_allocator *elastic,
-                                    coded_lists *&cur_coded_list, ui32 &ph_bytes)
+    static inline
+    void bb_put_zeros(bit_write_buf *bbp, int num_zeros,
+                      mem_elastic_allocator *elastic,
+                      coded_lists*& cur_coded_list, ui32& ph_bytes)
     {
       for (int i = num_zeros; i > 0; --i)
         bb_put_bit(bbp, 0, elastic, cur_coded_list, ph_bytes);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void bb_put_bits(bit_write_buf *bbp, ui32 data, int num_bits,
-                                   mem_elastic_allocator *elastic,
-                                   coded_lists *&cur_coded_list, ui32 &ph_bytes)
+    static inline
+    void bb_put_bits(bit_write_buf *bbp, ui32 data, int num_bits,
+                     mem_elastic_allocator *elastic,
+                     coded_lists*& cur_coded_list, ui32& ph_bytes)
     {
       assert(num_bits <= 32);
-      for (int i = num_bits - 1; i >= 0; --i)
+      for (int i = num_bits - 1; i >= 0; --i) 
         bb_put_bit(bbp, data >> i, elastic, cur_coded_list, ph_bytes);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void bb_terminate(bit_write_buf *bbp)
+    static inline
+    void bb_terminate(bit_write_buf *bbp)
     {
-      if (bbp->avail_bits < 8) // bits have been written
+      if (bbp->avail_bits < 8) //bits have been written
       {
         ui8 val = (ui8)(bbp->tmp & 0xFF);
         bbp->ccl->buf[bbp->ccl->buf_size - bbp->ccl->avail_size] = val;

--- a/Native/Common/OpenJPH/codestream/ojph_codeblock.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codeblock.cpp
@@ -36,6 +36,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 
@@ -46,17 +47,16 @@
 #include "ojph_subband.h"
 #include "ojph_resolution.h"
 
-namespace ojph
-{
+namespace ojph {
 
   namespace local
   {
 
     //////////////////////////////////////////////////////////////////////////
-    void codeblock::pre_alloc(codestream *codestream, const size &nominal,
+    void codeblock::pre_alloc(codestream *codestream, const size& nominal,
                               ui32 precision)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      mem_fixed_allocator* allocator = codestream->get_allocator();
 
       assert(byte_alignment / sizeof(ui32) > 1);
       const ui32 f = byte_alignment / sizeof(ui32) - 1;
@@ -70,25 +70,23 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void codeblock::finalize_alloc(codestream *codestream,
-                                   subband *parent, const size &nominal,
-                                   const size &cb_size,
-                                   coded_cb_header *coded_cb,
+                                   subband *parent, const size& nominal,
+                                   const size& cb_size,
+                                   coded_cb_header* coded_cb,
                                    ui32 K_max, int line_offset,
                                    ui32 precision, ui32 comp_idx)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      mem_fixed_allocator* allocator = codestream->get_allocator();
 
       const ui32 f = byte_alignment / sizeof(ui32) - 1;
       this->stride = (nominal.w + f) & ~f; // a multiple of 8
       this->buf_size = this->stride * nominal.h;
 
-      if (precision <= 32)
-      {
+      if (precision <= 32) {
         this->precision = BUF32;
         this->buf32 = allocator->post_alloc_data<ui32>(this->buf_size, 0);
       }
-      else
-      {
+      else {
         this->precision = BUF64;
         this->buf64 = allocator->post_alloc_data<ui64>(this->buf_size, 0);
       }
@@ -103,7 +101,7 @@ namespace ojph
       this->K_max = K_max;
       for (int i = 0; i < 4; ++i)
         this->max_val64[i] = 0;
-      const param_cod *coc = codestream->get_coc(comp_idx);
+      const param_cod* coc = codestream->get_coc(comp_idx);
       this->reversible = coc->is_reversible();
       this->resilient = codestream->is_resilient();
       this->stripe_causal = coc->get_block_vertical_causality();
@@ -151,9 +149,9 @@ namespace ojph
           assert(coded_cb->missing_msbs < K_max);
           coded_cb->num_passes = 1;
 
-          this->codeblock_functions.encode_cb32(buf32, K_max - 1, 1,
-                                                cb_size.w, cb_size.h, stride, coded_cb->pass_length,
-                                                elastic, coded_cb->next_coded);
+          this->codeblock_functions.encode_cb32(buf32, K_max-1, 1,
+            cb_size.w, cb_size.h, stride, coded_cb->pass_length,
+            elastic, coded_cb->next_coded);
         }
       }
       else
@@ -167,15 +165,15 @@ namespace ojph
           assert(coded_cb->missing_msbs < K_max);
           coded_cb->num_passes = 1;
 
-          this->codeblock_functions.encode_cb64(buf64, K_max - 1, 1,
-                                                cb_size.w, cb_size.h, stride, coded_cb->pass_length,
-                                                elastic, coded_cb->next_coded);
+          this->codeblock_functions.encode_cb64(buf64, K_max-1, 1,
+            cb_size.w, cb_size.h, stride, coded_cb->pass_length,
+            elastic, coded_cb->next_coded);
         }
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void codeblock::recreate(const size &cb_size, coded_cb_header *coded_cb)
+    void codeblock::recreate(const size &cb_size, coded_cb_header* coded_cb)
     {
       assert(cb_size.h * stride <= buf_size && cb_size.w <= stride);
       this->cb_size = cb_size;
@@ -196,25 +194,24 @@ namespace ojph
         if (precision == BUF32)
         {
           result = this->codeblock_functions.decode_cb32(
-              coded_cb->next_coded->buf + coded_cb_header::prefix_buf_size,
-              buf32, coded_cb->missing_msbs, coded_cb->num_passes,
-              coded_cb->pass_length[0], coded_cb->pass_length[1],
-              cb_size.w, cb_size.h, stride, stripe_causal);
+            coded_cb->next_coded->buf + coded_cb_header::prefix_buf_size,
+            buf32, coded_cb->missing_msbs, coded_cb->num_passes,
+            coded_cb->pass_length[0], coded_cb->pass_length[1],
+            cb_size.w, cb_size.h, stride, stripe_causal);
         }
         else
         {
           assert(precision == BUF64);
           result = this->codeblock_functions.decode_cb64(
-              coded_cb->next_coded->buf + coded_cb_header::prefix_buf_size,
-              buf64, coded_cb->missing_msbs, coded_cb->num_passes,
-              coded_cb->pass_length[0], coded_cb->pass_length[1],
-              cb_size.w, cb_size.h, stride, stripe_causal);
+            coded_cb->next_coded->buf + coded_cb_header::prefix_buf_size,
+            buf64, coded_cb->missing_msbs, coded_cb->num_passes,
+            coded_cb->pass_length[0], coded_cb->pass_length[1],
+            cb_size.w, cb_size.h, stride, stripe_causal);
         }
 
         if (result == false)
         {
-          if (resilient == true)
-          {
+          if (resilient == true) {
             OJPH_INFO(0x000300A1, "Error decoding a codeblock.");
             zero_block = true;
           }
@@ -226,10 +223,11 @@ namespace ojph
         zero_block = true;
     }
 
+
     //////////////////////////////////////////////////////////////////////////
     void codeblock::pull_line(line_buf *line)
     {
-      // convert to sign and magnitude
+      //convert to sign and magnitude
       if (precision == BUF32)
       {
         assert(line->flags & line_buf::LFT_32BIT);
@@ -246,7 +244,8 @@ namespace ojph
       else
       {
         assert(precision == BUF64);
-        assert(line->flags & line_buf::LFT_64BIT);
+        assert((reversible && (line->flags & line_buf::LFT_64BIT))
+               || (!reversible && (line->flags & line_buf::LFT_32BIT)));
         si64 *dp = line->i64 + line_offset;
         if (!zero_block)
         {

--- a/Native/Common/OpenJPH/codestream/ojph_codeblock.h
+++ b/Native/Common/OpenJPH/codestream/ojph_codeblock.h
@@ -1,5 +1,4 @@
 
-
 //***************************************************************************/
 // This software is released under the 2-Clause BSD license, included
 // below.
@@ -37,6 +36,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_CODEBLOCK_H
 #define OJPH_CODEBLOCK_H
 
@@ -44,21 +44,19 @@
 #include "ojph_file.h"
 #include "ojph_codeblock_fun.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class line_buf;
   class mem_elastic_allocator;
   class codestream;
   struct coded_lists;
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    // defined here
+    //defined here
     struct precinct;
     class subband;
     struct coded_cb_header;
@@ -67,38 +65,36 @@ namespace ojph
     class codeblock
     {
       friend struct precinct;
-      enum : ui32
-      {
+      enum : ui32 {
         BUF32 = 4,
         BUF64 = 8,
       };
 
     public:
-      static void pre_alloc(codestream *codestream, const size &nominal,
+      static void pre_alloc(codestream *codestream, const size& nominal,
                             ui32 precision);
-      void finalize_alloc(codestream *codestream, subband *parent,
-                          const size &nominal, const size &cb_size,
-                          coded_cb_header *coded_cb, ui32 K_max,
+      void finalize_alloc(codestream *codestream, subband* parent,
+                          const size& nominal, const size& cb_size,
+                          coded_cb_header* coded_cb, ui32 K_max,
                           int tbx0, ui32 precision, ui32 comp_idx);
       void push(line_buf *line);
       void encode(mem_elastic_allocator *elastic);
-      void recreate(const size &cb_size, coded_cb_header *coded_cb);
+      void recreate(const size& cb_size, coded_cb_header* coded_cb);
 
       void decode();
       void pull_line(line_buf *line);
 
     private:
       ui32 precision;
-      union
-      {
-        ui32 *buf32;
-        ui64 *buf64;
+      union {
+        ui32* buf32;
+        ui64* buf64;
       };
       size nominal_size;
       size cb_size;
       ui32 stride;
       ui32 buf_size;
-      subband *parent;
+      subband* parent;
       int line_offset;
       ui32 cur_line;
       float delta, delta_inv;
@@ -107,12 +103,11 @@ namespace ojph
       bool resilient;
       bool stripe_causal;
       bool zero_block; // true when the decoded block is all zero
-      union
-      {
+      union {
         ui32 max_val32[8]; // supports up to 256 bits
         ui64 max_val64[4]; // supports up to 256 bits
       };
-      coded_cb_header *coded_cb;
+      coded_cb_header* coded_cb;
       codeblock_fun codeblock_functions;
     };
 
@@ -120,7 +115,7 @@ namespace ojph
     struct coded_cb_header
     {
       ui32 pass_length[2];
-      ui32 num_passes;
+      ui32 num_passes;       // number of passes to be decoded
       ui32 Kmax;
       ui32 missing_msbs;
       coded_lists *next_coded;

--- a/Native/Common/OpenJPH/codestream/ojph_codeblock_fun.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codeblock_fun.cpp
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 
@@ -50,64 +51,64 @@
 #include "../coding/ojph_block_decoder.h"
 #include "../coding/ojph_block_encoder.h"
 
-namespace ojph
-{
+namespace ojph {
 
   namespace local
   {
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_mem_clear(void *addr, size_t count);
-    void sse_mem_clear(void *addr, size_t count);
-    void avx_mem_clear(void *addr, size_t count);
-    void wasm_mem_clear(void *addr, size_t count);
+    void gen_mem_clear(void* addr, size_t count);
+    void sse_mem_clear(void* addr, size_t count);
+    void avx_mem_clear(void* addr, size_t count);
+    void wasm_mem_clear(void* addr, size_t count);
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 gen_find_max_val32(ui32 *address);
-    ui32 sse2_find_max_val32(ui32 *address);
-    ui32 avx2_find_max_val32(ui32 *address);
-    ui32 wasm_find_max_val32(ui32 *address);
-    ui64 gen_find_max_val64(ui64 *address);
-    ui64 sse2_find_max_val64(ui64 *address);
-    ui64 avx2_find_max_val64(ui64 *address);
-    ui64 wasm_find_max_val64(ui64 *address);
+    ui32  gen_find_max_val32(ui32* address);
+    ui32 sse2_find_max_val32(ui32* address);
+    ui32 avx2_find_max_val32(ui32* address);
+    ui32 wasm_find_max_val32(ui32* address);
+    ui64  gen_find_max_val64(ui64* address);
+    ui64 sse2_find_max_val64(ui64* address);
+    ui64 avx2_find_max_val64(ui64* address);
+    ui64 wasm_find_max_val64(ui64* address);
+
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                            float delta_inv, ui32 count, ui32 *max_val);
+    void  gen_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
+                             float delta_inv, ui32 count, ui32* max_val);
     void sse2_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val);
+                             float delta_inv, ui32 count, ui32* max_val);
     void avx2_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val);
-    void gen_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                            float delta_inv, ui32 count, ui32 *max_val);
+                             float delta_inv, ui32 count, ui32* max_val);
+    void  gen_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
+                             float delta_inv, ui32 count, ui32* max_val);
     void sse2_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val);
+                             float delta_inv, ui32 count, ui32* max_val);
     void avx2_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val);
+                             float delta_inv, ui32 count, ui32* max_val);
     void wasm_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val);
+                             float delta_inv, ui32 count, ui32* max_val);
     void wasm_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val);
+                             float delta_inv, ui32 count, ui32* max_val);
 
-    void gen_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
-                            float delta_inv, ui32 count, ui64 *max_val);
+    void  gen_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
+                             float delta_inv, ui32 count, ui64* max_val);
     void sse2_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui64 *max_val);
+                             float delta_inv, ui32 count, ui64* max_val);
     void avx2_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui64 *max_val);
+                             float delta_inv, ui32 count, ui64* max_val);
     void wasm_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui64 *max_val);
+                             float delta_inv, ui32 count, ui64* max_val);
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
-                              float delta, ui32 count);
+    void  gen_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+                               float delta, ui32 count);
     void sse2_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
     void avx2_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
-    void gen_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
-                              float delta, ui32 count);
+    void  gen_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+                               float delta, ui32 count);
     void sse2_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
     void avx2_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
@@ -117,17 +118,18 @@ namespace ojph
     void wasm_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
 
-    void gen_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
-                              float delta, ui32 count);
+    void  gen_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                               float delta, ui32 count);
     void sse2_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
     void avx2_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
+    void gen_irv_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count);
     void wasm_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
 
-    void codeblock_fun::init(bool reversible)
-    {
+    void codeblock_fun::init(bool reversible) {
 
 #if !defined(OJPH_ENABLE_WASM_SIMD) || !defined(OJPH_EMSCRIPTEN)
 
@@ -135,8 +137,7 @@ namespace ojph
       decode_cb32 = ojph_decode_codeblock32;
       find_max_val32 = gen_find_max_val32;
       mem_clear = gen_mem_clear;
-      if (reversible)
-      {
+      if (reversible) {
         tx_to_cb32 = gen_rev_tx_to_cb32;
         tx_from_cb32 = gen_rev_tx_from_cb32;
       }
@@ -149,118 +150,105 @@ namespace ojph
 
       decode_cb64 = ojph_decode_codeblock64;
       find_max_val64 = gen_find_max_val64;
-      if (reversible)
-      {
+      if (reversible) {
         tx_to_cb64 = gen_rev_tx_to_cb64;
         tx_from_cb64 = gen_rev_tx_from_cb64;
       }
       else
       {
         tx_to_cb64 = NULL;
-        tx_from_cb64 = NULL;
+        tx_from_cb64 = gen_irv_tx_from_cb64;
       }
       encode_cb64 = ojph_encode_codeblock64;
       bool result = initialize_block_encoder_tables();
-      assert(result);
-      ojph_unused(result);
+      assert(result); ojph_unused(result);
 
-#ifndef OJPH_DISABLE_SIMD
+  #ifndef OJPH_DISABLE_SIMD
 
-#if (defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
+    #if (defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
-// Accelerated functions for INTEL/AMD CPUs
-#ifndef OJPH_DISABLE_SSE
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE)
-        mem_clear = sse_mem_clear;
-#endif // !OJPH_DISABLE_SSE
+      // Accelerated functions for INTEL/AMD CPUs
+      #ifndef OJPH_DISABLE_SSE
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE)
+          mem_clear = sse_mem_clear;
+      #endif // !OJPH_DISABLE_SSE
 
-#ifndef OJPH_DISABLE_SSE2
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE2)
-      {
-        find_max_val32 = sse2_find_max_val32;
-        if (reversible)
-        {
-          tx_to_cb32 = sse2_rev_tx_to_cb32;
-          tx_from_cb32 = sse2_rev_tx_from_cb32;
+      #ifndef OJPH_DISABLE_SSE2
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE2) {
+          find_max_val32 = sse2_find_max_val32;
+          if (reversible) {
+            tx_to_cb32 = sse2_rev_tx_to_cb32;
+            tx_from_cb32 = sse2_rev_tx_from_cb32;
+          }
+          else {
+            tx_to_cb32 = sse2_irv_tx_to_cb32;
+            tx_from_cb32 = sse2_irv_tx_from_cb32;
+          }
+          find_max_val64 = sse2_find_max_val64;
+          if (reversible) {
+            tx_to_cb64 = sse2_rev_tx_to_cb64;
+            tx_from_cb64 = sse2_rev_tx_from_cb64;
+          }
+          else
+          {
+            tx_to_cb64 = NULL;
+            tx_from_cb64 = gen_irv_tx_from_cb64;
+          }
         }
-        else
-        {
-          tx_to_cb32 = sse2_irv_tx_to_cb32;
-          tx_from_cb32 = sse2_irv_tx_from_cb32;
+      #endif // !OJPH_DISABLE_SSE2
+
+      #ifndef OJPH_DISABLE_SSSE3
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSSE3)
+          decode_cb32 = ojph_decode_codeblock_ssse3;
+      #endif // !OJPH_DISABLE_SSSE3
+
+      #ifndef OJPH_DISABLE_AVX
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX)
+          mem_clear = avx_mem_clear;
+      #endif // !OJPH_DISABLE_AVX
+
+      #ifndef OJPH_DISABLE_AVX2
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX2) {
+          decode_cb32 = ojph_decode_codeblock_avx2;
+          find_max_val32 = avx2_find_max_val32;
+          if (reversible) {
+            tx_to_cb32 = avx2_rev_tx_to_cb32;
+            tx_from_cb32 = avx2_rev_tx_from_cb32;
+          }
+          else {
+            tx_to_cb32 = avx2_irv_tx_to_cb32;
+            tx_from_cb32 = avx2_irv_tx_from_cb32;
+          }
+          encode_cb32 = ojph_encode_codeblock_avx2;
+          bool result = initialize_block_encoder_tables_avx2();
+          assert(result); ojph_unused(result);
+
+          find_max_val64 = avx2_find_max_val64;
+          if (reversible) {
+            tx_to_cb64 = avx2_rev_tx_to_cb64;
+            tx_from_cb64 = avx2_rev_tx_from_cb64;
+          }
+          else
+          {
+            tx_to_cb64 = NULL;
+            tx_from_cb64 = gen_irv_tx_from_cb64;
+          }
         }
-        find_max_val64 = sse2_find_max_val64;
-        if (reversible)
-        {
-          tx_to_cb64 = sse2_rev_tx_to_cb64;
-          tx_from_cb64 = sse2_rev_tx_from_cb64;
+      #endif // !OJPH_DISABLE_AVX2
+
+      #if (defined(OJPH_ARCH_X86_64) && !defined(OJPH_DISABLE_AVX512))
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX512) {
+          encode_cb32 = ojph_encode_codeblock_avx512;
+          bool result = initialize_block_encoder_tables_avx512();
+          assert(result); ojph_unused(result);
         }
-        else
-        {
-          tx_to_cb64 = NULL;
-          tx_from_cb64 = NULL;
-        }
-      }
-#endif // !OJPH_DISABLE_SSE2
+      #endif // !OJPH_DISABLE_AVX512
 
-#ifndef OJPH_DISABLE_SSSE3
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSSE3)
-        decode_cb32 = ojph_decode_codeblock_ssse3;
-#endif // !OJPH_DISABLE_SSSE3
+    #elif defined(OJPH_ARCH_ARM)
 
-#ifndef OJPH_DISABLE_AVX
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX)
-        mem_clear = avx_mem_clear;
-#endif // !OJPH_DISABLE_AVX
+    #endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
-#ifndef OJPH_DISABLE_AVX2
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX2)
-      {
-        decode_cb32 = ojph_decode_codeblock_avx2;
-        find_max_val32 = avx2_find_max_val32;
-        if (reversible)
-        {
-          tx_to_cb32 = avx2_rev_tx_to_cb32;
-          tx_from_cb32 = avx2_rev_tx_from_cb32;
-        }
-        else
-        {
-          tx_to_cb32 = avx2_irv_tx_to_cb32;
-          tx_from_cb32 = avx2_irv_tx_from_cb32;
-        }
-        encode_cb32 = ojph_encode_codeblock_avx2;
-        bool result = initialize_block_encoder_tables_avx2();
-        assert(result);
-        ojph_unused(result);
-
-        find_max_val64 = avx2_find_max_val64;
-        if (reversible)
-        {
-          tx_to_cb64 = avx2_rev_tx_to_cb64;
-          tx_from_cb64 = avx2_rev_tx_from_cb64;
-        }
-        else
-        {
-          tx_to_cb64 = NULL;
-          tx_from_cb64 = NULL;
-        }
-      }
-#endif // !OJPH_DISABLE_AVX2
-
-#if (defined(OJPH_ARCH_X86_64) && !defined(OJPH_DISABLE_AVX512))
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX512)
-      {
-        encode_cb32 = ojph_encode_codeblock_avx512;
-        bool result = initialize_block_encoder_tables_avx512();
-        assert(result);
-        ojph_unused(result);
-      }
-#endif // !OJPH_DISABLE_AVX512
-
-#elif defined(OJPH_ARCH_ARM)
-
-#endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
-
-#endif // !OJPH_DISABLE_SIMD
+  #endif // !OJPH_DISABLE_SIMD
 
 #else // OJPH_ENABLE_WASM_SIMD
 
@@ -268,13 +256,11 @@ namespace ojph
       decode_cb32 = ojph_decode_codeblock_wasm;
       find_max_val32 = wasm_find_max_val32;
       mem_clear = wasm_mem_clear;
-      if (reversible)
-      {
+      if (reversible) {
         tx_to_cb32 = wasm_rev_tx_to_cb32;
         tx_from_cb32 = wasm_rev_tx_from_cb32;
       }
-      else
-      {
+      else {
         tx_to_cb32 = wasm_irv_tx_to_cb32;
         tx_from_cb32 = wasm_irv_tx_from_cb32;
       }
@@ -282,22 +268,21 @@ namespace ojph
 
       decode_cb64 = ojph_decode_codeblock64;
       find_max_val64 = wasm_find_max_val64;
-      if (reversible)
-      {
+      if (reversible) {
         tx_to_cb64 = wasm_rev_tx_to_cb64;
         tx_from_cb64 = wasm_rev_tx_from_cb64;
       }
       else
       {
         tx_to_cb64 = NULL;
-        tx_from_cb64 = NULL;
+        tx_from_cb64 = gen_irv_tx_from_cb64;
       }
       encode_cb64 = ojph_encode_codeblock64;
       bool result = initialize_block_encoder_tables();
-      assert(result);
-      ojph_unused(result);
+      assert(result); ojph_unused(result);
 
 #endif // !OJPH_ENABLE_WASM_SIMD
+
     }
-  } // local
-} // ojph
+  }  // local
+}  // ojph

--- a/Native/Common/OpenJPH/codestream/ojph_codeblock_fun.h
+++ b/Native/Common/OpenJPH/codestream/ojph_codeblock_fun.h
@@ -1,23 +1,22 @@
-
 //***************************************************************************/
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -36,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_CODEBLOCK_FUN_H
 #define OJPH_CODEBLOCK_FUN_H
 
@@ -43,26 +43,24 @@
 #include "ojph_file.h"
 #include "ojph_params_local.h"
 
-namespace ojph
-{
+namespace ojph {
 
-  namespace local
-  {
+  namespace local {
 
     // define function signature simple memory clearing
-    typedef void (*mem_clear_fun)(void *addr, size_t count);
+    typedef void (*mem_clear_fun)(void* addr, size_t count);
 
     // define function signature for max value finding
-    typedef ui32 (*find_max_val_fun32)(ui32 *addr);
+    typedef ui32 (*find_max_val_fun32)(ui32* addr);
 
-    typedef ui64 (*find_max_val_fun64)(ui64 *addr);
+    typedef ui64 (*find_max_val_fun64)(ui64* addr);
 
     // define line transfer function signature from subbands to codeblocks
     typedef void (*tx_to_cb_fun32)(const void *sp, ui32 *dp, ui32 K_max,
-                                   float delta_inv, ui32 count, ui32 *max_val);
+                                   float delta_inv, ui32 count, ui32* max_val);
 
     typedef void (*tx_to_cb_fun64)(const void *sp, ui64 *dp, ui32 K_max,
-                                   float delta_inv, ui32 count, ui64 *max_val);
+                                   float delta_inv, ui32 count, ui64* max_val);
 
     // define line transfer function signature from codeblock to subband
     typedef void (*tx_from_cb_fun32)(const ui32 *sp, void *dp, ui32 K_max,
@@ -72,46 +70,45 @@ namespace ojph
                                      float delta, ui32 count);
 
     // define the block decoder function signature
-    typedef bool (*cb_decoder_fun32)(ui8 *coded_data, ui32 *decoded_data,
-                                     ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
-                                     ui32 width, ui32 height, ui32 stride, bool stripe_causal);
+    typedef bool (*cb_decoder_fun32)(ui8* coded_data, ui32* decoded_data,
+      ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
+      ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
-    typedef bool (*cb_decoder_fun64)(ui8 *coded_data, ui64 *decoded_data,
-                                     ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
-                                     ui32 width, ui32 height, ui32 stride, bool stripe_causal);
+    typedef bool (*cb_decoder_fun64)(ui8* coded_data, ui64* decoded_data,
+      ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
+      ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
     // define the block encoder function signature
-    typedef void (*cb_encoder_fun32)(ui32 *buf, ui32 missing_msbs,
-                                     ui32 num_passes, ui32 width, ui32 height, ui32 stride,
-                                     ui32 *lengths, ojph::mem_elastic_allocator *elastic,
-                                     ojph::coded_lists *&coded);
+    typedef void (*cb_encoder_fun32)(ui32* buf, ui32 missing_msbs, 
+      ui32 num_passes, ui32 width, ui32 height, ui32 stride,
+      ui32* lengths, ojph::mem_elastic_allocator* elastic,
+      ojph::coded_lists*& coded);
 
-    typedef void (*cb_encoder_fun64)(ui64 *buf, ui32 missing_msbs,
-                                     ui32 num_passes, ui32 width, ui32 height, ui32 stride,
-                                     ui32 *lengths, ojph::mem_elastic_allocator *elastic,
-                                     ojph::coded_lists *&coded);
+    typedef void (*cb_encoder_fun64)(ui64* buf, ui32 missing_msbs, 
+      ui32 num_passes, ui32 width, ui32 height, ui32 stride,
+      ui32* lengths, ojph::mem_elastic_allocator* elastic,
+      ojph::coded_lists*& coded);
 
     //////////////////////////////////////////////////////////////////////////
-    struct codeblock_fun
-    {
+    struct codeblock_fun {
 
       void init(bool reversible);
 
       // a pointer to the max value finding function
       mem_clear_fun mem_clear;
-
+     
       // a pointer to the max value finding function
       find_max_val_fun32 find_max_val32;
       find_max_val_fun64 find_max_val64;
-
+     
       // a pointer to function transferring samples from subbands to codeblocks
       tx_to_cb_fun32 tx_to_cb32;
       tx_to_cb_fun64 tx_to_cb64;
-
+     
       // a pointer to function transferring samples from codeblocks to subbands
       tx_from_cb_fun32 tx_from_cb32;
       tx_from_cb_fun64 tx_from_cb64;
-
+     
       // a pointer to the decoder function
       cb_decoder_fun32 decode_cb32;
       cb_decoder_fun64 decode_cb64;
@@ -120,7 +117,7 @@ namespace ojph
       cb_encoder_fun32 encode_cb32;
       cb_encoder_fun64 encode_cb64;
     };
-
+    
   }
 }
 #endif // !OJPH_CODEBLOCK_FUN_H

--- a/Native/Common/OpenJPH/codestream/ojph_codestream.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream.cpp
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 
@@ -43,8 +44,7 @@
 #include "ojph_codestream.h"
 #include "ojph_codestream_local.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -59,12 +59,20 @@ namespace ojph
   {
     if (state)
       delete state;
+    state = NULL;
   }
 
   ////////////////////////////////////////////////////////////////////////////
   codestream::codestream()
   {
     state = new local::codestream;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void codestream::restart()
+  {
+    assert(state != NULL);
+    state->restart();
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -149,7 +157,7 @@ namespace ojph
 
   ////////////////////////////////////////////////////////////////////////////
   void codestream::write_headers(outfile_base *file,
-                                 const comment_exchange *comments,
+                                 const comment_exchange* comments,
                                  ui32 num_comments)
   {
     state->write_headers(file, comments, num_comments);
@@ -172,7 +180,7 @@ namespace ojph
                                              ui32 skipped_res_for_recon)
   {
     state->restrict_input_resolution(skipped_res_for_read,
-                                     skipped_res_for_recon);
+      skipped_res_for_recon);
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -182,10 +190,11 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  line_buf *codestream::pull(ui32 &comp_num)
+  line_buf* codestream::pull(ui32 &comp_num)
   {
     return state->pull(comp_num);
   }
+
 
   ////////////////////////////////////////////////////////////////////////////
   void codestream::flush()
@@ -200,8 +209,9 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  line_buf *codestream::exchange(line_buf *line, ui32 &next_component)
+  line_buf* codestream::exchange(line_buf* line, ui32& next_component)
   {
     return state->exchange(line, next_component);
   }
+
 }

--- a/Native/Common/OpenJPH/codestream/ojph_codestream_avx.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream_avx.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -36,26 +36,23 @@
 //***************************************************************************/
 
 #include "ojph_arch.h"
-
 #if defined(OJPH_ARCH_I386) || defined(OJPH_ARCH_X86_64)
 #include <immintrin.h>
 #include "ojph_defs.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    void avx_mem_clear(void *addr, size_t count)
+    void avx_mem_clear(void* addr, size_t count)
     {
-      float *p = (float *)addr;
+      float* p = (float*)addr;
       __m256 zero = _mm256_setzero_ps();
       for (size_t i = 0; i < count; i += 32, p += 8)
         _mm256_storeu_ps(p, zero);
     }
-
-  }
+    
+ }
 }
 
 #endif

--- a/Native/Common/OpenJPH/codestream/ojph_codestream_avx2.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream_avx2.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -43,32 +43,30 @@
 #include "ojph_defs.h"
 #include "ojph_arch.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 avx2_find_max_val32(ui32 *address)
+    ui32 avx2_find_max_val32(ui32* address)
     {
-      __m128i x0 = _mm_loadu_si128((__m128i *)address);
-      __m128i x1 = _mm_loadu_si128((__m128i *)address + 1);
+      __m128i x0 = _mm_loadu_si128((__m128i*)address);
+      __m128i x1 = _mm_loadu_si128((__m128i*)address + 1);
       x0 = _mm_or_si128(x0, x1);
-      x1 = _mm_shuffle_epi32(x0, 0xEE); // x1 = x0[2,3,2,3]
+      x1 = _mm_shuffle_epi32(x0, 0xEE);   // x1 = x0[2,3,2,3]
       x0 = _mm_or_si128(x0, x1);
-      x1 = _mm_shuffle_epi32(x0, 0x55); // x1 = x0[1,1,1,1]
+      x1 = _mm_shuffle_epi32(x0, 0x55);   // x1 = x0[1,1,1,1]
       x0 = _mm_or_si128(x0, x1);
       ui32 t = (ui32)_mm_extract_epi32(x0, 0);
       return t;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    ui64 avx2_find_max_val64(ui64 *address)
+    ui64 avx2_find_max_val64(ui64* address)
     {
-      __m128i x0 = _mm_loadu_si128((__m128i *)address);
-      __m128i x1 = _mm_loadu_si128((__m128i *)address + 1);
+      __m128i x0 = _mm_loadu_si128((__m128i*)address);
+      __m128i x1 = _mm_loadu_si128((__m128i*)address + 1);
       x0 = _mm_or_si128(x0, x1);
-      x1 = _mm_shuffle_epi32(x0, 0xEE); // x1 = x0[2,3,2,3]
+      x1 = _mm_shuffle_epi32(x0, 0xEE);   // x1 = x0[2,3,2,3]
       x0 = _mm_or_si128(x0, x1);
       ui64 t;
 #ifdef OJPH_ARCH_X86_64
@@ -77,23 +75,23 @@ namespace ojph
       t = (ui64)(ui32)_mm_extract_epi32(x0, 0);
       t |= (ui64)(ui32)_mm_extract_epi32(x0, 1) << 32;
 #else
-#error Error unsupport compiler
-#endif
+      #error Error unsupport compiler
+#endif      
       return t;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx2_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val)
+    void avx2_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max, 
+                             float delta_inv, ui32 count, ui32* max_val)
     {
       ojph_unused(delta_inv);
 
-      // convert to sign and magnitude and keep max_val
+      // convert to sign and magnitude and keep max_val      
       ui32 shift = 31 - K_max;
       __m256i m0 = _mm256_set1_epi32(INT_MIN);
-      __m256i tmax = _mm256_loadu_si256((__m256i *)max_val);
-      __m256i *p = (__m256i *)sp;
-      for (; count >= 8; count -= 8, p += 1, dp += 8)
+      __m256i tmax = _mm256_loadu_si256((__m256i*)max_val);
+      __m256i *p = (__m256i*)sp;
+      for ( ; count >= 8; count -= 8, p += 1, dp += 8)
       {
         __m256i v = _mm256_loadu_si256(p);
         __m256i sign = _mm256_and_si256(v, m0);
@@ -101,7 +99,7 @@ namespace ojph
         val = _mm256_slli_epi32(val, (int)shift);
         tmax = _mm256_or_si256(tmax, val);
         val = _mm256_or_si256(val, sign);
-        _mm256_storeu_si256((__m256i *)dp, val);
+        _mm256_storeu_si256((__m256i*)dp, val);
       }
       if (count)
       {
@@ -117,24 +115,24 @@ namespace ojph
         tmax = _mm256_or_si256(tmax, c);
 
         val = _mm256_or_si256(val, sign);
-        _mm256_storeu_si256((__m256i *)dp, val);
+        _mm256_storeu_si256((__m256i*)dp, val);
       }
-      _mm256_storeu_si256((__m256i *)max_val, tmax);
+      _mm256_storeu_si256((__m256i*)max_val, tmax);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val)
+                             float delta_inv, ui32 count, ui32* max_val)
     {
       ojph_unused(K_max);
 
-      // quantize and convert to sign and magnitude and keep max_val
+      //quantize and convert to sign and magnitude and keep max_val
       __m256 d = _mm256_set1_ps(delta_inv);
       __m256i m0 = _mm256_set1_epi32(INT_MIN);
-      __m256i tmax = _mm256_loadu_si256((__m256i *)max_val);
-      float *p = (float *)sp;
-
-      for (; count >= 8; count -= 8, p += 8, dp += 8)
+      __m256i tmax = _mm256_loadu_si256((__m256i*)max_val);
+      float *p = (float*)sp;
+      
+      for ( ; count >= 8; count -= 8, p += 8, dp += 8)
       {
         __m256 vf = _mm256_loadu_ps(p);
         vf = _mm256_mul_ps(vf, d);                // multiply
@@ -143,7 +141,7 @@ namespace ojph
         val = _mm256_abs_epi32(val);
         tmax = _mm256_or_si256(tmax, val);
         val = _mm256_or_si256(val, sign);
-        _mm256_storeu_si256((__m256i *)dp, val);
+        _mm256_storeu_si256((__m256i*)dp, val);
       }
       if (count)
       {
@@ -160,42 +158,42 @@ namespace ojph
         tmax = _mm256_or_si256(tmax, c);
 
         val = _mm256_or_si256(val, sign);
-        _mm256_storeu_si256((__m256i *)dp, val);
+        _mm256_storeu_si256((__m256i*)dp, val);
       }
-      _mm256_storeu_si256((__m256i *)max_val, tmax);
+      _mm256_storeu_si256((__m256i*)max_val, tmax);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx2_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+    void avx2_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(delta);
       ui32 shift = 31 - K_max;
       __m256i m1 = _mm256_set1_epi32(INT_MAX);
-      si32 *p = (si32 *)dp;
+      si32 *p = (si32*)dp;
       for (ui32 i = 0; i < count; i += 8, sp += 8, p += 8)
       {
-        __m256i v = _mm256_load_si256((__m256i *)sp);
+        __m256i v = _mm256_load_si256((__m256i*)sp);
         __m256i val = _mm256_and_si256(v, m1);
         val = _mm256_srli_epi32(val, (int)shift);
         val = _mm256_sign_epi32(val, v);
-        _mm256_storeu_si256((__m256i *)p, val);
+        _mm256_storeu_si256((__m256i*)p, val);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx2_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+    void avx2_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(K_max);
       __m256i m1 = _mm256_set1_epi32(INT_MAX);
       __m256 d = _mm256_set1_ps(delta);
-      float *p = (float *)dp;
+      float *p = (float*)dp;
       for (ui32 i = 0; i < count; i += 8, sp += 8, p += 8)
       {
-        __m256i v = _mm256_load_si256((__m256i *)sp);
+        __m256i v = _mm256_load_si256((__m256i*)sp);
         __m256i vali = _mm256_and_si256(v, m1);
-        __m256 valf = _mm256_cvtepi32_ps(vali);
+        __m256  valf = _mm256_cvtepi32_ps(vali);
         valf = _mm256_mul_ps(valf, d);
         __m256i sign = _mm256_andnot_si256(m1, v);
         valf = _mm256_or_ps(valf, _mm256_castsi256_ps(sign));
@@ -204,38 +202,38 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx2_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui64 *max_val)
+    void avx2_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max, 
+                             float delta_inv, ui32 count, ui64* max_val)
     {
       ojph_unused(delta_inv);
 
-      // convert to sign and magnitude and keep max_val
+      // convert to sign and magnitude and keep max_val      
       ui32 shift = 63 - K_max;
       __m256i m0 = _mm256_set1_epi64x(LLONG_MIN);
       __m256i zero = _mm256_setzero_si256();
       __m256i one = _mm256_set1_epi64x(1);
-      __m256i tmax = _mm256_loadu_si256((__m256i *)max_val);
-      __m256i *p = (__m256i *)sp;
-      for (; count >= 4; count -= 4, p += 1, dp += 4)
+      __m256i tmax = _mm256_loadu_si256((__m256i*)max_val);
+      __m256i *p = (__m256i*)sp;
+      for ( ; count >= 4; count -= 4, p += 1, dp += 4)
       {
         __m256i v = _mm256_loadu_si256(p);
         __m256i sign = _mm256_cmpgt_epi64(zero, v);
-        __m256i val = _mm256_xor_si256(v, sign); // negate 1's complement
+        __m256i val = _mm256_xor_si256(v, sign);  // negate 1's complement
         __m256i ones = _mm256_and_si256(sign, one);
-        val = _mm256_add_epi64(val, ones); // 2's complement
+        val = _mm256_add_epi64(val, ones);        // 2's complement
         sign = _mm256_and_si256(sign, m0);
         val = _mm256_slli_epi64(val, (int)shift);
         tmax = _mm256_or_si256(tmax, val);
         val = _mm256_or_si256(val, sign);
-        _mm256_storeu_si256((__m256i *)dp, val);
+        _mm256_storeu_si256((__m256i*)dp, val);
       }
       if (count)
       {
         __m256i v = _mm256_loadu_si256(p);
         __m256i sign = _mm256_cmpgt_epi64(zero, v);
-        __m256i val = _mm256_xor_si256(v, sign); // negate 1's complement
+        __m256i val = _mm256_xor_si256(v, sign);  // negate 1's complement
         __m256i ones = _mm256_and_si256(sign, one);
-        val = _mm256_add_epi64(val, ones); // 2's complement
+        val = _mm256_add_epi64(val, ones);        // 2's complement
         sign = _mm256_and_si256(sign, m0);
         val = _mm256_slli_epi64(val, (int)shift);
 
@@ -246,32 +244,32 @@ namespace ojph
         tmax = _mm256_or_si256(tmax, c);
 
         val = _mm256_or_si256(val, sign);
-        _mm256_storeu_si256((__m256i *)dp, val);
+        _mm256_storeu_si256((__m256i*)dp, val);
       }
-      _mm256_storeu_si256((__m256i *)max_val, tmax);
+      _mm256_storeu_si256((__m256i*)max_val, tmax);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx2_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+    void avx2_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(delta);
-
+      
       ui32 shift = 63 - K_max;
       __m256i m1 = _mm256_set1_epi64x(LLONG_MAX);
       __m256i zero = _mm256_setzero_si256();
       __m256i one = _mm256_set1_epi64x(1);
-      si64 *p = (si64 *)dp;
+      si64 *p = (si64*)dp;
       for (ui32 i = 0; i < count; i += 4, sp += 4, p += 4)
       {
-        __m256i v = _mm256_load_si256((__m256i *)sp);
+        __m256i v = _mm256_load_si256((__m256i*)sp);
         __m256i val = _mm256_and_si256(v, m1);
         val = _mm256_srli_epi64(val, (int)shift);
         __m256i sign = _mm256_cmpgt_epi64(zero, v);
         val = _mm256_xor_si256(val, sign); // negate 1's complement
         __m256i ones = _mm256_and_si256(sign, one);
         val = _mm256_add_epi64(val, ones); // 2's complement
-        _mm256_storeu_si256((__m256i *)p, val);
+        _mm256_storeu_si256((__m256i*)p, val);
       }
     }
   }

--- a/Native/Common/OpenJPH/codestream/ojph_codestream_gen.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream_gen.cpp
@@ -35,38 +35,38 @@
 // Date: 15 May 2022
 //***************************************************************************/
 
+#include <climits>
+
 #include "ojph_defs.h"
 #include "ojph_arch.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_mem_clear(void *addr, size_t count)
+    void gen_mem_clear(void* addr, size_t count)
     {
-      si64 *p = (si64 *)addr;
+      si64* p = (si64*)addr;
       for (size_t i = 0; i < count; i += 8)
         *p++ = 0;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 gen_find_max_val32(ui32 *addr) { return addr[0]; }
+    ui32 gen_find_max_val32(ui32* addr) { return addr[0]; }
 
     //////////////////////////////////////////////////////////////////////////
-    ui64 gen_find_max_val64(ui64 *addr) { return addr[0]; }
+    ui64 gen_find_max_val64(ui64* addr) { return addr[0]; }
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
                             float delta_inv, ui32 count,
-                            ui32 *max_val)
+                            ui32* max_val)
     {
       ojph_unused(delta_inv);
       ui32 shift = 31 - K_max;
       // convert to sign and magnitude and keep max_val
       ui32 tmax = *max_val;
-      si32 *p = (si32 *)sp;
+      si32 *p = (si32*)sp;
       for (ui32 i = count; i > 0; --i)
       {
         si32 v = *p++;
@@ -82,13 +82,13 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     void gen_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
                             float delta_inv, ui32 count,
-                            ui64 *max_val)
+                            ui64* max_val)
     {
       ojph_unused(delta_inv);
       ui32 shift = 63 - K_max;
       // convert to sign and magnitude and keep max_val
       ui64 tmax = *max_val;
-      si64 *p = (si64 *)sp;
+      si64 *p = (si64*)sp;
       for (ui32 i = count; i > 0; --i)
       {
         si64 v = *p++;
@@ -104,12 +104,12 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
                             float delta_inv, ui32 count,
-                            ui32 *max_val)
+                            ui32* max_val)
     {
       ojph_unused(K_max);
-      // quantize and convert to sign and magnitude and keep max_val
+      //quantize and convert to sign and magnitude and keep max_val
       ui32 tmax = *max_val;
-      float *p = (float *)sp;
+      float *p = (float*)sp;
       for (ui32 i = count; i > 0; --i)
       {
         float v = *p++;
@@ -128,8 +128,8 @@ namespace ojph
     {
       ojph_unused(delta);
       ui32 shift = 31 - K_max;
-      // convert to sign and magnitude
-      si32 *p = (si32 *)dp;
+      //convert to sign and magnitude
+      si32 *p = (si32*)dp;
       for (ui32 i = count; i > 0; --i)
       {
         ui32 v = *sp++;
@@ -144,8 +144,8 @@ namespace ojph
     {
       ojph_unused(delta);
       ui32 shift = 63 - K_max;
-      // convert to sign and magnitude
-      si64 *p = (si64 *)dp;
+      //convert to sign and magnitude
+      si64 *p = (si64*)dp;
       for (ui32 i = count; i > 0; --i)
       {
         ui64 v = *sp++;
@@ -159,8 +159,8 @@ namespace ojph
                               float delta, ui32 count)
     {
       ojph_unused(K_max);
-      // convert to sign and magnitude
-      float *p = (float *)dp;
+      //convert to sign and magnitude
+      float *p = (float*)dp;
       for (ui32 i = count; i > 0; --i)
       {
         ui32 v = *sp++;
@@ -169,5 +169,20 @@ namespace ojph
       }
     }
 
-  }
+    //////////////////////////////////////////////////////////////////////////
+    void gen_irv_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count)
+    {
+      ojph_unused(K_max);
+      //convert to sign and magnitude
+      float *p = (float*)dp;
+      for (ui32 i = count; i > 0; --i)
+      {
+        ui64 v = *sp++;
+        float val = (float)(v & LLONG_MAX) * delta;
+        *p++ = (v & (ui64)LLONG_MIN) ? -val : val;
+      }
+    }
+
+ }
 }

--- a/Native/Common/OpenJPH/codestream/ojph_codestream_local.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream_local.cpp
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 
@@ -46,21 +47,40 @@
 #include "../transform/ojph_colour.h"
 #include "../transform/ojph_transform.h"
 
-namespace ojph
-{
+namespace ojph {
 
   namespace local
   {
 
-    ////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
     codestream::codestream()
-        : precinct_scratch(NULL), allocator(NULL), elastic_alloc(NULL)
+    : precinct_scratch(NULL), allocator(NULL), elastic_alloc(NULL)
+    {
+      allocator = new mem_fixed_allocator;
+      elastic_alloc = new mem_elastic_allocator(1048576); // 1 megabyte
+
+      init_colour_transform_functions();
+      init_wavelet_transform_functions();
+
+      restart();
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    codestream::~codestream()
+    {
+      if (allocator)
+        delete allocator;
+      if (elastic_alloc)
+        delete elastic_alloc;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void codestream::restart()
     {
       tiles = NULL;
       lines = NULL;
       comp_size = NULL;
       recon_comp_size = NULL;
-      allocator = NULL;
       outfile = NULL;
       infile = NULL;
 
@@ -79,26 +99,14 @@ namespace ojph
 
       precinct_scratch_needed_bytes = 0;
 
-      atk = atk_store;
-      atk[0].init_irv97();
-      atk[0].link(atk_store + 1);
-      atk[1].init_rev53();
-      atk[1].link(atk_store + 2);
+      cod.restart();
+      qcd.restart();
+      nlt.restart();
+      dfs.restart();
+      atk.restart();
 
-      allocator = new mem_fixed_allocator;
-      elastic_alloc = new mem_elastic_allocator(1048576); // 1 megabyte
-
-      init_colour_transform_functions();
-      init_wavelet_transform_functions();
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    codestream::~codestream()
-    {
-      if (allocator)
-        delete allocator;
-      if (elastic_alloc)
-        delete elastic_alloc;
+      allocator->restart();
+      elastic_alloc->restart();
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -110,9 +118,11 @@ namespace ojph
       num_tiles.h = sz.get_image_extent().y - sz.get_tile_offset().y;
       num_tiles.h = ojph_div_ceil(num_tiles.h, sz.get_tile_size().h);
       if (num_tiles.area() > 65535)
-        OJPH_ERROR(0x00030011, "number of tiles cannot exceed 65535");
+        OJPH_ERROR(0x00030011, "the number of tiles cannot exceed 65535");
+      if (num_tiles.area() == 0)
+        OJPH_ERROR(0x00030012, "the number of tiles cannot be 0");
 
-      // allocate tiles
+      //allocate tiles
       allocator->pre_alloc_obj<tile>((size_t)num_tiles.area());
 
       ui32 num_tileparts = 0;
@@ -121,33 +131,35 @@ namespace ojph
       ui32 ds = 1 << skipped_res_for_recon;
       for (index.y = 0; index.y < num_tiles.h; ++index.y)
       {
-        ui32 y0 = sz.get_tile_offset().y + index.y * sz.get_tile_size().h;
-        ui32 y1 = y0 + sz.get_tile_size().h; // end of tile
+        ui32 y0 = sz.get_tile_offset().y
+                + index.y * sz.get_tile_size().h;
+        ui32 y1 = y0 + sz.get_tile_size().h; //end of tile
 
         tile_rect.org.y = ojph_max(y0, sz.get_image_offset().y);
         tile_rect.siz.h =
-            ojph_min(y1, sz.get_image_extent().y) - tile_rect.org.y;
+          ojph_min(y1, sz.get_image_extent().y) - tile_rect.org.y;
 
         recon_tile_rect.org.y = ojph_max(ojph_div_ceil(y0, ds),
-                                         ojph_div_ceil(sz.get_image_offset().y, ds));
+          ojph_div_ceil(sz.get_image_offset().y, ds));
         recon_tile_rect.siz.h = ojph_min(ojph_div_ceil(y1, ds),
-                                         ojph_div_ceil(sz.get_image_extent().y, ds)) -
-                                recon_tile_rect.org.y;
+          ojph_div_ceil(sz.get_image_extent().y, ds))
+          - recon_tile_rect.org.y;
 
         for (index.x = 0; index.x < num_tiles.w; ++index.x)
         {
-          ui32 x0 = sz.get_tile_offset().x + index.x * sz.get_tile_size().w;
+          ui32 x0 = sz.get_tile_offset().x
+                  + index.x * sz.get_tile_size().w;
           ui32 x1 = x0 + sz.get_tile_size().w;
 
           tile_rect.org.x = ojph_max(x0, sz.get_image_offset().x);
           tile_rect.siz.w =
-              ojph_min(x1, sz.get_image_extent().x) - tile_rect.org.x;
+            ojph_min(x1, sz.get_image_extent().x) - tile_rect.org.x;
 
           recon_tile_rect.org.x = ojph_max(ojph_div_ceil(x0, ds),
-                                           ojph_div_ceil(sz.get_image_offset().x, ds));
+            ojph_div_ceil(sz.get_image_offset().x, ds));
           recon_tile_rect.siz.w = ojph_min(ojph_div_ceil(x1, ds),
-                                           ojph_div_ceil(sz.get_image_extent().x, ds)) -
-                                  recon_tile_rect.org.x;
+            ojph_div_ceil(sz.get_image_extent().x, ds))
+            - recon_tile_rect.org.x;
 
           ui32 tps = 0; // number of tileparts for this tile
           tile::pre_alloc(this, tile_rect, recon_tile_rect, tps);
@@ -155,30 +167,40 @@ namespace ojph
         }
       }
 
-      // allocate lines
-      // These lines are used by codestream to exchange data with external
-      //  world
+      //allocate lines
+      //These lines are used by codestream to exchange data with external
+      // world
       ui32 num_comps = sz.get_num_components();
       allocator->pre_alloc_obj<line_buf>(num_comps);
-      allocator->pre_alloc_obj<size>(num_comps); // for *comp_size
-      allocator->pre_alloc_obj<size>(num_comps); // for *recon_comp_size
+      allocator->pre_alloc_obj<size>(num_comps); //for *comp_size
+      allocator->pre_alloc_obj<size>(num_comps); //for *recon_comp_size
       for (ui32 i = 0; i < num_comps; ++i)
         allocator->pre_alloc_data<si32>(siz.get_recon_width(i), 0);
 
-      // allocate tlm
+      //allocate tlm
       if (outfile != NULL && need_tlm)
         allocator->pre_alloc_obj<param_tlm::Ttlm_Ptlm_pair>(num_tileparts);
 
-      // precinct scratch buffer
-      ui32 num_decomps = cod.get_num_decompositions();
-      size log_cb = cod.get_log_block_dims();
-
+      //precinct scratch buffer
+      // The precinct scratch is shared by all components, but each component
+      // may override the codeblock/precinct geometry via a COC marker.  The
+      // per-component tag-tree storage (resolution.cpp) is derived from that
+      // component's effective params, so size the shared buffer from the
+      // largest ratio across every component (the main COD and all COC
+      // overrides).  Sizing from the COD alone under-reserves the buffer for
+      // any component whose COC declares a smaller codeblock than the COD.
       size ratio;
-      for (ui32 r = 0; r <= num_decomps; ++r)
+      for (ui32 c = 0; c < num_comps; ++c)
       {
-        size log_PP = cod.get_log_precinct_size(r);
-        ratio.w = ojph_max(ratio.w, log_PP.w - ojph_min(log_cb.w, log_PP.w));
-        ratio.h = ojph_max(ratio.h, log_PP.h - ojph_min(log_cb.h, log_PP.h));
+        const param_cod* cdp = cod.get_coc(c);
+        ui32 num_decomps = cdp->get_num_decompositions();
+        size log_cb = cdp->get_log_block_dims();
+        for (ui32 r = 0; r <= num_decomps; ++r)
+        {
+          size log_PP = cdp->get_log_precinct_size(r);
+          ratio.w = ojph_max(ratio.w, log_PP.w - ojph_min(log_cb.w, log_PP.w));
+          ratio.h = ojph_max(ratio.h, log_PP.h - ojph_min(log_cb.h, log_PP.h));
+        }
       }
       ui32 max_ratio = ojph_max(ratio.w, ratio.h);
       max_ratio = 1 << max_ratio;
@@ -190,7 +212,7 @@ namespace ojph
       // 1. missing msbs and 2. their flags,
       // 3. number of layers and 4. their flags
       precinct_scratch_needed_bytes =
-          4 * ((max_ratio * max_ratio * 4 + 2) / 3);
+        4 * ((max_ratio * max_ratio * 4 + 2) / 3);
 
       allocator->pre_alloc_obj<ui8>(precinct_scratch_needed_bytes);
     }
@@ -200,11 +222,11 @@ namespace ojph
     {
       allocator->alloc();
 
-      // precinct scratch buffer
+      //precinct scratch buffer
       precinct_scratch =
-          allocator->post_alloc_obj<ui8>(precinct_scratch_needed_bytes);
+        allocator->post_alloc_obj<ui8>(precinct_scratch_needed_bytes);
 
-      // get tiles
+      //get tiles
       tiles = this->allocator->post_alloc_obj<tile>((size_t)num_tiles.area());
 
       ui32 num_tileparts = 0;
@@ -213,22 +235,24 @@ namespace ojph
       ojph::param_siz sz = access_siz();
       for (index.y = 0; index.y < num_tiles.h; ++index.y)
       {
-        ui32 y0 = sz.get_tile_offset().y + index.y * sz.get_tile_size().h;
-        ui32 y1 = y0 + sz.get_tile_size().h; // end of tile
+        ui32 y0 = sz.get_tile_offset().y
+                + index.y * sz.get_tile_size().h;
+        ui32 y1 = y0 + sz.get_tile_size().h; //end of tile
 
         tile_rect.org.y = ojph_max(y0, sz.get_image_offset().y);
         tile_rect.siz.h =
-            ojph_min(y1, sz.get_image_extent().y) - tile_rect.org.y;
+          ojph_min(y1, sz.get_image_extent().y) - tile_rect.org.y;
 
         ui32 offset = 0;
         for (index.x = 0; index.x < num_tiles.w; ++index.x)
         {
-          ui32 x0 = sz.get_tile_offset().x + index.x * sz.get_tile_size().w;
+          ui32 x0 = sz.get_tile_offset().x
+                  + index.x * sz.get_tile_size().w;
           ui32 x1 = x0 + sz.get_tile_size().w;
 
           tile_rect.org.x = ojph_max(x0, sz.get_image_offset().x);
           tile_rect.siz.w =
-              ojph_min(x1, sz.get_image_extent().x) - tile_rect.org.x;
+            ojph_min(x1, sz.get_image_extent().x) - tile_rect.org.x;
 
           ui32 tps = 0; // number of tileparts for this tile
           ui32 idx = index.y * num_tiles.w + index.x;
@@ -237,9 +261,9 @@ namespace ojph
         }
       }
 
-      // allocate lines
-      // These lines are used by codestream to exchange data with external
-      //  world
+      //allocate lines
+      //These lines are used by codestream to exchange data with external
+      // world
       this->num_comps = sz.get_num_components();
       lines = allocator->post_alloc_obj<line_buf>(this->num_comps);
       comp_size = allocator->post_alloc_obj<size>(this->num_comps);
@@ -258,17 +282,18 @@ namespace ojph
       cur_comp = 0;
       cur_line = 0;
 
-      // allocate tlm
+      //allocate tlm
       if (outfile != NULL && need_tlm)
         tlm.init(num_tileparts,
-                 allocator->post_alloc_obj<param_tlm::Ttlm_Ptlm_pair>(num_tileparts));
+          allocator->post_alloc_obj<param_tlm::Ttlm_Ptlm_pair>(num_tileparts));
     }
+
 
     //////////////////////////////////////////////////////////////////////////
     void codestream::check_imf_validity()
     {
-      // two possibilities lossy single tile or lossless
-      // For the following code, we use the least strict profile
+      //two possibilities lossy single tile or lossless
+      //For the following code, we use the least strict profile
       ojph::param_siz sz(&siz);
       ojph::param_cod cd(&cod);
       bool reversible = cd.is_reversible();
@@ -287,7 +312,7 @@ namespace ojph
 
         if (!imf2kls && !imf4kls && !imf8kls)
           OJPH_ERROR(0x000300C1,
-                     "Image dimensions do not meet any of the lossless IMF profiles");
+            "Image dimensions do not meet any of the lossless IMF profiles");
       }
       else
       {
@@ -301,19 +326,20 @@ namespace ojph
 
         if (!imf2k && !imf4k && !imf8k)
           OJPH_ERROR(0x000300C2,
-                     "Image dimensions do not meet any of the lossy IMF profiles");
+            "Image dimensions do not meet any of the lossy IMF profiles");
       }
+
 
       if (sz.get_image_offset().x != 0 || sz.get_image_offset().y != 0)
         OJPH_ERROR(0x000300C3,
-                   "For IMF profile, image offset (XOsiz, YOsiz) has to be 0.");
+          "For IMF profile, image offset (XOsiz, YOsiz) has to be 0.");
       if (sz.get_tile_offset().x != 0 || sz.get_tile_offset().y != 0)
         OJPH_ERROR(0x000300C4,
-                   "For IMF profile, tile offset (XTOsiz, YTOsiz) has to be 0.");
+          "For IMF profile, tile offset (XTOsiz, YTOsiz) has to be 0.");
       if (sz.get_num_components() > 3)
         OJPH_ERROR(0x000300C5,
-                   "For IMF profile, the number of components has to be less "
-                   " or equal to 3");
+          "For IMF profile, the number of components has to be less "
+          " or equal to 3");
       bool test_ds1 = true, test_ds2 = true;
       for (ojph::ui32 i = 0; i < sz.get_num_components(); ++i)
       {
@@ -329,9 +355,9 @@ namespace ojph
       }
       if (!test_ds1 && !test_ds2)
         OJPH_ERROR(0x000300C6,
-                   "For IMF profile, either no component downsampling is used,"
-                   " or the x-dimension of the 2nd and 3rd components is downsampled"
-                   " by 2.");
+          "For IMF profile, either no component downsampling is used,"
+          " or the x-dimension of the 2nd and 3rd components is downsampled"
+          " by 2.");
 
       bool test_bd = true;
       for (ojph::ui32 i = 0; i < sz.get_num_components(); ++i)
@@ -342,27 +368,29 @@ namespace ojph
       }
       if (!test_bd)
         OJPH_ERROR(0x000300C7,
-                   "For IMF profile, compnent bit_depth has to be between"
-                   " 8 and 16 bits inclusively, and the samples must be unsigned");
+          "For IMF profile, compnent bit_depth has to be between"
+          " 8 and 16 bits inclusively, and the samples must be unsigned");
 
       if (cd.get_log_block_dims().w != 5 || cd.get_log_block_dims().h != 5)
         OJPH_ERROR(0x000300C8,
-                   "For IMF profile, codeblock dimensions are restricted."
-                   " Use \"-block_size {32,32}\" at the commandline");
+          "For IMF profile, codeblock dimensions are restricted."
+          " Use \"-block_size {32,32}\" at the commandline");
 
       ui32 num_decomps = cd.get_num_decompositions();
-      bool test_pz = cd.get_log_precinct_size(0).w == 7 && cd.get_log_precinct_size(0).h == 7;
+      bool test_pz = cd.get_log_precinct_size(0).w == 7
+                  && cd.get_log_precinct_size(0).h == 7;
       for (ui32 i = 1; i <= num_decomps; ++i)
-        test_pz = cd.get_log_precinct_size(i).w == 8 && cd.get_log_precinct_size(i).h == 8;
+        test_pz = cd.get_log_precinct_size(i).w == 8
+               && cd.get_log_precinct_size(i).h == 8;
       if (!test_pz)
         OJPH_ERROR(0x000300C9,
-                   "For IMF profile, precinct sizes are restricted."
-                   " Use \"-precincts {128,128},{256,256}\" at the commandline");
+          "For IMF profile, precinct sizes are restricted."
+          " Use \"-precincts {128,128},{256,256}\" at the commandline");
 
       if (cd.get_progression_order() != OJPH_PO_CPRL)
         OJPH_ERROR(0x000300CA,
-                   "For IMF profile, the CPRL progression order must be used."
-                   " Use \"-prog_order CPRL\".");
+          "For IMF profile, the CPRL progression order must be used."
+          " Use \"-prog_order CPRL\".");
 
       imf2k &= num_decomps <= 5;
       imf2kls &= num_decomps <= 5;
@@ -372,10 +400,10 @@ namespace ojph
       imf8kls &= num_decomps <= 7;
 
       if (num_decomps == 0 ||
-          (!imf2k && !imf4k && !imf8k && !imf2kls && !imf4kls && !imf8kls))
+        (!imf2k && !imf4k && !imf8k && !imf2kls && !imf4kls && !imf8kls))
         OJPH_ERROR(0x000300CB,
-                   "Number of decompositions does not match the IMF profile"
-                   " dictated by wavelet reversibility and image dimensions.");
+          "Number of decompositions does not match the IMF profile"
+          " dictated by wavelet reversibility and image dimensions.");
 
       ui32 tiles_w = sz.get_image_extent().x;
       tiles_w = ojph_div_ceil(tiles_w, sz.get_tile_size().w);
@@ -387,20 +415,29 @@ namespace ojph
       {
         if (!reversible)
           OJPH_ERROR(0x000300CC,
-                     "Lossy IMF profile must have one tile.");
+            "Lossy IMF profile must have one tile.");
 
         size tt = sz.get_tile_size();
         imf2kls &= (tt.w == 1024 && tt.h == 1024);
-        imf2kls &= (tt.w >= 1024 && num_decomps <= 4) || (tt.w >= 2048 && num_decomps <= 5);
-        imf4kls &= (tt.w == 1024 && tt.h == 1024) || (tt.w == 2048 && tt.h == 2048);
-        imf4kls &= (tt.w >= 1024 && num_decomps <= 4) || (tt.w >= 2048 && num_decomps <= 5) || (tt.w >= 4096 && num_decomps <= 6);
-        imf8kls &= (tt.w == 1024 && tt.h == 1024) || (tt.w == 2048 && tt.h == 2048) || (tt.w == 4096 && tt.h == 4096);
-        imf8kls &= (tt.w >= 1024 && num_decomps <= 4) || (tt.w >= 2048 && num_decomps <= 5) || (tt.w >= 4096 && num_decomps <= 6) || (tt.w >= 8192 && num_decomps <= 7);
+        imf2kls &= (tt.w >= 1024 && num_decomps <= 4)
+                || (tt.w >= 2048 && num_decomps <= 5);
+        imf4kls &= (tt.w == 1024 && tt.h == 1024)
+                || (tt.w == 2048 && tt.h == 2048);
+        imf4kls &= (tt.w >= 1024 && num_decomps <= 4)
+                || (tt.w >= 2048 && num_decomps <= 5)
+                || (tt.w >= 4096 && num_decomps <= 6);
+        imf8kls &= (tt.w == 1024 && tt.h == 1024)
+                || (tt.w == 2048 && tt.h == 2048)
+                || (tt.w == 4096 && tt.h == 4096);
+        imf8kls &= (tt.w >= 1024 && num_decomps <= 4)
+                || (tt.w >= 2048 && num_decomps <= 5)
+                || (tt.w >= 4096 && num_decomps <= 6)
+                || (tt.w >= 8192 && num_decomps <= 7);
         if (!imf2kls && !imf4kls && !imf8kls)
           OJPH_ERROR(0x000300CD,
-                     "Number of decompositions does not match the IMF profile"
-                     " dictated by wavelet reversibility and image dimensions and"
-                     " tiles.");
+            "Number of decompositions does not match the IMF profile"
+            " dictated by wavelet reversibility and image dimensions and"
+            " tiles.");
       }
 
       need_tlm = true;
@@ -409,9 +446,9 @@ namespace ojph
       {
         tilepart_div = OJPH_TILEPART_COMPONENTS;
         OJPH_WARN(0x000300C1,
-                  "In IMF profile, tile part divisions at the component level must be "
-                  "employed, while at the resolution level is not allowed. "
-                  "This has been corrected.");
+          "In IMF profile, tile part divisions at the component level must be "
+          "employed, while at the resolution level is not allowed. "
+          "This has been corrected.");
       }
     }
 
@@ -423,14 +460,14 @@ namespace ojph
 
       if (sz.get_image_offset().x != 0 || sz.get_image_offset().y != 0)
         OJPH_ERROR(0x000300B1,
-                   "For broadcast profile, image offset (XOsiz, YOsiz) has to be 0.");
+          "For broadcast profile, image offset (XOsiz, YOsiz) has to be 0.");
       if (sz.get_tile_offset().x != 0 || sz.get_tile_offset().y != 0)
         OJPH_ERROR(0x000300B2,
-                   "For broadcast profile, tile offset (XTOsiz, YTOsiz) has to be 0.");
+          "For broadcast profile, tile offset (XTOsiz, YTOsiz) has to be 0.");
       if (sz.get_num_components() > 4)
         OJPH_ERROR(0x000300B3,
-                   "For broadcast profile, the number of components has to be less "
-                   " or equal to 4");
+          "For broadcast profile, the number of components has to be less "
+          " or equal to 4");
       bool test_ds1 = true, test_ds2 = true;
       for (ojph::ui32 i = 0; i < sz.get_num_components(); ++i)
       {
@@ -446,9 +483,9 @@ namespace ojph
       }
       if (!test_ds1 && !test_ds2)
         OJPH_ERROR(0x000300B4,
-                   "For broadcast profile, either no component downsampling is used,"
-                   " or the x-dimension of the 2nd and 3rd components is downsampled"
-                   " by 2.");
+          "For broadcast profile, either no component downsampling is used,"
+          " or the x-dimension of the 2nd and 3rd components is downsampled"
+          " by 2.");
 
       bool test_bd = true;
       for (ojph::ui32 i = 0; i < sz.get_num_components(); ++i)
@@ -459,37 +496,39 @@ namespace ojph
       }
       if (!test_bd)
         OJPH_ERROR(0x000300B5,
-                   "For broadcast profile, compnent bit_depth has to be between"
-                   " 8 and 12 bits inclusively, and the samples must be unsigned");
+          "For broadcast profile, compnent bit_depth has to be between"
+          " 8 and 12 bits inclusively, and the samples must be unsigned");
 
       ui32 num_decomps = cd.get_num_decompositions();
       if (num_decomps == 0 || num_decomps > 5)
         OJPH_ERROR(0x000300B6,
-                   "For broadcast profile, number of decompositions has to be between"
-                   "1 and 5 inclusively.");
+          "For broadcast profile, number of decompositions has to be between"
+          "1 and 5 inclusively.");
 
       if (cd.get_log_block_dims().w < 5 || cd.get_log_block_dims().w > 7)
         OJPH_ERROR(0x000300B7,
-                   "For broadcast profile, codeblock dimensions are restricted such"
-                   " that codeblock width has to be either 32, 64, or 128.");
+          "For broadcast profile, codeblock dimensions are restricted such"
+          " that codeblock width has to be either 32, 64, or 128.");
 
       if (cd.get_log_block_dims().h < 5 || cd.get_log_block_dims().h > 7)
         OJPH_ERROR(0x000300B8,
-                   "For broadcast profile, codeblock dimensions are restricted such"
-                   " that codeblock height has to be either 32, 64, or 128.");
+          "For broadcast profile, codeblock dimensions are restricted such"
+          " that codeblock height has to be either 32, 64, or 128.");
 
-      bool test_pz = cd.get_log_precinct_size(0).w == 7 && cd.get_log_precinct_size(0).h == 7;
+      bool test_pz = cd.get_log_precinct_size(0).w == 7
+                  && cd.get_log_precinct_size(0).h == 7;
       for (ui32 i = 1; i <= num_decomps; ++i)
-        test_pz = cd.get_log_precinct_size(i).w == 8 && cd.get_log_precinct_size(i).h == 8;
+        test_pz = cd.get_log_precinct_size(i).w == 8
+               && cd.get_log_precinct_size(i).h == 8;
       if (!test_pz)
         OJPH_ERROR(0x000300B9,
-                   "For broadcast profile, precinct sizes are restricted."
-                   " Use \"-precincts {128,128},{256,256}\" at the commandline");
+          "For broadcast profile, precinct sizes are restricted."
+          " Use \"-precincts {128,128},{256,256}\" at the commandline");
 
       if (cd.get_progression_order() != OJPH_PO_CPRL)
         OJPH_ERROR(0x000300BA,
-                   "For broadcast profile, the CPRL progression order must be used."
-                   " Use \"-prog_order CPRL\".");
+          "For broadcast profile, the CPRL progression order must be used."
+          " Use \"-prog_order CPRL\".");
 
       ui32 tiles_w = sz.get_image_extent().x;
       tiles_w = ojph_div_ceil(tiles_w, sz.get_tile_size().w);
@@ -499,7 +538,7 @@ namespace ojph
 
       if (total_tiles != 1 && total_tiles != 4)
         OJPH_ERROR(0x000300BB,
-                   "The broadcast profile can only have 1 or 4 tiles");
+          "The broadcast profile can only have 1 or 4 tiles");
 
       need_tlm = true;
       tilepart_div |= OJPH_TILEPART_COMPONENTS;
@@ -507,21 +546,31 @@ namespace ojph
       {
         tilepart_div = OJPH_TILEPART_COMPONENTS;
         OJPH_WARN(0x000300B1,
-                  "In BROADCAST profile, tile part divisions at the component level "
-                  "must be employed, while at the resolution level is not allowed. "
-                  "This has been corrected.");
+          "In BROADCAST profile, tile part divisions at the component level "
+          "must be employed, while at the resolution level is not allowed. "
+          "This has been corrected.");
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
     void codestream::write_headers(outfile_base *file,
-                                   const comment_exchange *comments,
+                                   const comment_exchange* comments,
                                    ui32 num_comments)
     {
-      // finalize
-      siz.check_validity(cod);
+      //finalize
+      siz.set_cod(cod);
+      // set the tile size if it was not set by the user
+      size tile_size = siz.get_tile_size();
+      if (tile_size.h == 0 && tile_size.w == 0)
+      {
+        point img_offset = siz.get_image_offset();
+        point img_extent = siz.get_image_extent();
+        size t(img_extent.x + img_offset.x, img_extent.y + img_offset.y);
+        siz.set_tile_size(t);
+      }
+      siz.check_validity();
       cod.check_validity(siz);
-      cod.update_atk(atk);
+      cod.update_atk(&atk);
       qcd.check_validity(siz, cod);
       cap.check_validity(cod, qcd);
       nlt.check_validity(siz);
@@ -532,56 +581,56 @@ namespace ojph
 
       int po = ojph::param_cod(&cod).get_progression_order();
       if ((po == OJPH_PO_LRCP || po == OJPH_PO_RLCP) &&
-          tilepart_div == OJPH_TILEPART_COMPONENTS)
+           tilepart_div == OJPH_TILEPART_COMPONENTS)
       {
         tilepart_div |= OJPH_TILEPART_RESOLUTIONS;
         OJPH_INFO(0x00030021,
-                  "For LRCP and RLCP progression orders, tilepart divisions at the "
-                  "component level, means that we have a tilepart for every "
-                  "resolution and component.\n");
+          "For LRCP and RLCP progression orders, tilepart divisions at the "
+          "component level, means that we have a tilepart for every "
+          "resolution and component.\n");
       }
       if (po == OJPH_PO_RPCL && (tilepart_div & OJPH_TILEPART_COMPONENTS) != 0)
       {
         tilepart_div &= ~OJPH_TILEPART_COMPONENTS;
         OJPH_WARN(0x00030021,
-                  "For RPCL progression, having tilepart divisions at the component "
-                  "level means a tilepart for every precinct, which does not "
-                  "make sense, since we can have no more than 255 tile parts. This "
-                  "has been corrected by removing tilepart divisions at the component "
-                  "level.");
+          "For RPCL progression, having tilepart divisions at the component "
+          "level means a tilepart for every precinct, which does not "
+          "make sense, since we can have no more than 255 tile parts. This "
+          "has been corrected by removing tilepart divisions at the component "
+          "level.");
       }
       if (po == OJPH_PO_PCRL && tilepart_div != 0)
       {
         tilepart_div = 0;
         OJPH_WARN(0x00030022,
-                  "For PCRL progression, having tilepart divisions at the component "
-                  "level or the resolution level means a tile part for every "
-                  "precinct, which does not make sense, since we can have no more "
-                  "than 255 tile parts.  This has been corrected by removing tilepart "
-                  "divisions; use another progression if you want tileparts.");
+          "For PCRL progression, having tilepart divisions at the component "
+          "level or the resolution level means a tile part for every "
+          "precinct, which does not make sense, since we can have no more "
+          "than 255 tile parts.  This has been corrected by removing tilepart "
+          "divisions; use another progression if you want tileparts.");
       }
       if (po == OJPH_PO_CPRL && (tilepart_div & OJPH_TILEPART_RESOLUTIONS) != 0)
       {
         tilepart_div &= ~OJPH_TILEPART_RESOLUTIONS;
         OJPH_WARN(0x00030023,
-                  "For CPRL progression, having tilepart divisions at the resolution "
-                  "level means a tile part for every precinct, which does not "
-                  "make sense, since we can have no more than 255 tile parts. This "
-                  "has been corrected by removing tilepart divisions at the "
-                  "resolution level.");
+          "For CPRL progression, having tilepart divisions at the resolution "
+          "level means a tile part for every precinct, which does not "
+          "make sense, since we can have no more than 255 tile parts. This "
+          "has been corrected by removing tilepart divisions at the "
+          "resolution level.");
       }
 
-      if (planar == -1) // not initialized
+      if (planar == -1) //not initialized
         planar = cod.is_employing_color_transform() ? 1 : 0;
-      else if (planar == 0) // interleaved is chosen
+      else if (planar == 0) //interleaved is chosen
       {
       }
-      else if (planar == 1) // plannar is chosen
+      else if (planar == 1) //plannar is chosen
       {
         if (cod.is_employing_color_transform() == true)
           OJPH_ERROR(0x00030021,
-                     "the planar interface option cannot be used when colour "
-                     "transform is employed");
+            "the planar interface option cannot be used when colour "
+            "transform is employed");
       }
       else
         assert(0);
@@ -591,7 +640,7 @@ namespace ojph
       this->pre_alloc();
       this->finalize_alloc();
 
-      ui16 t = swap_byte(JP2K_MARKER::SOC);
+      ui16 t = swap_bytes_if_le(JP2K_MARKER::SOC);
       if (file->write(&t, 2) != 2)
         OJPH_ERROR(0x00030022, "Error writing to file");
 
@@ -616,51 +665,54 @@ namespace ojph
       if (!nlt.write(file))
         OJPH_ERROR(0x00030027, "Error writing to file");
 
-      char buf[] = "      OpenJPH Ver " OJPH_INT_TO_STRING(OPENJPH_VERSION_MAJOR) "." OJPH_INT_TO_STRING(OPENJPH_VERSION_MINOR) "." OJPH_INT_TO_STRING(OPENJPH_VERSION_PATCH) ".";
+      char buf[] = "      OpenJPH Ver "
+        OJPH_INT_TO_STRING(OPENJPH_VERSION_MAJOR) "."
+        OJPH_INT_TO_STRING(OPENJPH_VERSION_MINOR) "."
+        OJPH_INT_TO_STRING(OPENJPH_VERSION_PATCH) ".";
       size_t len = strlen(buf);
-      *(ui16 *)buf = swap_byte(JP2K_MARKER::COM);
-      *(ui16 *)(buf + 2) = swap_byte((ui16)(len - 2));
-      // 1 for General use (IS 8859-15:1999 (Latin) values)
-      *(ui16 *)(buf + 4) = swap_byte((ui16)(1));
+      *(ui16*)buf = swap_bytes_if_le(JP2K_MARKER::COM);
+      *(ui16*)(buf + 2) = swap_bytes_if_le((ui16)(len - 2));
+      //1 for General use (IS 8859-15:1999 (Latin) values)
+      *(ui16*)(buf + 4) = swap_bytes_if_le((ui16)(1));
       if (file->write(buf, len) != len)
         OJPH_ERROR(0x00030028, "Error writing to file");
 
-      if (comments != NULL)
-      {
+      if (comments != NULL) {
         for (ui32 i = 0; i < num_comments; ++i)
         {
-          t = swap_byte(JP2K_MARKER::COM);
+          t = swap_bytes_if_le(JP2K_MARKER::COM);
           if (file->write(&t, 2) != 2)
             OJPH_ERROR(0x00030029, "Error writing to file");
-          t = swap_byte((ui16)(comments[i].len + 4));
+          t = swap_bytes_if_le((ui16)(comments[i].len + 4));
           if (file->write(&t, 2) != 2)
             OJPH_ERROR(0x0003002A, "Error writing to file");
-          // 1 for General use (IS 8859-15:1999 (Latin) values)
-          t = swap_byte(comments[i].Rcom);
+          //1 for General use (IS 8859-15:1999 (Latin) values)
+          t = swap_bytes_if_le(comments[i].Rcom);
           if (file->write(&t, 2) != 2)
             OJPH_ERROR(0x0003002B, "Error writing to file");
-          if (file->write(comments[i].data, comments[i].len) != comments[i].len)
+          if (file->write(comments[i].data, comments[i].len)!=comments[i].len)
             OJPH_ERROR(0x0003002C, "Error writing to file");
         }
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static int find_marker(infile_base *f, const ui16 *char_list, int list_len)
+    static
+    int find_marker(infile_base *f, const ui16* char_list, int list_len)
     {
-      // returns the marker index in char_list, or -1
+      //returns the marker index in char_list, or -1
       while (!f->eof())
       {
         ui8 new_char;
         size_t num_bytes = f->read(&new_char, 1);
         if (num_bytes != 1)
-          return -1;
+            return -1;
         if (new_char == 0xFF)
         {
           size_t num_bytes = f->read(&new_char, 1);
 
           if (num_bytes != 1)
-            return -1;
+              return -1;
 
           for (int i = 0; i < list_len; ++i)
             if (new_char == (char_list[i] & 0xFF))
@@ -671,8 +723,9 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static int skip_marker(infile_base *file, const char *marker,
-                           const char *msg, int msg_level, bool resilient)
+    static
+    int skip_marker(infile_base *file, const char *marker,
+                     const char *msg, int msg_level, bool resilient)
     {
       ojph_unused(marker);
       ui16 com_len;
@@ -683,19 +736,19 @@ namespace ojph
         else
           OJPH_ERROR(0x00030041, "error reading marker");
       }
-      com_len = swap_byte(com_len);
+      com_len = swap_bytes_if_le(com_len);
       file->seek(com_len - 2, infile_base::OJPH_SEEK_CUR);
-      if (msg != NULL && msg_level != OJPH_MSG_LEVEL::NO_MSG)
+      if (msg != NULL && msg_level != OJPH_MSG_NO_MSG)
       {
-        if (msg_level == OJPH_MSG_LEVEL::INFO)
+        if (msg_level == OJPH_MSG_INFO)
         {
           OJPH_INFO(0x00030001, "%s", msg);
         }
-        else if (msg_level == OJPH_MSG_LEVEL::WARN)
+        else if (msg_level == OJPH_MSG_WARN)
         {
           OJPH_WARN(0x00030001, "%s", msg);
         }
-        else if (msg_level == OJPH_MSG_LEVEL::ERROR)
+        else if (msg_level == OJPH_MSG_ERROR)
         {
           OJPH_ERROR(0x00030001, "%s", msg);
         }
@@ -708,24 +761,24 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     void codestream::read_headers(infile_base *file)
     {
-      ui16 marker_list[20] = {SOC, SIZ, CAP, PRF, CPF, COD, COC, QCD, QCC,
-                              RGN, POC, PPM, TLM, PLM, CRG, COM, DFS, ATK, NLT, SOT};
-      find_marker(file, marker_list, 1);     // find SOC
-      find_marker(file, marker_list + 1, 1); // find SIZ
+      ui16 marker_list[20] = { SOC, SIZ, CAP, PRF, CPF, COD, COC, QCD, QCC,
+        RGN, POC, PPM, TLM, PLM, CRG, COM, DFS, ATK, NLT, SOT };
+      find_marker(file, marker_list, 1); //find SOC
+      find_marker(file, marker_list + 1, 1); //find SIZ
       siz.read(file);
       int marker_idx = 0;
-      int received_markers = 0; // check that COD, & QCD received
+      int received_markers = 0; //check that COD, & QCD received
       while (true)
       {
         marker_idx = find_marker(file, marker_list + 2, 18);
         if (marker_idx == 0)
           cap.read(file);
         else if (marker_idx == 1)
-          // Skipping PRF marker segment; this should not cause any issues
-          skip_marker(file, "PRF", NULL, OJPH_MSG_LEVEL::NO_MSG, false);
+          //Skipping PRF marker segment; this should not cause any issues
+          skip_marker(file, "PRF", NULL, OJPH_MSG_NO_MSG, false);
         else if (marker_idx == 2)
-          // Skipping CPF marker segment; this should not cause any issues
-          skip_marker(file, "CPF", NULL, OJPH_MSG_LEVEL::NO_MSG, false);
+          //Skipping CPF marker segment; this should not cause any issues
+          skip_marker(file, "CPF", NULL, OJPH_MSG_NO_MSG, false);
         else if (marker_idx == 3)
         {
           cod.read(file);
@@ -734,23 +787,22 @@ namespace ojph
           int num_qlayers = c.get_num_layers();
           if (num_qlayers != 1)
             OJPH_ERROR(0x00030053, "The current implementation supports "
-                                   "1 quality layer only.  This codestream has %d quality layers",
-                       num_qlayers);
+              "1 quality layer only.  This codestream has %d quality layers",
+              num_qlayers);
         }
         else if (marker_idx == 4)
         {
-          param_cod *p = cod.add_coc_object(param_cod::OJPH_COD_UNKNOWN);
+          param_cod* p = cod.add_coc_object(param_cod::OJPH_COD_UNKNOWN);
           p->read_coc(file, siz.get_num_components(), &cod);
           if (p->get_comp_idx() >= siz.get_num_components())
             OJPH_INFO(0x00030056, "The codestream carries a COC marker "
-                                  "segment for a component indexed by %d, which is more than the "
-                                  "allowed index number, since the codestream has %d components",
-                      p->get_comp_idx(), num_comps);
+              "segment for a component indexed by %d, which is more than the "
+              "allowed index number, since the codestream has %d components",
+              p->get_comp_idx(), num_comps);
           param_cod *q = cod.get_coc(p->get_comp_idx());
           if (p != q && p->get_comp_idx() == q->get_comp_idx())
             OJPH_ERROR(0x00030057, "The codestream has two COC marker "
-                                   "segments for one component of index %d",
-                       p->get_comp_idx());
+              "segments for one component of index %d",  p->get_comp_idx());
         }
         else if (marker_idx == 5)
         {
@@ -759,48 +811,47 @@ namespace ojph
         }
         else if (marker_idx == 6)
         {
-          param_qcd *p = qcd.add_qcc_object(param_qcd::OJPH_QCD_UNKNOWN);
+          param_qcd* p = qcd.add_qcc_object(param_qcd::OJPH_QCD_UNKNOWN);
           p->read_qcc(file, siz.get_num_components());
           if (p->get_comp_idx() >= siz.get_num_components())
             OJPH_ERROR(0x00030054, "The codestream carries a QCC marker "
-                                   "segment for a component indexed by %d, which is more than the "
-                                   "allowed index number, since the codestream has %d components",
-                       p->get_comp_idx(), num_comps);
+              "segment for a component indexed by %d, which is more than the "
+              "allowed index number, since the codestream has %d components",
+              p->get_comp_idx(), num_comps);
           param_qcd *q = qcd.get_qcc(p->get_comp_idx());
           if (p != q && p->get_comp_idx() == q->get_comp_idx())
             OJPH_ERROR(0x00030055, "The codestream has two QCC marker "
-                                   "segments for one component of index %d",
-                       p->get_comp_idx());
+              "segments for one component of index %d", p->get_comp_idx());
         }
         else if (marker_idx == 7)
           skip_marker(file, "RGN", "RGN is not supported yet",
-                      OJPH_MSG_LEVEL::WARN, false);
+            OJPH_MSG_WARN, false);
         else if (marker_idx == 8)
           skip_marker(file, "POC", "POC is not supported yet",
-                      OJPH_MSG_LEVEL::WARN, false);
+            OJPH_MSG_WARN, false);
         else if (marker_idx == 9)
           skip_marker(file, "PPM", "PPM is not supported yet",
-                      OJPH_MSG_LEVEL::WARN, false);
+            OJPH_MSG_WARN, false);
         else if (marker_idx == 10)
-          // Skipping TLM marker segment; this should not cause any issues
-          skip_marker(file, "TLM", NULL, OJPH_MSG_LEVEL::NO_MSG, false);
+          //Skipping TLM marker segment; this should not cause any issues
+          skip_marker(file, "TLM", NULL, OJPH_MSG_NO_MSG, false);
         else if (marker_idx == 11)
-          // Skipping PLM marker segment; this should not cause any issues
-          skip_marker(file, "PLM", NULL, OJPH_MSG_LEVEL::NO_MSG, false);
+          //Skipping PLM marker segment; this should not cause any issues
+          skip_marker(file, "PLM", NULL, OJPH_MSG_NO_MSG, false);
         else if (marker_idx == 12)
-          // Skipping CRG marker segment;
+          //Skipping CRG marker segment;
           skip_marker(file, "CRG", "CRG has been ignored; CRG is related to"
-                                   " where the Cb and Cr colour components are co-sited or located"
-                                   " with respect to the Y' luma component. Perhaps, it is better"
-                                   " to get the individual components and assemble the samples"
-                                   " according to your needs",
-                      OJPH_MSG_LEVEL::INFO, false);
+            " where the Cb and Cr colour components are co-sited or located"
+            " with respect to the Y' luma component. Perhaps, it is better"
+            " to get the individual components and assemble the samples"
+            " according to your needs",
+            OJPH_MSG_INFO, false);
         else if (marker_idx == 13)
-          skip_marker(file, "COM", NULL, OJPH_MSG_LEVEL::NO_MSG, false);
+          skip_marker(file, "COM", NULL, OJPH_MSG_NO_MSG, false);
         else if (marker_idx == 14)
           dfs.read(file);
         else if (marker_idx == 15)
-          atk[2].read(file);
+          atk.read(file);
         else if (marker_idx == 16)
           nlt.read(file);
         else if (marker_idx == 17)
@@ -809,7 +860,7 @@ namespace ojph
           OJPH_ERROR(0x00030051, "File ended before finding a tile segment");
       }
 
-      cod.update_atk(atk);
+      cod.update_atk(&atk);
       siz.link(&cod);
       if (dfs.exists())
         siz.link(&dfs);
@@ -823,18 +874,18 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void codestream::restrict_input_resolution(ui32 skipped_res_for_read,
-                                               ui32 skipped_res_for_recon)
+      ui32 skipped_res_for_recon)
     {
       if (skipped_res_for_read < skipped_res_for_recon)
         OJPH_ERROR(0x000300A1,
-                   "skipped_resolution for data %d must be equal or smaller than "
-                   " skipped_resolution for reconstruction %d\n",
-                   skipped_res_for_read, skipped_res_for_recon);
+          "skipped_resolution for data %d must be equal or smaller than "
+          " skipped_resolution for reconstruction %d\n",
+          skipped_res_for_read, skipped_res_for_recon);
       if (skipped_res_for_read > cod.get_num_decompositions())
         OJPH_ERROR(0x000300A2,
-                   "skipped_resolution for data %d must be smaller than "
-                   " the number of decomposition levels %d\n",
-                   skipped_res_for_read, cod.get_num_decompositions());
+          "skipped_resolution for data %d must be smaller than "
+          " the number of decomposition levels %d\n",
+          skipped_res_for_read, cod.get_num_decompositions());
 
       this->skipped_res_for_read = skipped_res_for_read;
       this->skipped_res_for_recon = skipped_res_for_recon;
@@ -846,7 +897,7 @@ namespace ojph
     {
       if (infile != NULL)
         OJPH_ERROR(0x000300A3, "Codestream resilience must be enabled before"
-                               " reading file headers.\n");
+          " reading file headers.\n");
       this->resilient = true;
     }
 
@@ -862,181 +913,187 @@ namespace ojph
         if (sot.read(infile, resilient))
         {
           ui64 tile_start_location = (ui64)infile->tell();
+          bool skip_tile = false;
 
-          if (sot.get_tile_index() > (int)num_tiles.area())
+          if (sot.get_tile_index() >= (int)num_tiles.area())
           {
-            if (resilient)
+            if (resilient) {
               OJPH_INFO(0x00030061, "wrong tile index")
+              skip_tile = true; // skip the faulty tile
+            }
             else
               OJPH_ERROR(0x00030061, "wrong tile index")
           }
 
-          if (sot.get_tile_part_index())
-          { // tile part
-            if (sot.get_num_tile_parts() &&
+          if (!skip_tile)
+          {
+            if (sot.get_tile_part_index())
+            { //tile part
+              if (sot.get_num_tile_parts() &&
                 sot.get_tile_part_index() >= sot.get_num_tile_parts())
-            {
-              if (resilient)
-                OJPH_INFO(0x00030062,
-                          "error in tile part number, should be smaller than total"
-                          " number of tile parts")
-              else
-                OJPH_ERROR(0x00030062,
-                           "error in tile part number, should be smaller than total"
-                           " number of tile parts")
-            }
-
-            bool sod_found = false;
-            ui16 other_tile_part_markers[7] = {SOT, POC, PPT, PLT, COM,
-                                               NLT, SOD};
-            while (true)
-            {
-              int marker_idx = 0;
-              int result = 0;
-              marker_idx = find_marker(infile, other_tile_part_markers + 1, 6);
-              if (marker_idx == 0)
-                result = skip_marker(infile, "POC",
-                                     "POC marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 1)
-                result = skip_marker(infile, "PPT",
-                                     "PPT marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 2)
-                // Skipping PLT marker segment;this should not cause any issues
-                result = skip_marker(infile, "PLT", NULL,
-                                     OJPH_MSG_LEVEL::NO_MSG, resilient);
-              else if (marker_idx == 3)
-                result = skip_marker(infile, "COM", NULL,
-                                     OJPH_MSG_LEVEL::NO_MSG, resilient);
-              else if (marker_idx == 4)
-                result = skip_marker(infile, "NLT",
-                                     "NLT marker in tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 5)
               {
-                sod_found = true;
-                break;
+                if (resilient)
+                  OJPH_INFO(0x00030062,
+                    "error in tile part number, should be smaller than total"
+                    " number of tile parts")
+                else
+                  OJPH_ERROR(0x00030062,
+                    "error in tile part number, should be smaller than total"
+                    " number of tile parts")
               }
 
-              if (marker_idx == -1) // marker not found
+              bool sod_found = false;
+              ui16 other_tile_part_markers[7] = { SOT, POC, PPT, PLT, COM,
+                NLT, SOD };
+              while (true)
               {
-                if (resilient)
-                  OJPH_INFO(0x00030063,
-                            "File terminated early before start of data is found"
-                            " for tile indexed %d and tile part %d",
-                            sot.get_tile_index(), sot.get_tile_part_index())
-                else
-                  OJPH_ERROR(0x00030063,
-                             "File terminated early before start of data is found"
-                             " for tile indexed %d and tile part %d",
-                             sot.get_tile_index(), sot.get_tile_part_index())
-                break;
-              }
-              if (result == -1) // file terminated during marker seg. skipping
-              {
-                if (resilient)
-                  OJPH_INFO(0x00030064,
-                            "File terminated during marker segment skipping")
-                else
-                  OJPH_ERROR(0x00030064,
-                             "File terminated during marker segment skipping")
-                break;
-              }
-            }
-            if (sod_found)
-              tiles[sot.get_tile_index()].parse_tile_header(sot, infile,
-                                                            tile_start_location);
-          }
-          else
-          { // first tile part
-            bool sod_found = false;
-            ui16 first_tile_part_markers[12] = {SOT, COD, COC, QCD, QCC, RGN,
-                                                POC, PPT, PLT, COM, NLT, SOD};
-            while (true)
-            {
-              int marker_idx = 0;
-              int result = 0;
-              marker_idx = find_marker(infile, first_tile_part_markers + 1, 11);
-              if (marker_idx == 0)
-                result = skip_marker(infile, "COD",
-                                     "COD marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 1)
-                result = skip_marker(infile, "COC",
-                                     "COC marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 2)
-                result = skip_marker(infile, "QCD",
-                                     "QCD marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 3)
-                result = skip_marker(infile, "QCC",
-                                     "QCC marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 4)
-                result = skip_marker(infile, "RGN",
-                                     "RGN marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 5)
-                result = skip_marker(infile, "POC",
-                                     "POC marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 6)
-                result = skip_marker(infile, "PPT",
-                                     "PPT marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 7)
-                // Skipping PLT marker segment;this should not cause any issues
-                result = skip_marker(infile, "PLT", NULL,
-                                     OJPH_MSG_LEVEL::NO_MSG, resilient);
-              else if (marker_idx == 8)
-                result = skip_marker(infile, "COM", NULL,
-                                     OJPH_MSG_LEVEL::NO_MSG, resilient);
-              else if (marker_idx == 9)
-                result = skip_marker(infile, "NLT",
-                                     "PPT marker segment in a tile is not supported yet",
-                                     OJPH_MSG_LEVEL::WARN, resilient);
-              else if (marker_idx == 10)
-              {
-                sod_found = true;
-                break;
-              }
+                int marker_idx = 0;
+                int result = 0;
+                marker_idx = find_marker(infile, other_tile_part_markers+1, 6);
+                if (marker_idx == 0)
+                  result = skip_marker(infile, "POC",
+                    "POC marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 1)
+                  result = skip_marker(infile, "PPT",
+                    "PPT marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 2)
+                  //Skipping PLT marker segment;this should not cause any issues
+                  result = skip_marker(infile, "PLT", NULL,
+                    OJPH_MSG_NO_MSG, resilient);
+                else if (marker_idx == 3)
+                  result = skip_marker(infile, "COM", NULL,
+                    OJPH_MSG_NO_MSG, resilient);
+                else if (marker_idx == 4)
+                  result = skip_marker(infile, "NLT",
+                    "NLT marker in tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 5)
+                {
+                  sod_found = true;
+                  break;
+                }
 
-              if (marker_idx == -1) // marker not found
-              {
-                if (resilient)
-                  OJPH_INFO(0x00030065,
-                            "File terminated early before start of data is found"
-                            " for tile indexed %d and tile part %d",
-                            sot.get_tile_index(), sot.get_tile_part_index())
-                else
-                  OJPH_ERROR(0x00030065,
-                             "File terminated early before start of data is found"
-                             " for tile indexed %d and tile part %d",
-                             sot.get_tile_index(), sot.get_tile_part_index())
-                break;
+                if (marker_idx == -1) //marker not found
+                {
+                  if (resilient)
+                    OJPH_INFO(0x00030063,
+                      "File terminated early before start of data is found"
+                      " for tile indexed %d and tile part %d",
+                      sot.get_tile_index(), sot.get_tile_part_index())
+                  else
+                    OJPH_ERROR(0x00030063,
+                      "File terminated early before start of data is found"
+                      " for tile indexed %d and tile part %d",
+                      sot.get_tile_index(), sot.get_tile_part_index())
+                  break;
+                }
+                if (result == -1) //file terminated during marker seg. skipping
+                {
+                  if (resilient)
+                    OJPH_INFO(0x00030064,
+                      "File terminated during marker segment skipping")
+                  else
+                    OJPH_ERROR(0x00030064,
+                      "File terminated during marker segment skipping")
+                  break;
+                }
               }
-              if (result == -1) // file terminated during marker seg. skipping
-              {
-                if (resilient)
-                  OJPH_INFO(0x00030066,
-                            "File terminated during marker segment skipping")
-                else
-                  OJPH_ERROR(0x00030066,
-                             "File terminated during marker segment skipping")
-                break;
-              }
+              if (sod_found)
+                tiles[sot.get_tile_index()].parse_tile_header(sot, infile,
+                  tile_start_location);
             }
-            if (sod_found)
-              tiles[sot.get_tile_index()].parse_tile_header(sot, infile,
-                                                            tile_start_location);
+            else
+            { //first tile part
+              bool sod_found = false;
+              ui16 first_tile_part_markers[12] = { SOT, COD, COC, QCD, QCC, RGN,
+                POC, PPT, PLT, COM, NLT, SOD };
+              while (true)
+              {
+                int marker_idx = 0;
+                int result = 0;
+                marker_idx = find_marker(infile, first_tile_part_markers+1, 11);
+                if (marker_idx == 0)
+                  result = skip_marker(infile, "COD",
+                    "COD marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 1)
+                  result = skip_marker(infile, "COC",
+                    "COC marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 2)
+                  result = skip_marker(infile, "QCD",
+                    "QCD marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 3)
+                  result = skip_marker(infile, "QCC",
+                    "QCC marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 4)
+                  result = skip_marker(infile, "RGN",
+                    "RGN marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 5)
+                  result = skip_marker(infile, "POC",
+                    "POC marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 6)
+                  result = skip_marker(infile, "PPT",
+                    "PPT marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 7)
+                  //Skipping PLT marker segment;this should not cause any issues
+                  result = skip_marker(infile, "PLT", NULL,
+                    OJPH_MSG_NO_MSG, resilient);
+                else if (marker_idx == 8)
+                  result = skip_marker(infile, "COM", NULL,
+                    OJPH_MSG_NO_MSG, resilient);
+                else if (marker_idx == 9)
+                  result = skip_marker(infile, "NLT",
+                    "PPT marker segment in a tile is not supported yet",
+                    OJPH_MSG_WARN, resilient);
+                else if (marker_idx == 10)
+                {
+                  sod_found = true;
+                  break;
+                }
+
+                if (marker_idx == -1) //marker not found
+                {
+                  if (resilient)
+                    OJPH_INFO(0x00030065,
+                      "File terminated early before start of data is found"
+                      " for tile indexed %d and tile part %d",
+                      sot.get_tile_index(), sot.get_tile_part_index())
+                  else
+                    OJPH_ERROR(0x00030065,
+                      "File terminated early before start of data is found"
+                      " for tile indexed %d and tile part %d",
+                      sot.get_tile_index(), sot.get_tile_part_index())
+                  break;
+                }
+                if (result == -1) //file terminated during marker seg. skipping
+                {
+                  if (resilient)
+                    OJPH_INFO(0x00030066,
+                      "File terminated during marker segment skipping")
+                  else
+                    OJPH_ERROR(0x00030066,
+                      "File terminated during marker segment skipping")
+                  break;
+                }
+              }
+              if (sod_found)
+                tiles[sot.get_tile_index()].parse_tile_header(sot, infile,
+                  tile_start_location);
+            }
           }
         }
 
         // check the next marker; either SOT or EOC,
         // if something is broken, just an end of file
-        ui16 next_markers[2] = {SOT, EOC};
+        ui16 next_markers[2] = { SOT, EOC };
         int marker_idx = find_marker(infile, next_markers, 2);
         if (marker_idx == -1)
         {
@@ -1087,14 +1144,14 @@ namespace ojph
       for (si32 i = 0; i < repeat; ++i)
         tiles[i].prepare_for_flush();
       if (need_tlm)
-      { // write tlm
+      { //write tlm
         for (si32 i = 0; i < repeat; ++i)
           tiles[i].fill_tlm(&tlm);
         tlm.write(outfile);
       }
       for (si32 i = 0; i < repeat; ++i)
         tiles[i].flush(outfile);
-      ui16 t = swap_byte(JP2K_MARKER::EOC);
+      ui16 t = swap_bytes_if_le(JP2K_MARKER::EOC);
       if (!outfile->write(&t, 2))
         OJPH_ERROR(0x00030071, "Error writing to file");
     }
@@ -1109,7 +1166,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    line_buf *codestream::exchange(line_buf *line, ui32 &next_component)
+    line_buf* codestream::exchange(line_buf *line, ui32 &next_component)
     {
       if (line)
       {
@@ -1128,7 +1185,7 @@ namespace ojph
             cur_tile_row = 0;
         }
 
-        if (planar) // process one component at a time
+        if (planar) //process one component at a time
         {
           if (++cur_line >= comp_size[cur_comp].h)
           {
@@ -1141,7 +1198,7 @@ namespace ojph
             }
           }
         }
-        else // process all component for a line
+        else //process all component for a line
         {
           if (++cur_comp >= num_comps)
           {
@@ -1160,7 +1217,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    line_buf *codestream::pull(ui32 &comp_num)
+    line_buf* codestream::pull(ui32 &comp_num)
     {
       bool success = false;
       while (!success)
@@ -1178,7 +1235,7 @@ namespace ojph
       }
       comp_num = cur_comp;
 
-      if (planar) // process one component at a time
+      if (planar) //process one component at a time
       {
         if (++cur_line >= recon_comp_size[cur_comp].h)
         {
@@ -1191,7 +1248,7 @@ namespace ojph
           }
         }
       }
-      else // process all component for a line
+      else //process all component for a line
       {
         if (++cur_comp >= num_comps)
         {
@@ -1206,5 +1263,6 @@ namespace ojph
 
       return lines + comp_num;
     }
+
   }
 }

--- a/Native/Common/OpenJPH/codestream/ojph_codestream_local.h
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream_local.h
@@ -35,33 +35,29 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_CODESTREAM_LOCAL_H
 #define OJPH_CODESTREAM_LOCAL_H
 
 #include "ojph_defs.h"
+#include "ojph_arch.h"
 #include "ojph_params_local.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class line_buf;
   class mem_fixed_allocator;
   class mem_elastic_allocator;
   class codestream;
 
-  namespace local
-  {
+  namespace local {
 
     /////////////////////////////////////////////////////////////////////////
-    static inline ui16 swap_byte(ui16 t)
-    {
-      return (ui16)((t << 8) | (t >> 8));
-    }
 
     //////////////////////////////////////////////////////////////////////////
-    // defined elsewhere
+    //defined elsewhere
     class tile;
 
     //////////////////////////////////////////////////////////////////////////
@@ -73,62 +69,45 @@ namespace ojph
       codestream();
       ~codestream();
 
+      void restart();
+
       void pre_alloc();
       void finalize_alloc();
 
-      ojph::param_siz access_siz() // return externally wrapped siz
-      {
-        return ojph::param_siz(&siz);
-      }
-      const param_siz *get_siz() // return internal siz
-      {
-        return &siz;
-      }
-      ojph::param_cod access_cod() // return externally wrapped cod
-      {
-        return ojph::param_cod(&cod);
-      }
-      const param_cod *get_cod() // return internal cod
-      {
-        return &cod;
-      }
-      const param_cod *get_coc(ui32 comp_num) // return internal cod
-      {
-        return cod.get_coc(comp_num);
-      }
-      const param_qcd *access_qcd()
-      {
-        return &qcd;
-      }
-      const param_dfs *access_dfs()
-      {
-        if (dfs.exists())
-          return &dfs;
-        else
-          return NULL;
-      }
-      const param_nlt *get_nlt()
-      {
-        return &nlt;
-      }
-      mem_fixed_allocator *get_allocator() { return allocator; }
-      mem_elastic_allocator *get_elastic_alloc() { return elastic_alloc; }
-      outfile_base *get_file() { return outfile; }
+      ojph::param_siz access_siz()            // returns externally wrapped siz
+      { return ojph::param_siz(&siz); }
+      const param_siz* get_siz()              // returns internal siz
+      { return &siz; }
+      ojph::param_cod access_cod()            // returns externally wrapped cod
+      { return ojph::param_cod(&cod); }
+      const param_cod* get_cod()              // returns internal cod
+      { return &cod; }
+      const param_cod* get_coc(ui32 comp_num) // returns internal cod
+      { return cod.get_coc(comp_num); }
+      const param_qcd* access_qcd()
+      { return &qcd; }
+      const param_dfs* access_dfs()
+      { if (dfs.exists()) return &dfs; else return NULL; }
+      const param_nlt* get_nlt()
+      { return &nlt; }
+      mem_fixed_allocator* get_allocator() { return allocator; }
+      mem_elastic_allocator* get_elastic_alloc() { return elastic_alloc; }
+      outfile_base* get_file() { return outfile; }
 
-      line_buf *exchange(line_buf *line, ui32 &next_component);
-      void write_headers(outfile_base *file, const comment_exchange *comments,
+      line_buf* exchange(line_buf* line, ui32& next_component);
+      void write_headers(outfile_base *file, const comment_exchange* comments,
                          ui32 num_comments);
       void enable_resilience();
       bool is_resilient() { return resilient; }
       void read_headers(infile_base *file);
       void restrict_input_resolution(ui32 skipped_res_for_data,
-                                     ui32 skipped_res_for_recon);
+        ui32 skipped_res_for_recon);
       void read();
       void set_planar(int planar);
       void set_profile(const char *s);
       void set_tilepart_divisions(ui32 value);
       void request_tlm_marker(bool needed);
-      line_buf *pull(ui32 &comp_num);
+      line_buf* pull(ui32 &comp_num);
       void flush();
       void close();
 
@@ -140,19 +119,15 @@ namespace ojph
       void check_imf_validity();
       void check_broadcast_validity();
 
-      ui8 *get_precinct_scratch() { return precinct_scratch; }
+      ui8* get_precinct_scratch() { return precinct_scratch; }
       ui32 get_skipped_res_for_recon()
-      {
-        return skipped_res_for_recon;
-      }
+      { return skipped_res_for_recon; }
       ui32 get_skipped_res_for_read()
-      {
-        return skipped_res_for_read;
-      }
+      { return skipped_res_for_read; }
 
     private:
       ui32 precinct_scratch_needed_bytes;
-      ui8 *precinct_scratch;
+      ui8* precinct_scratch;
 
     private:
       ui32 cur_line;
@@ -164,29 +139,28 @@ namespace ojph
     private:
       size num_tiles;
       tile *tiles;
-      line_buf *lines;
+      line_buf* lines;
       ui32 num_comps;
-      size *comp_size;       // stores full resolution no. of lines and width
-      size *recon_comp_size; // stores number of lines and width of each comp
+      size *comp_size;       //stores full resolution no. of lines and width
+      size *recon_comp_size; //stores number of lines and width of each comp
       bool employ_color_transform;
       int planar;
       int profile;
-      ui32 tilepart_div; // tilepart division value
-      bool need_tlm;     // true if tlm markers are needed
+      ui32 tilepart_div;     // tilepart division value
+      bool need_tlm;         // true if tlm markers are needed
 
     private:
-      param_siz siz; // image and tile size
-      param_cod cod; // coding style default
-      param_cap cap; // extended capabilities
-      param_qcd qcd; // quantization default
-      param_tlm tlm; // tile-part lengths
-      param_nlt nlt; // non-linearity point transformation
+      param_siz siz;         // image and tile size
+      param_cod cod;         // coding style default
+      param_cap cap;         // extended capabilities
+      param_qcd qcd;         // quantization default
+      param_tlm tlm;         // tile-part lengths
+      param_nlt nlt;         // non-linearity point transformation
 
-    private:                  // these are from Part 2 of the standard
-      param_dfs dfs;          // downsmapling factor styles
-      param_atk *atk;         // a pointer to atk
-      param_atk atk_store[3]; // 0 and 1 are for DWT from Part 1, 2 onward are
-                              // for arbitrary transformation kernels
+    private:  // these are from Part 2 of the standard
+      param_dfs dfs;         // downsmapling factor styles
+      param_atk atk;         // wavelet structure and coefficients
+
     private:
       mem_fixed_allocator *allocator;
       mem_elastic_allocator *elastic_alloc;

--- a/Native/Common/OpenJPH/codestream/ojph_codestream_sse.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream_sse.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -34,22 +34,20 @@
 // Author: Aous Naman
 // Date: 15 May 2022
 //***************************************************************************/
-#include "ojph_arch.h"
 
+#include "ojph_arch.h"
 #if defined(OJPH_ARCH_I386) || defined(OJPH_ARCH_X86_64)
 
 #include <immintrin.h>
 #include "ojph_defs.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    void sse_mem_clear(void *addr, size_t count)
+    void sse_mem_clear(void* addr, size_t count)
     {
-      float *p = (float *)addr;
+      float* p = (float*)addr;
       __m128 zero = _mm_setzero_ps();
       for (size_t i = 0; i < count; i += 16, p += 4)
         _mm_storeu_ps(p, zero);

--- a/Native/Common/OpenJPH/codestream/ojph_codestream_sse2.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream_sse2.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -42,20 +42,18 @@
 #include <immintrin.h>
 #include "ojph_defs.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 sse2_find_max_val32(ui32 *address)
+    ui32 sse2_find_max_val32(ui32* address)
     {
-      __m128i x1, x0 = _mm_loadu_si128((__m128i *)address);
-      x1 = _mm_shuffle_epi32(x0, 0xEE); // x1 = x0[2,3,2,3]
+      __m128i x1, x0 = _mm_loadu_si128((__m128i*)address);
+      x1 = _mm_shuffle_epi32(x0, 0xEE);   // x1 = x0[2,3,2,3]
       x0 = _mm_or_si128(x0, x1);
-      x1 = _mm_shuffle_epi32(x0, 0x55); // x1 = x0[1,1,1,1]
+      x1 = _mm_shuffle_epi32(x0, 0x55);   // x1 = x0[1,1,1,1]
       x0 = _mm_or_si128(x0, x1);
-      _mm_storeu_si128((__m128i *)address, x0);
+      _mm_storeu_si128((__m128i*)address, x0);
       return *address;
       // A single movd t, xmm0 can do the trick, but it is not available
       // in SSE2 intrinsics. extract_epi32 is available in sse4.1
@@ -65,45 +63,45 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    ui64 sse2_find_max_val64(ui64 *address)
+    ui64 sse2_find_max_val64(ui64* address)
     {
-      __m128i x1, x0 = _mm_loadu_si128((__m128i *)address);
-      x1 = _mm_shuffle_epi32(x0, 0xEE); // x1 = x0[2,3,2,3]
+      __m128i x1, x0 = _mm_loadu_si128((__m128i*)address);
+      x1 = _mm_shuffle_epi32(x0, 0xEE);   // x1 = x0[2,3,2,3]
       x0 = _mm_or_si128(x0, x1);
-      _mm_storeu_si128((__m128i *)address, x0);
+      _mm_storeu_si128((__m128i*)address, x0);
       return *address;
       // A single movd t, xmm0 can do the trick, but it is not available
       // in SSE2 intrinsics. extract_epi32 is available in sse4.1
       // ui32 t = (ui32)_mm_extract_epi16(x0, 0);
       // t |= (ui32)_mm_extract_epi16(x0, 1) << 16;
       // return t;
-    }
+    }    
 
     //////////////////////////////////////////////////////////////////////////
-    void sse2_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val)
+    void sse2_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max, 
+                             float delta_inv, ui32 count, ui32* max_val)
     {
       ojph_unused(delta_inv);
 
-      // convert to sign and magnitude and keep max_val
+      // convert to sign and magnitude and keep max_val      
       ui32 shift = 31 - K_max;
       __m128i m0 = _mm_set1_epi32(INT_MIN);
       __m128i zero = _mm_setzero_si128();
       __m128i one = _mm_set1_epi32(1);
-      __m128i tmax = _mm_loadu_si128((__m128i *)max_val);
-      __m128i *p = (__m128i *)sp;
-      for (; count >= 4; count -= 4, p += 1, dp += 4)
+      __m128i tmax = _mm_loadu_si128((__m128i*)max_val);
+      __m128i *p = (__m128i*)sp;
+      for ( ; count >= 4; count -= 4, p += 1, dp += 4)
       {
         __m128i v = _mm_loadu_si128(p);
         __m128i sign = _mm_cmplt_epi32(v, zero);
         __m128i val = _mm_xor_si128(v, sign); // negate 1's complement
         __m128i ones = _mm_and_si128(sign, one);
-        val = _mm_add_epi32(val, ones); // 2's complement
+        val = _mm_add_epi32(val, ones);        // 2's complement
         sign = _mm_and_si128(sign, m0);
         val = _mm_slli_epi32(val, (int)shift);
         tmax = _mm_or_si128(tmax, val);
         val = _mm_or_si128(val, sign);
-        _mm_storeu_si128((__m128i *)dp, val);
+        _mm_storeu_si128((__m128i*)dp, val);
       }
       if (count)
       {
@@ -111,7 +109,7 @@ namespace ojph
         __m128i sign = _mm_cmplt_epi32(v, zero);
         __m128i val = _mm_xor_si128(v, sign); // negate 1's complement
         __m128i ones = _mm_and_si128(sign, one);
-        val = _mm_add_epi32(val, ones); // 2's complement
+        val = _mm_add_epi32(val, ones);        // 2's complement
         sign = _mm_and_si128(sign, m0);
         val = _mm_slli_epi32(val, (int)shift);
 
@@ -122,25 +120,25 @@ namespace ojph
         tmax = _mm_or_si128(tmax, c);
 
         val = _mm_or_si128(val, sign);
-        _mm_storeu_si128((__m128i *)dp, val);
+        _mm_storeu_si128((__m128i*)dp, val);
       }
-      _mm_storeu_si128((__m128i *)max_val, tmax);
+      _mm_storeu_si128((__m128i*)max_val, tmax);
     }
-
+                           
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val)
+                             float delta_inv, ui32 count, ui32* max_val)
     {
       ojph_unused(K_max);
 
-      // quantize and convert to sign and magnitude and keep max_val
+      //quantize and convert to sign and magnitude and keep max_val
 
       __m128 d = _mm_set1_ps(delta_inv);
       __m128i zero = _mm_setzero_si128();
       __m128i one = _mm_set1_epi32(1);
-      __m128i tmax = _mm_loadu_si128((__m128i *)max_val);
-      float *p = (float *)sp;
-      for (; count >= 4; count -= 4, p += 4, dp += 4)
+      __m128i tmax = _mm_loadu_si128((__m128i*)max_val);
+      float *p = (float*)sp;
+      for ( ; count >= 4; count -= 4, p += 4, dp += 4)
       {
         __m128 vf = _mm_loadu_ps(p);
         vf = _mm_mul_ps(vf, d);                    // multiply
@@ -148,11 +146,11 @@ namespace ojph
         __m128i sign = _mm_cmplt_epi32(val, zero); // get sign
         val = _mm_xor_si128(val, sign);            // negate 1's complement
         __m128i ones = _mm_and_si128(sign, one);
-        val = _mm_add_epi32(val, ones); // 2's complement
+        val = _mm_add_epi32(val, ones);            // 2's complement
         tmax = _mm_or_si128(tmax, val);
         sign = _mm_slli_epi32(sign, 31);
         val = _mm_or_si128(val, sign);
-        _mm_storeu_si128((__m128i *)dp, val);
+        _mm_storeu_si128((__m128i*)dp, val);
       }
       if (count)
       {
@@ -162,7 +160,7 @@ namespace ojph
         __m128i sign = _mm_cmplt_epi32(val, zero); // get sign
         val = _mm_xor_si128(val, sign);            // negate 1's complement
         __m128i ones = _mm_and_si128(sign, one);
-        val = _mm_add_epi32(val, ones); // 2's complement
+        val = _mm_add_epi32(val, ones);            // 2's complement
 
         __m128i c = _mm_set1_epi32((si32)count);
         __m128i idx = _mm_set_epi32(3, 2, 1, 0);
@@ -172,13 +170,13 @@ namespace ojph
 
         sign = _mm_slli_epi32(sign, 31);
         val = _mm_or_si128(val, sign);
-        _mm_storeu_si128((__m128i *)dp, val);
+        _mm_storeu_si128((__m128i*)dp, val);
       }
-      _mm_storeu_si128((__m128i *)max_val, tmax);
+      _mm_storeu_si128((__m128i*)max_val, tmax);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void sse2_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+    void sse2_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(delta);
@@ -186,33 +184,33 @@ namespace ojph
       __m128i m1 = _mm_set1_epi32(INT_MAX);
       __m128i zero = _mm_setzero_si128();
       __m128i one = _mm_set1_epi32(1);
-      si32 *p = (si32 *)dp;
+      si32 *p = (si32*)dp;
       for (ui32 i = 0; i < count; i += 4, sp += 4, p += 4)
       {
-        __m128i v = _mm_load_si128((__m128i *)sp);
+        __m128i v = _mm_load_si128((__m128i*)sp);
         __m128i val = _mm_and_si128(v, m1);
         val = _mm_srli_epi32(val, (int)shift);
         __m128i sign = _mm_cmplt_epi32(v, zero);
         val = _mm_xor_si128(val, sign); // negate 1's complement
         __m128i ones = _mm_and_si128(sign, one);
         val = _mm_add_epi32(val, ones); // 2's complement
-        _mm_storeu_si128((__m128i *)p, val);
+        _mm_storeu_si128((__m128i*)p, val);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void sse2_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+    void sse2_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(K_max);
       __m128i m1 = _mm_set1_epi32(INT_MAX);
       __m128 d = _mm_set1_ps(delta);
-      float *p = (float *)dp;
+      float *p = (float*)dp;
       for (ui32 i = 0; i < count; i += 4, sp += 4, p += 4)
       {
-        __m128i v = _mm_load_si128((__m128i *)sp);
+        __m128i v = _mm_load_si128((__m128i*)sp);
         __m128i vali = _mm_and_si128(v, m1);
-        __m128 valf = _mm_cvtepi32_ps(vali);
+        __m128  valf = _mm_cvtepi32_ps(vali);
         valf = _mm_mul_ps(valf, d);
         __m128i sign = _mm_andnot_si128(m1, v);
         valf = _mm_or_ps(valf, _mm_castsi128_ps(sign));
@@ -221,40 +219,40 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void sse2_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui64 *max_val)
+    void sse2_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max, 
+                             float delta_inv, ui32 count, ui64* max_val)
     {
       ojph_unused(delta_inv);
 
-      // convert to sign and magnitude and keep max_val
+      // convert to sign and magnitude and keep max_val      
       ui32 shift = 63 - K_max;
       __m128i m0 = _mm_set1_epi64x(LLONG_MIN);
       __m128i zero = _mm_setzero_si128();
       __m128i one = _mm_set1_epi64x(1);
-      __m128i tmax = _mm_loadu_si128((__m128i *)max_val);
-      __m128i *p = (__m128i *)sp;
-      for (; count >= 2; count -= 2, p += 1, dp += 2)
+      __m128i tmax = _mm_loadu_si128((__m128i*)max_val);
+      __m128i *p = (__m128i*)sp;
+      for ( ; count >= 2; count -= 2, p += 1, dp += 2)
       {
         __m128i v = _mm_loadu_si128(p);
         __m128i sign = _mm_cmplt_epi32(v, zero);
-        sign = _mm_shuffle_epi32(sign, 0xF5); // sign = sign[1,1,3,3];
-        __m128i val = _mm_xor_si128(v, sign); // negate 1's complement
+        sign = _mm_shuffle_epi32(sign, 0xF5);  // sign = sign[1,1,3,3];
+        __m128i val = _mm_xor_si128(v, sign);  // negate 1's complement
         __m128i ones = _mm_and_si128(sign, one);
-        val = _mm_add_epi64(val, ones); // 2's complement
+        val = _mm_add_epi64(val, ones);        // 2's complement
         sign = _mm_and_si128(sign, m0);
         val = _mm_slli_epi64(val, (int)shift);
         tmax = _mm_or_si128(tmax, val);
         val = _mm_or_si128(val, sign);
-        _mm_storeu_si128((__m128i *)dp, val);
+        _mm_storeu_si128((__m128i*)dp, val);
       }
       if (count)
       {
         __m128i v = _mm_loadu_si128(p);
         __m128i sign = _mm_cmplt_epi32(v, zero);
-        sign = _mm_shuffle_epi32(sign, 0xF5); // sign = sign[1,1,3,3];
-        __m128i val = _mm_xor_si128(v, sign); // negate 1's complement
+        sign = _mm_shuffle_epi32(sign, 0xF5);  // sign = sign[1,1,3,3];
+        __m128i val = _mm_xor_si128(v, sign);  // negate 1's complement
         __m128i ones = _mm_and_si128(sign, one);
-        val = _mm_add_epi64(val, ones); // 2's complement
+        val = _mm_add_epi64(val, ones);        // 2's complement
         sign = _mm_and_si128(sign, m0);
         val = _mm_slli_epi64(val, (int)shift);
 
@@ -263,13 +261,13 @@ namespace ojph
         tmax = _mm_or_si128(tmax, c);
 
         val = _mm_or_si128(val, sign);
-        _mm_storeu_si128((__m128i *)dp, val);
+        _mm_storeu_si128((__m128i*)dp, val);
       }
-      _mm_storeu_si128((__m128i *)max_val, tmax);
+      _mm_storeu_si128((__m128i*)max_val, tmax);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void sse2_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+    void sse2_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(delta);
@@ -277,18 +275,18 @@ namespace ojph
       __m128i m1 = _mm_set1_epi64x(LLONG_MAX);
       __m128i zero = _mm_setzero_si128();
       __m128i one = _mm_set1_epi64x(1);
-      si64 *p = (si64 *)dp;
+      si64 *p = (si64*)dp;
       for (ui32 i = 0; i < count; i += 2, sp += 2, p += 2)
       {
-        __m128i v = _mm_load_si128((__m128i *)sp);
+        __m128i v = _mm_load_si128((__m128i*)sp);
         __m128i val = _mm_and_si128(v, m1);
         val = _mm_srli_epi64(val, (int)shift);
         __m128i sign = _mm_cmplt_epi32(v, zero);
-        sign = _mm_shuffle_epi32(sign, 0xF5); // sign = sign[1,1,3,3];
-        val = _mm_xor_si128(val, sign);       // negate 1's complement
+        sign = _mm_shuffle_epi32(sign, 0xF5);      // sign = sign[1,1,3,3];
+        val = _mm_xor_si128(val, sign);            // negate 1's complement
         __m128i ones = _mm_and_si128(sign, one);
-        val = _mm_add_epi64(val, ones); // 2's complement
-        _mm_storeu_si128((__m128i *)p, val);
+        val = _mm_add_epi64(val, ones);            // 2's complement
+        _mm_storeu_si128((__m128i*)p, val);
       }
     }
   }

--- a/Native/Common/OpenJPH/codestream/ojph_codestream_wasm.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_codestream_wasm.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -36,67 +36,65 @@
 //***************************************************************************/
 
 #include <climits>
-#include <cstddef>
+#include <cstddef> 
 #include <wasm_simd128.h>
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_mem_clear(void *addr, size_t count)
+    void wasm_mem_clear(void* addr, size_t count)
     {
-      float *p = (float *)addr;
+      float* p = (float*)addr;
       v128_t zero = wasm_i32x4_splat(0);
       for (size_t i = 0; i < count; i += 16, p += 4)
         wasm_v128_store(p, zero);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 wasm_find_max_val32(ui32 *address)
+    ui32 wasm_find_max_val32(ui32* address)
     {
       v128_t x1, x0 = wasm_v128_load(address);
-      x1 = wasm_i32x4_shuffle(x0, x0, 2, 3, 2, 3); // x1 = x0[2,3,2,3]
+      x1 = wasm_i32x4_shuffle(x0, x0, 2, 3, 2, 3);   // x1 = x0[2,3,2,3]
       x0 = wasm_v128_or(x0, x1);
-      x1 = wasm_i32x4_shuffle(x0, x0, 1, 1, 1, 1); // x1 = x0[1,1,1,1]
+      x1 = wasm_i32x4_shuffle(x0, x0, 1, 1, 1, 1);   // x1 = x0[1,1,1,1]
       x0 = wasm_v128_or(x0, x1);
       ui32 t = (ui32)wasm_i32x4_extract_lane(x0, 0);
       return t;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    ui64 wasm_find_max_val64(ui64 *address)
+    ui64 wasm_find_max_val64(ui64* address)
     {
       v128_t x1, x0 = wasm_v128_load(address);
-      x1 = wasm_i64x2_shuffle(x0, x0, 1, 1); // x1 = x0[2,3,2,3]
+      x1 = wasm_i64x2_shuffle(x0, x0, 1, 1);   // x1 = x0[2,3,2,3]
       x0 = wasm_v128_or(x0, x1);
       ui64 t = (ui64)wasm_i64x2_extract_lane(x0, 0);
       return t;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val)
+    void wasm_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max, 
+                             float delta_inv, ui32 count, ui32* max_val)
     {
       ojph_unused(delta_inv);
 
-      // convert to sign and magnitude and keep max_val
+      // convert to sign and magnitude and keep max_val      
       ui32 shift = 31 - K_max;
       v128_t m0 = wasm_i32x4_splat(INT_MIN);
       v128_t zero = wasm_i32x4_splat(0);
       v128_t one = wasm_i32x4_splat(1);
       v128_t tmax = wasm_v128_load(max_val);
-      si32 *p = (si32 *)sp;
-      for (; count >= 4; count -= 4, p += 4, dp += 4)
+      si32 *p = (si32*)sp;
+      for ( ; count >= 4; count -= 4, p += 4, dp += 4)
       {
         v128_t v = wasm_v128_load(p);
         v128_t sign = wasm_i32x4_lt(v, zero);
         v128_t val = wasm_v128_xor(v, sign); // negate 1's complement
         v128_t ones = wasm_v128_and(sign, one);
-        val = wasm_i32x4_add(val, ones); // 2's complement
+        val = wasm_i32x4_add(val, ones);     // 2's complement
         sign = wasm_v128_and(sign, m0);
         val = wasm_i32x4_shl(val, shift);
         tmax = wasm_v128_or(tmax, val);
@@ -109,7 +107,7 @@ namespace ojph
         v128_t sign = wasm_i32x4_lt(v, zero);
         v128_t val = wasm_v128_xor(v, sign); // negate 1's complement
         v128_t ones = wasm_v128_and(sign, one);
-        val = wasm_i32x4_add(val, ones); // 2's complement
+        val = wasm_i32x4_add(val, ones);     // 2's complement
         sign = wasm_v128_and(sign, m0);
         val = wasm_i32x4_shl(val, shift);
 
@@ -124,29 +122,29 @@ namespace ojph
       }
       wasm_v128_store(max_val, tmax);
     }
-
+                           
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui32 *max_val)
+                             float delta_inv, ui32 count, ui32* max_val)
     {
       ojph_unused(K_max);
 
-      // quantize and convert to sign and magnitude and keep max_val
+      //quantize and convert to sign and magnitude and keep max_val
 
       v128_t d = wasm_f32x4_splat(delta_inv);
       v128_t zero = wasm_i32x4_splat(0);
       v128_t one = wasm_i32x4_splat(1);
       v128_t tmax = wasm_v128_load(max_val);
-      float *p = (float *)sp;
-      for (; count >= 4; count -= 4, p += 4, dp += 4)
+      float *p = (float*)sp;
+      for ( ; count >= 4; count -= 4, p += 4, dp += 4)
       {
         v128_t vf = wasm_v128_load(p);
-        vf = wasm_f32x4_mul(vf, d);                  // multiply
-        v128_t val = wasm_i32x4_trunc_sat_f32x4(vf); // convert to signed int
-        v128_t sign = wasm_i32x4_lt(val, zero);      // get sign
-        val = wasm_v128_xor(val, sign);              // negate 1's complement
+        vf = wasm_f32x4_mul(vf, d);                   // multiply
+        v128_t val = wasm_i32x4_trunc_sat_f32x4(vf);  // convert to signed int
+        v128_t sign = wasm_i32x4_lt(val, zero);       // get sign
+        val = wasm_v128_xor(val, sign);               // negate 1's complement
         v128_t ones = wasm_v128_and(sign, one);
-        val = wasm_i32x4_add(val, ones); // 2's complement
+        val = wasm_i32x4_add(val, ones);              // 2's complement
         tmax = wasm_v128_or(tmax, val);
         sign = wasm_i32x4_shl(sign, 31);
         val = wasm_v128_or(val, sign);
@@ -155,12 +153,12 @@ namespace ojph
       if (count)
       {
         v128_t vf = wasm_v128_load(p);
-        vf = wasm_f32x4_mul(vf, d);                  // multiply
-        v128_t val = wasm_i32x4_trunc_sat_f32x4(vf); // convert to signed int
-        v128_t sign = wasm_i32x4_lt(val, zero);      // get sign
-        val = wasm_v128_xor(val, sign);              // negate 1's complement
+        vf = wasm_f32x4_mul(vf, d);                   // multiply
+        v128_t val = wasm_i32x4_trunc_sat_f32x4(vf);  // convert to signed int
+        v128_t sign = wasm_i32x4_lt(val, zero);       // get sign
+        val = wasm_v128_xor(val, sign);               // negate 1's complement
         v128_t ones = wasm_v128_and(sign, one);
-        val = wasm_i32x4_add(val, ones); // 2's complement
+        val = wasm_i32x4_add(val, ones);              // 2's complement
 
         v128_t c = wasm_i32x4_splat((si32)count);
         v128_t idx = wasm_i32x4_make(0, 1, 2, 3);
@@ -176,7 +174,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+    void wasm_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(delta);
@@ -184,33 +182,33 @@ namespace ojph
       v128_t m1 = wasm_i32x4_splat(INT_MAX);
       v128_t zero = wasm_i32x4_splat(0);
       v128_t one = wasm_i32x4_splat(1);
-      si32 *p = (si32 *)dp;
+      si32 *p = (si32*)dp;
       for (ui32 i = 0; i < count; i += 4, sp += 4, p += 4)
       {
-        v128_t v = wasm_v128_load((v128_t *)sp);
-        v128_t val = wasm_v128_and(v, m1);
-        val = wasm_i32x4_shr(val, shift);
-        v128_t sign = wasm_i32x4_lt(v, zero);
-        val = wasm_v128_xor(val, sign); // negate 1's complement
-        v128_t ones = wasm_v128_and(sign, one);
-        val = wasm_i32x4_add(val, ones); // 2's complement
-        wasm_v128_store(p, val);
+          v128_t v = wasm_v128_load((v128_t*)sp);
+          v128_t val = wasm_v128_and(v, m1);
+          val = wasm_i32x4_shr(val, shift);
+          v128_t sign = wasm_i32x4_lt(v, zero);
+          val = wasm_v128_xor(val, sign); // negate 1's complement
+          v128_t ones = wasm_v128_and(sign, one);
+          val = wasm_i32x4_add(val, ones); // 2's complement
+          wasm_v128_store(p, val);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+    void wasm_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(K_max);
       v128_t m1 = wasm_i32x4_splat(INT_MAX);
       v128_t d = wasm_f32x4_splat(delta);
-      float *p = (float *)dp;
+      float *p = (float*)dp;
       for (ui32 i = 0; i < count; i += 4, sp += 4, p += 4)
       {
-        v128_t v = wasm_v128_load((v128_t *)sp);
+        v128_t v = wasm_v128_load((v128_t*)sp);
         v128_t vali = wasm_v128_and(v, m1);
-        v128_t valf = wasm_f32x4_convert_i32x4(vali);
+        v128_t  valf = wasm_f32x4_convert_i32x4(vali);
         valf = wasm_f32x4_mul(valf, d);
         v128_t sign = wasm_v128_andnot(v, m1);
         valf = wasm_v128_or(valf, sign);
@@ -219,25 +217,25 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
-                             float delta_inv, ui32 count, ui64 *max_val)
+    void wasm_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max, 
+                             float delta_inv, ui32 count, ui64* max_val)
     {
       ojph_unused(delta_inv);
 
-      // convert to sign and magnitude and keep max_val
+      // convert to sign and magnitude and keep max_val      
       ui32 shift = 63 - K_max;
       v128_t m0 = wasm_i64x2_splat(LLONG_MIN);
       v128_t zero = wasm_i64x2_splat(0);
       v128_t one = wasm_i64x2_splat(1);
       v128_t tmax = wasm_v128_load(max_val);
-      si64 *p = (si64 *)sp;
-      for (; count >= 2; count -= 2, p += 2, dp += 2)
+      si64 *p = (si64*)sp;
+      for ( ; count >= 2; count -= 2, p += 2, dp += 2)
       {
         v128_t v = wasm_v128_load(p);
         v128_t sign = wasm_i64x2_lt(v, zero);
         v128_t val = wasm_v128_xor(v, sign); // negate 1's complement
         v128_t ones = wasm_v128_and(sign, one);
-        val = wasm_i64x2_add(val, ones); // 2's complement
+        val = wasm_i64x2_add(val, ones);     // 2's complement
         sign = wasm_v128_and(sign, m0);
         val = wasm_i64x2_shl(val, shift);
         tmax = wasm_v128_or(tmax, val);
@@ -250,7 +248,7 @@ namespace ojph
         v128_t sign = wasm_i64x2_lt(v, zero);
         v128_t val = wasm_v128_xor(v, sign); // negate 1's complement
         v128_t ones = wasm_v128_and(sign, one);
-        val = wasm_i64x2_add(val, ones); // 2's complement
+        val = wasm_i64x2_add(val, ones);     // 2's complement
         sign = wasm_v128_and(sign, m0);
         val = wasm_i64x2_shl(val, shift);
 
@@ -263,10 +261,10 @@ namespace ojph
       }
 
       wasm_v128_store(max_val, tmax);
-    }
+    }   
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+    void wasm_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max, 
                                float delta, ui32 count)
     {
       ojph_unused(delta);
@@ -274,17 +272,17 @@ namespace ojph
       v128_t m1 = wasm_i64x2_splat(LLONG_MAX);
       v128_t zero = wasm_i64x2_splat(0);
       v128_t one = wasm_i64x2_splat(1);
-      si64 *p = (si64 *)dp;
+      si64 *p = (si64*)dp;
       for (ui32 i = 0; i < count; i += 2, sp += 2, p += 2)
       {
-        v128_t v = wasm_v128_load((v128_t *)sp);
-        v128_t val = wasm_v128_and(v, m1);
-        val = wasm_i64x2_shr(val, shift);
-        v128_t sign = wasm_i64x2_lt(v, zero);
-        val = wasm_v128_xor(val, sign); // negate 1's complement
-        v128_t ones = wasm_v128_and(sign, one);
-        val = wasm_i64x2_add(val, ones); // 2's complement
-        wasm_v128_store(p, val);
+          v128_t v = wasm_v128_load((v128_t*)sp);
+          v128_t val = wasm_v128_and(v, m1);
+          val = wasm_i64x2_shr(val, shift);
+          v128_t sign = wasm_i64x2_lt(v, zero);
+          val = wasm_v128_xor(val, sign); // negate 1's complement
+          v128_t ones = wasm_v128_and(sign, one);
+          val = wasm_i64x2_add(val, ones); // 2's complement
+          wasm_v128_store(p, val);
       }
     }
   }

--- a/Native/Common/OpenJPH/codestream/ojph_params.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_params.cpp
@@ -38,6 +38,7 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 
+#include "ojph_arch.h"
 #include "ojph_base.h"
 #include "ojph_file.h"
 #include "ojph_params.h"
@@ -45,8 +46,7 @@
 #include "ojph_params_local.h"
 #include "ojph_message.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -59,29 +59,25 @@ namespace ojph
   ////////////////////////////////////////////////////////////////////////////
   void param_siz::set_image_extent(point dims)
   {
-    state->Xsiz = dims.x;
-    state->Ysiz = dims.y;
+    state->set_image_extent(dims);
   }
 
   ////////////////////////////////////////////////////////////////////////////
   void param_siz::set_tile_size(size s)
   {
-    state->XTsiz = s.w;
-    state->YTsiz = s.h;
+    state->set_tile_size(s);
   }
 
   ////////////////////////////////////////////////////////////////////////////
   void param_siz::set_image_offset(point offset)
-  { // WARNING need to check if these are valid
-    state->XOsiz = offset.x;
-    state->YOsiz = offset.y;
+  {
+    state->set_image_offset(offset);
   }
 
   ////////////////////////////////////////////////////////////////////////////
   void param_siz::set_tile_offset(point offset)
-  { // WARNING need to check if these are valid
-    state->XTOsiz = offset.x;
-    state->YTOsiz = offset.y;
+  {
+    state->set_tile_offset(offset);
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -91,7 +87,7 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void param_siz::set_component(ui32 comp_num, const point &downsampling,
+  void param_siz::set_component(ui32 comp_num, const point& downsampling,
                                 ui32 bit_depth, bool is_signed)
   {
     state->set_comp_info(comp_num, downsampling, bit_depth, is_signed);
@@ -170,7 +166,7 @@ namespace ojph
   {
     if (num_decompositions > 32)
       OJPH_ERROR(0x00050001,
-                 "maximum number of decompositions cannot exceed 32");
+        "maximum number of decompositions cannot exceed 32");
     state->SPcod.num_decomp = (ui8)num_decompositions;
   }
 
@@ -179,14 +175,17 @@ namespace ojph
   {
     ui32 log_width = 31 - count_leading_zeros(width);
     ui32 log_height = 31 - count_leading_zeros(height);
-    if (width == 0 || width != (1u << log_width) || height == 0 || height != (1u << log_height) || log_width < 2 || log_height < 2 || log_width + log_height > 12)
+    if (width == 0 || width != (1u << log_width)
+      || height == 0 || height != (1u << log_height)
+      || log_width < 2 || log_height < 2
+      || log_width + log_height > 12)
       OJPH_ERROR(0x00050011, "incorrect code block dimensions");
     state->SPcod.block_width = (ui8)(log_width - 2);
     state->SPcod.block_height = (ui8)(log_height - 2);
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void param_cod::set_precinct_size(int num_levels, size *precinct_size)
+  void param_cod::set_precinct_size(int num_levels, size* precinct_size)
   {
     if (num_levels == 0 || precinct_size == NULL)
       state->Scod &= 0xFE;
@@ -201,9 +200,9 @@ namespace ojph
         ui32 PPy = 31 - count_leading_zeros(t.h);
         if (t.w == 0 || t.h == 0)
           OJPH_ERROR(0x00050021, "precinct width or height cannot be 0");
-        if (t.w != (1u << PPx) || t.h != (1u << PPy))
+        if (t.w != (1u<<PPx) || t.h != (1u<<PPy))
           OJPH_ERROR(0x00050022,
-                     "precinct width and height should be a power of 2");
+            "precinct width and height should be a power of 2");
         if (PPx > 15 || PPy > 15)
           OJPH_ERROR(0x00050023, "precinct size is too large");
         if (i > 0 && (PPx == 0 || PPy == 0))
@@ -235,6 +234,7 @@ namespace ojph
     }
     else
       OJPH_ERROR(0x00050032, "improper progression order");
+
 
     state->SGCod.prog_order = (ui8)prog_order;
   }
@@ -303,7 +303,7 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  const char *param_cod::get_progression_order_as_string() const
+  const char* param_cod::get_progression_order_as_string() const
   {
     if (state->SGCod.prog_order == OJPH_PO_LRCP)
       return OJPH_PO_STRING_LRCP;
@@ -360,69 +360,48 @@ namespace ojph
 
   ////////////////////////////////////////////////////////////////////////////
   void param_coc::set_num_decomposition(ui32 num_decompositions)
-  {
-    ojph::param_cod(state).set_num_decomposition(num_decompositions);
-  }
+  { ojph::param_cod(state).set_num_decomposition(num_decompositions); }
 
   ////////////////////////////////////////////////////////////////////////////
   void param_coc::set_block_dims(ui32 width, ui32 height)
-  {
-    ojph::param_cod(state).set_block_dims(width, height);
-  }
+  { ojph::param_cod(state).set_block_dims(width, height); }
 
   ////////////////////////////////////////////////////////////////////////////
-  void param_coc::set_precinct_size(int num_levels, size *precinct_size)
-  {
-    ojph::param_cod(state).set_precinct_size(num_levels, precinct_size);
-  }
+  void param_coc::set_precinct_size(int num_levels, size* precinct_size)
+  { ojph::param_cod(state).set_precinct_size(num_levels, precinct_size); }
 
   ////////////////////////////////////////////////////////////////////////////
   void param_coc::set_reversible(bool reversible)
-  {
-    ojph::param_cod(state).set_reversible(reversible);
-  }
+  { ojph::param_cod(state).set_reversible(reversible); }
 
   ////////////////////////////////////////////////////////////////////////////
   ui32 param_coc::get_num_decompositions() const
-  {
-    return ojph::param_cod(state).get_num_decompositions();
-  }
+  { return ojph::param_cod(state).get_num_decompositions(); }
 
   ////////////////////////////////////////////////////////////////////////////
   size param_coc::get_block_dims() const
-  {
-    return ojph::param_cod(state).get_block_dims();
-  }
+  { return ojph::param_cod(state).get_block_dims(); }
 
   ////////////////////////////////////////////////////////////////////////////
   size param_coc::get_log_block_dims() const
-  {
-    return ojph::param_cod(state).get_log_block_dims();
-  }
+  { return ojph::param_cod(state).get_log_block_dims(); }
 
   ////////////////////////////////////////////////////////////////////////////
   bool param_coc::is_reversible() const
-  {
-    return ojph::param_cod(state).is_reversible();
-  }
+  { return ojph::param_cod(state).is_reversible(); }
 
   ////////////////////////////////////////////////////////////////////////////
   size param_coc::get_precinct_size(ui32 level_num) const
-  {
-    return ojph::param_cod(state).get_precinct_size(level_num);
-  }
+  { return ojph::param_cod(state).get_precinct_size(level_num); }
 
   ////////////////////////////////////////////////////////////////////////////
   size param_coc::get_log_precinct_size(ui32 level_num) const
-  {
-    return ojph::param_cod(state).get_log_precinct_size(level_num);
-  }
+  { return ojph::param_cod(state).get_log_precinct_size(level_num); }
 
   ////////////////////////////////////////////////////////////////////////////
   bool param_coc::get_block_vertical_causality() const
-  {
-    return ojph::param_cod(state).get_block_vertical_causality();
-  }
+  { return ojph::param_cod(state).get_block_vertical_causality(); }
+
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -459,8 +438,8 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  bool param_nlt::get_nonlinear_transform(ui32 comp_num, ui8 &bit_depth,
-                                          bool &is_signed, ui8 &nl_type) const
+  bool param_nlt::get_nonlinear_transform(ui32 comp_num, ui8& bit_depth,
+                                          bool& is_signed, ui8& nl_type) const
   {
     return state->get_nonlinear_transform(comp_num, bit_depth, is_signed,
                                           nl_type);
@@ -475,23 +454,23 @@ namespace ojph
   ////////////////////////////////////////////////////////////////////////////
 
   //////////////////////////////////////////////////////////////////////////
-  void comment_exchange::set_string(const char *str)
+  void comment_exchange::set_string(const char* str)
   {
     size_t t = strlen(str);
     if (len > 65531)
       OJPH_ERROR(0x000500C1,
-                 "COM marker string length cannot be larger than 65531");
+        "COM marker string length cannot be larger than 65531");
     this->data = str;
     this->len = (ui16)t;
     this->Rcom = 1;
   }
 
   //////////////////////////////////////////////////////////////////////////
-  void comment_exchange::set_data(const char *data, ui16 len)
+  void comment_exchange::set_data(const char* data, ui16 len)
   {
     if (len > 65531)
       OJPH_ERROR(0x000500C2,
-                 "COM marker string length cannot be larger than 65531");
+        "COM marker string length cannot be larger than 65531");
     this->data = data;
     this->len = len;
     this->Rcom = 0;
@@ -505,54 +484,17 @@ namespace ojph
   //
   //////////////////////////////////////////////////////////////////////////
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    static inline ui16 swap_byte(ui16 t)
-    {
-      return (ui16)((t << 8) | (t >> 8));
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline ui32 swap_byte(ui32 t)
-    {
-      ui32 u = swap_byte((ui16)(t & 0xFFFFu));
-      u <<= 16;
-      u |= swap_byte((ui16)(t >> 16));
-      return u;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline ui64 swap_byte(ui64 t)
-    {
-      ui64 u = swap_byte((ui32)(t & 0xFFFFFFFFu));
-      u <<= 32;
-      u |= swap_byte((ui32)(t >> 32));
-      return u;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    //
-    //
-    //
-    //
-    //
-    //////////////////////////////////////////////////////////////////////////
-
-    //////////////////////////////////////////////////////////////////////////
-    // static
+    //static
     class sqrt_energy_gains
     {
     public:
       static float get_gain_l(ui32 num_decomp, bool reversible)
-      {
-        return reversible ? gain_5x3_l[num_decomp] : gain_9x7_l[num_decomp];
-      }
+      { return reversible ? gain_5x3_l[num_decomp] : gain_9x7_l[num_decomp]; }
       static float get_gain_h(ui32 num_decomp, bool reversible)
-      {
-        return reversible ? gain_5x3_h[num_decomp] : gain_9x7_h[num_decomp];
-      }
+      { return reversible ? gain_5x3_h[num_decomp] : gain_9x7_h[num_decomp]; }
 
     private:
       static const float gain_9x7_l[34];
@@ -562,52 +504,48 @@ namespace ojph
     };
 
     //////////////////////////////////////////////////////////////////////////
-    const float sqrt_energy_gains::gain_9x7_l[34] = {1.0000e+00f,
-                                                     1.4021e+00f, 2.0304e+00f, 2.9012e+00f, 4.1153e+00f, 5.8245e+00f,
-                                                     8.2388e+00f, 1.1652e+01f, 1.6479e+01f, 2.3304e+01f, 3.2957e+01f,
-                                                     4.6609e+01f, 6.5915e+01f, 9.3217e+01f, 1.3183e+02f, 1.8643e+02f,
-                                                     2.6366e+02f, 3.7287e+02f, 5.2732e+02f, 7.4574e+02f, 1.0546e+03f,
-                                                     1.4915e+03f, 2.1093e+03f, 2.9830e+03f, 4.2185e+03f, 5.9659e+03f,
-                                                     8.4371e+03f, 1.1932e+04f, 1.6874e+04f, 2.3864e+04f, 3.3748e+04f,
-                                                     4.7727e+04f, 6.7496e+04f, 9.5454e+04f};
-    const float sqrt_energy_gains::gain_9x7_h[34] = {1.4425e+00f,
-                                                     1.9669e+00f, 2.8839e+00f, 4.1475e+00f, 5.8946e+00f, 8.3472e+00f,
-                                                     1.1809e+01f, 1.6701e+01f, 2.3620e+01f, 3.3403e+01f, 4.7240e+01f,
-                                                     6.6807e+01f, 9.4479e+01f, 1.3361e+02f, 1.8896e+02f, 2.6723e+02f,
-                                                     3.7792e+02f, 5.3446e+02f, 7.5583e+02f, 1.0689e+03f, 1.5117e+03f,
-                                                     2.1378e+03f, 3.0233e+03f, 4.2756e+03f, 6.0467e+03f, 8.5513e+03f,
-                                                     1.2093e+04f, 1.7103e+04f, 2.4187e+04f, 3.4205e+04f, 4.8373e+04f,
-                                                     6.8410e+04f, 9.6747e+04f, 1.3682e+05f};
-    const float sqrt_energy_gains::gain_5x3_l[34] = {1.0000e+00f,
-                                                     1.2247e+00f, 1.3229e+00f, 1.5411e+00f, 1.7139e+00f, 1.9605e+00f,
-                                                     2.2044e+00f, 2.5047e+00f, 2.8277e+00f, 3.2049e+00f, 3.6238e+00f,
-                                                     4.1033e+00f, 4.6423e+00f, 5.2548e+00f, 5.9462e+00f, 6.7299e+00f,
-                                                     7.6159e+00f, 8.6193e+00f, 9.7544e+00f, 1.1039e+01f, 1.2493e+01f,
-                                                     1.4139e+01f, 1.6001e+01f, 1.8108e+01f, 2.0493e+01f, 2.3192e+01f,
-                                                     2.6246e+01f, 2.9702e+01f, 3.3614e+01f, 3.8041e+01f, 4.3051e+01f,
-                                                     4.8721e+01f, 5.5138e+01f, 6.2399e+01f};
-    const float sqrt_energy_gains::gain_5x3_h[34] = {1.0458e+00f,
-                                                     1.3975e+00f, 1.4389e+00f, 1.7287e+00f, 1.8880e+00f, 2.1841e+00f,
-                                                     2.4392e+00f, 2.7830e+00f, 3.1341e+00f, 3.5576e+00f, 4.0188e+00f,
-                                                     4.5532e+00f, 5.1494e+00f, 5.8301e+00f, 6.5963e+00f, 7.4663e+00f,
-                                                     8.4489e+00f, 9.5623e+00f, 1.0821e+01f, 1.2247e+01f, 1.3860e+01f,
-                                                     1.5685e+01f, 1.7751e+01f, 2.0089e+01f, 2.2735e+01f, 2.5729e+01f,
-                                                     2.9117e+01f, 3.2952e+01f, 3.7292e+01f, 4.2203e+01f, 4.7761e+01f,
-                                                     5.4051e+01f, 6.1170e+01f, 6.9226e+01f};
+    const float sqrt_energy_gains::gain_9x7_l[34] = { 1.0000e+00f,
+      1.4021e+00f, 2.0304e+00f, 2.9012e+00f, 4.1153e+00f, 5.8245e+00f,
+      8.2388e+00f, 1.1652e+01f, 1.6479e+01f, 2.3304e+01f, 3.2957e+01f,
+      4.6609e+01f, 6.5915e+01f, 9.3217e+01f, 1.3183e+02f, 1.8643e+02f,
+      2.6366e+02f, 3.7287e+02f, 5.2732e+02f, 7.4574e+02f, 1.0546e+03f,
+      1.4915e+03f, 2.1093e+03f, 2.9830e+03f, 4.2185e+03f, 5.9659e+03f,
+      8.4371e+03f, 1.1932e+04f, 1.6874e+04f, 2.3864e+04f, 3.3748e+04f,
+      4.7727e+04f, 6.7496e+04f, 9.5454e+04f };
+    const float sqrt_energy_gains::gain_9x7_h[34] = { 1.4425e+00f,
+      1.9669e+00f, 2.8839e+00f, 4.1475e+00f, 5.8946e+00f, 8.3472e+00f,
+      1.1809e+01f, 1.6701e+01f, 2.3620e+01f, 3.3403e+01f, 4.7240e+01f,
+      6.6807e+01f, 9.4479e+01f, 1.3361e+02f, 1.8896e+02f, 2.6723e+02f,
+      3.7792e+02f, 5.3446e+02f, 7.5583e+02f, 1.0689e+03f, 1.5117e+03f,
+      2.1378e+03f, 3.0233e+03f, 4.2756e+03f, 6.0467e+03f, 8.5513e+03f,
+      1.2093e+04f, 1.7103e+04f, 2.4187e+04f, 3.4205e+04f, 4.8373e+04f,
+      6.8410e+04f, 9.6747e+04f, 1.3682e+05f };
+    const float sqrt_energy_gains::gain_5x3_l[34] = { 1.0000e+00f,
+      1.2247e+00f, 1.3229e+00f, 1.5411e+00f, 1.7139e+00f, 1.9605e+00f,
+      2.2044e+00f, 2.5047e+00f, 2.8277e+00f, 3.2049e+00f, 3.6238e+00f,
+      4.1033e+00f, 4.6423e+00f, 5.2548e+00f, 5.9462e+00f, 6.7299e+00f,
+      7.6159e+00f, 8.6193e+00f, 9.7544e+00f, 1.1039e+01f, 1.2493e+01f,
+      1.4139e+01f, 1.6001e+01f, 1.8108e+01f, 2.0493e+01f, 2.3192e+01f,
+      2.6246e+01f, 2.9702e+01f, 3.3614e+01f, 3.8041e+01f, 4.3051e+01f,
+      4.8721e+01f, 5.5138e+01f, 6.2399e+01f };
+    const float sqrt_energy_gains::gain_5x3_h[34] = { 1.0458e+00f,
+      1.3975e+00f, 1.4389e+00f, 1.7287e+00f, 1.8880e+00f, 2.1841e+00f,
+      2.4392e+00f, 2.7830e+00f, 3.1341e+00f, 3.5576e+00f, 4.0188e+00f,
+      4.5532e+00f, 5.1494e+00f, 5.8301e+00f, 6.5963e+00f, 7.4663e+00f,
+      8.4489e+00f, 9.5623e+00f, 1.0821e+01f, 1.2247e+01f, 1.3860e+01f,
+      1.5685e+01f, 1.7751e+01f, 2.0089e+01f, 2.2735e+01f, 2.5729e+01f,
+      2.9117e+01f, 3.2952e+01f, 3.7292e+01f, 4.2203e+01f, 4.7761e+01f,
+      5.4051e+01f, 6.1170e+01f, 6.9226e+01f };
 
     //////////////////////////////////////////////////////////////////////////
-    // static
+    //static
     class bibo_gains
     {
     public:
       static float get_bibo_gain_l(ui32 num_decomp, bool reversible)
-      {
-        return reversible ? gain_5x3_l[num_decomp] : gain_9x7_l[num_decomp];
-      }
+      { return reversible ? gain_5x3_l[num_decomp] : gain_9x7_l[num_decomp]; }
       static float get_bibo_gain_h(ui32 num_decomp, bool reversible)
-      {
-        return reversible ? gain_5x3_h[num_decomp] : gain_9x7_h[num_decomp];
-      }
+      { return reversible ? gain_5x3_h[num_decomp] : gain_9x7_h[num_decomp]; }
 
     private:
       static const float gain_9x7_l[34];
@@ -617,38 +555,39 @@ namespace ojph
     };
 
     //////////////////////////////////////////////////////////////////////////
-    const float bibo_gains::gain_9x7_l[34] = {1.0000e+00f, 1.3803e+00f,
-                                              1.3328e+00f, 1.3067e+00f, 1.3028e+00f, 1.3001e+00f, 1.2993e+00f,
-                                              1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
-                                              1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
-                                              1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
-                                              1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
-                                              1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
-                                              1.2992e+00f, 1.2992e+00f};
-    const float bibo_gains::gain_9x7_h[34] = {1.2976e+00f, 1.3126e+00f,
-                                              1.2757e+00f, 1.2352e+00f, 1.2312e+00f, 1.2285e+00f, 1.2280e+00f,
-                                              1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
-                                              1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
-                                              1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
-                                              1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
-                                              1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
-                                              1.2278e+00f, 1.2278e+00f};
-    const float bibo_gains::gain_5x3_l[34] = {1.0000e+00f, 1.5000e+00f,
-                                              1.6250e+00f, 1.6875e+00f, 1.6963e+00f, 1.7067e+00f, 1.7116e+00f,
-                                              1.7129e+00f, 1.7141e+00f, 1.7145e+00f, 1.7151e+00f, 1.7152e+00f,
-                                              1.7155e+00f, 1.7155e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f,
-                                              1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f,
-                                              1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f,
-                                              1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f,
-                                              1.7156e+00f, 1.7156e+00f};
-    const float bibo_gains::gain_5x3_h[34] = {2.0000e+00f, 2.5000e+00f,
-                                              2.7500e+00f, 2.8047e+00f, 2.8198e+00f, 2.8410e+00f, 2.8558e+00f,
-                                              2.8601e+00f, 2.8628e+00f, 2.8656e+00f, 2.8662e+00f, 2.8667e+00f,
-                                              2.8669e+00f, 2.8670e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
-                                              2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
-                                              2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
-                                              2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
-                                              2.8671e+00f, 2.8671e+00f};
+    const float bibo_gains::gain_9x7_l[34] = { 1.0000e+00f, 1.3803e+00f,
+      1.3328e+00f, 1.3067e+00f, 1.3028e+00f, 1.3001e+00f, 1.2993e+00f,
+      1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
+      1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
+      1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
+      1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
+      1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f, 1.2992e+00f,
+      1.2992e+00f, 1.2992e+00f };
+    const float bibo_gains::gain_9x7_h[34] = { 1.2976e+00f, 1.3126e+00f,
+      1.2757e+00f, 1.2352e+00f, 1.2312e+00f, 1.2285e+00f, 1.2280e+00f,
+      1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
+      1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
+      1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
+      1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
+      1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f, 1.2278e+00f,
+      1.2278e+00f, 1.2278e+00f };
+    const float bibo_gains::gain_5x3_l[34] = { 1.0000e+00f, 1.5000e+00f,
+      1.6250e+00f, 1.6875e+00f, 1.6963e+00f, 1.7067e+00f, 1.7116e+00f,
+      1.7129e+00f, 1.7141e+00f, 1.7145e+00f, 1.7151e+00f, 1.7152e+00f,
+      1.7155e+00f, 1.7155e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f,
+      1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f,
+      1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f,
+      1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f, 1.7156e+00f,
+      1.7156e+00f, 1.7156e+00f };
+    const float bibo_gains::gain_5x3_h[34] = { 2.0000e+00f, 2.5000e+00f,
+      2.7500e+00f, 2.8047e+00f, 2.8198e+00f, 2.8410e+00f, 2.8558e+00f,
+      2.8601e+00f, 2.8628e+00f, 2.8656e+00f, 2.8662e+00f, 2.8667e+00f,
+      2.8669e+00f, 2.8670e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
+      2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
+      2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
+      2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
+      2.8671e+00f, 2.8671e+00f };
+
 
     //////////////////////////////////////////////////////////////////////////
     //
@@ -661,36 +600,36 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     bool param_siz::write(outfile_base *file)
     {
-      // marker size excluding header
+      //marker size excluding header
       Lsiz = (ui16)(38 + 3 * Csiz);
 
       ui8 buf[4];
       bool result = true;
 
-      *(ui16 *)buf = JP2K_MARKER::SIZ;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::SIZ;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Lsiz);
+      *(ui16*)buf = swap_bytes_if_le(Lsiz);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Rsiz);
+      *(ui16*)buf = swap_bytes_if_le(Rsiz);
       result &= file->write(&buf, 2) == 2;
-      *(ui32 *)buf = swap_byte(Xsiz);
+      *(ui32*)buf = swap_bytes_if_le(Xsiz);
       result &= file->write(&buf, 4) == 4;
-      *(ui32 *)buf = swap_byte(Ysiz);
+      *(ui32*)buf = swap_bytes_if_le(Ysiz);
       result &= file->write(&buf, 4) == 4;
-      *(ui32 *)buf = swap_byte(XOsiz);
+      *(ui32*)buf = swap_bytes_if_le(XOsiz);
       result &= file->write(&buf, 4) == 4;
-      *(ui32 *)buf = swap_byte(YOsiz);
+      *(ui32*)buf = swap_bytes_if_le(YOsiz);
       result &= file->write(&buf, 4) == 4;
-      *(ui32 *)buf = swap_byte(XTsiz);
+      *(ui32*)buf = swap_bytes_if_le(XTsiz);
       result &= file->write(&buf, 4) == 4;
-      *(ui32 *)buf = swap_byte(YTsiz);
+      *(ui32*)buf = swap_bytes_if_le(YTsiz);
       result &= file->write(&buf, 4) == 4;
-      *(ui32 *)buf = swap_byte(XTOsiz);
+      *(ui32*)buf = swap_bytes_if_le(XTOsiz);
       result &= file->write(&buf, 4) == 4;
-      *(ui32 *)buf = swap_byte(YTOsiz);
+      *(ui32*)buf = swap_bytes_if_le(YTOsiz);
       result &= file->write(&buf, 4) == 4;
-      *(ui16 *)buf = swap_byte(Csiz);
+      *(ui16*)buf = swap_bytes_if_le(Csiz);
       result &= file->write(&buf, 2) == 2;
       for (int c = 0; c < Csiz; ++c)
       {
@@ -708,54 +647,56 @@ namespace ojph
     {
       if (file->read(&Lsiz, 2) != 2)
         OJPH_ERROR(0x00050041, "error reading SIZ marker");
-      Lsiz = swap_byte(Lsiz);
+      Lsiz = swap_bytes_if_le(Lsiz);
       int num_comps = (Lsiz - 38) / 3;
       if (Lsiz != 38 + 3 * num_comps)
         OJPH_ERROR(0x00050042, "error in SIZ marker length");
       if (file->read(&Rsiz, 2) != 2)
         OJPH_ERROR(0x00050043, "error reading SIZ marker");
-      Rsiz = swap_byte(Rsiz);
+      Rsiz = swap_bytes_if_le(Rsiz);
       if ((Rsiz & 0x4000) == 0)
         OJPH_ERROR(0x00050044,
-                   "Rsiz bit 14 is not set (this is not a JPH file)");
+          "Rsiz bit 14 is not set (this is not a JPH file)");
       if ((Rsiz & 0x8000) != 0 && (Rsiz & 0xD5F) != 0)
         OJPH_WARN(0x00050001, "Rsiz in SIZ has unimplemented fields");
       if (file->read(&Xsiz, 4) != 4)
         OJPH_ERROR(0x00050045, "error reading SIZ marker");
-      Xsiz = swap_byte(Xsiz);
+      Xsiz = swap_bytes_if_le(Xsiz);
       if (file->read(&Ysiz, 4) != 4)
         OJPH_ERROR(0x00050046, "error reading SIZ marker");
-      Ysiz = swap_byte(Ysiz);
-      if (file->read(&XOsiz, 4) != 4)
+      Ysiz = swap_bytes_if_le(Ysiz);
+      ui32 t_XOsiz, t_YOsiz;
+      if (file->read(&t_XOsiz, 4) != 4)
         OJPH_ERROR(0x00050047, "error reading SIZ marker");
-      XOsiz = swap_byte(XOsiz);
-      if (file->read(&YOsiz, 4) != 4)
+      if (file->read(&t_YOsiz, 4) != 4)
         OJPH_ERROR(0x00050048, "error reading SIZ marker");
-      YOsiz = swap_byte(YOsiz);
-      if (file->read(&XTsiz, 4) != 4)
+      set_image_offset(point(
+        swap_bytes_if_le(t_XOsiz), 
+        swap_bytes_if_le(t_YOsiz)));
+      ui32 t_XTsiz, t_YTsiz;
+      if (file->read(&t_XTsiz, 4) != 4)
         OJPH_ERROR(0x00050049, "error reading SIZ marker");
-      XTsiz = swap_byte(XTsiz);
-      if (file->read(&YTsiz, 4) != 4)
+      if (file->read(&t_YTsiz, 4) != 4)
         OJPH_ERROR(0x0005004A, "error reading SIZ marker");
-      YTsiz = swap_byte(YTsiz);
-      if (file->read(&XTOsiz, 4) != 4)
+      set_tile_size(size(
+        swap_bytes_if_le(t_XTsiz), 
+        swap_bytes_if_le(t_YTsiz)));
+      ui32 t_XTOsiz, t_YTOsiz;
+      if (file->read(&t_XTOsiz, 4) != 4)
         OJPH_ERROR(0x0005004B, "error reading SIZ marker");
-      XTOsiz = swap_byte(XTOsiz);
-      if (file->read(&YTOsiz, 4) != 4)
+      if (file->read(&t_YTOsiz, 4) != 4)
         OJPH_ERROR(0x0005004C, "error reading SIZ marker");
-      YTOsiz = swap_byte(YTOsiz);
+      set_tile_offset(point(
+        swap_bytes_if_le(t_XTOsiz), 
+        swap_bytes_if_le(t_YTOsiz)));
       if (file->read(&Csiz, 2) != 2)
         OJPH_ERROR(0x0005004D, "error reading SIZ marker");
-      Csiz = swap_byte(Csiz);
+      Csiz = swap_bytes_if_le(Csiz);
       if (Csiz != num_comps)
         OJPH_ERROR(0x0005004E, "Csiz does not match the SIZ marker size");
-      if (Csiz > old_Csiz)
-      {
-        if (cptr != store)
-          delete[] cptr;
-        cptr = new siz_comp_info[(ui32)num_comps];
-        old_Csiz = Csiz;
-      }
+      if (Csiz == 0)
+        OJPH_ERROR(0x0005004F, "Wrong Csiz value of 0 in SIZ marker segment");
+      set_num_components(Csiz);
       for (int c = 0; c < Csiz; ++c)
       {
         if (file->read(&cptr[c].SSiz, 1) != 1)
@@ -764,10 +705,18 @@ namespace ojph
           OJPH_ERROR(0x00050052, "error reading SIZ marker");
         if (file->read(&cptr[c].YRsiz, 1) != 1)
           OJPH_ERROR(0x00050053, "error reading SIZ marker");
+        if ((cptr[c].SSiz & 0x7F) > 37)
+          OJPH_ERROR(0x00050054, "Wrong SIZ-SSiz value of %d", cptr[c].SSiz);
+        if (cptr[c].XRsiz == 0)
+          OJPH_ERROR(0x00050055, "Wrong SIZ-XRsiz value of %d", cptr[c].XRsiz);
+        if (cptr[c].YRsiz == 0)
+          OJPH_ERROR(0x00050056, "Wrong SIZ-YRsiz value of %d", cptr[c].YRsiz);
       }
 
       ws_kern_support_needed = (Rsiz & 0x20) != 0;
       dfs_support_needed = (Rsiz & 0x80) != 0;
+
+      check_validity();
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -776,10 +725,9 @@ namespace ojph
       assert(comp_num < get_num_components());
 
       point factor(1u << skipped_resolutions, 1u << skipped_resolutions);
-      const param_cod *cdp = cod->get_coc(comp_num);
-      if (dfs && cdp && cdp->is_dfs_defined())
-      {
-        const param_dfs *d = dfs->get_dfs(cdp->get_dfs_index());
+      const param_cod* cdp = cod->get_coc(comp_num);
+      if (dfs && cdp && cdp->is_dfs_defined()) {
+        const param_dfs* d = dfs->get_dfs(cdp->get_dfs_index());
         factor = d->get_res_downsamp(skipped_resolutions);
       }
       factor.x *= (ui32)cptr[comp_num].XRsiz;
@@ -799,6 +747,7 @@ namespace ojph
       return r;
     }
 
+
     //////////////////////////////////////////////////////////////////////////
     //
     //
@@ -810,21 +759,21 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     bool param_cap::write(outfile_base *file)
     {
-      // marker size excluding header
+      //marker size excluding header
       Lcap = 8;
 
       char buf[4];
       bool result = true;
 
-      *(ui16 *)buf = JP2K_MARKER::CAP;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::CAP;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Lcap);
+      *(ui16*)buf = swap_bytes_if_le(Lcap);
       result &= file->write(&buf, 2) == 2;
-      *(ui32 *)buf = swap_byte(Pcap);
+      *(ui32*)buf = swap_bytes_if_le(Pcap);
       result &= file->write(&buf, 4) == 4;
 
-      *(ui16 *)buf = swap_byte(Ccap[0]);
+      *(ui16*)buf = swap_bytes_if_le(Ccap[0]);
       result &= file->write(&buf, 2) == 2;
 
       return result;
@@ -835,20 +784,20 @@ namespace ojph
     {
       if (file->read(&Lcap, 2) != 2)
         OJPH_ERROR(0x00050061, "error reading CAP marker");
-      Lcap = swap_byte(Lcap);
+      Lcap = swap_bytes_if_le(Lcap);
       if (file->read(&Pcap, 4) != 4)
         OJPH_ERROR(0x00050062, "error reading CAP marker");
-      Pcap = swap_byte(Pcap);
+      Pcap = swap_bytes_if_le(Pcap);
       ui32 count = population_count(Pcap);
       if (Pcap & 0xFFFDFFFF)
         OJPH_ERROR(0x00050063,
-                   "error Pcap in CAP has options that are not supported");
+          "error Pcap in CAP has options that are not supported");
       if ((Pcap & 0x00020000) == 0)
         OJPH_ERROR(0x00050064,
-                   "error Pcap should have its 15th MSB set, Pcap^15. "
-                   " This is not a JPH file");
+          "error Pcap should have its 15th MSB set, Pcap^15. "
+          " This is not a JPH file");
       for (ui32 i = 0; i < count; ++i)
-        if (file->read(Ccap + i, 2) != 2)
+        if (file->read(Ccap+i, 2) != 2)
           OJPH_ERROR(0x00050065, "error reading CAP marker");
       if (Lcap != 6 + 2 * count)
         OJPH_ERROR(0x00050066, "error in CAP marker length");
@@ -867,8 +816,7 @@ namespace ojph
     {
       if (SPcod.wavelet_trans <= 1)
         return get_wavelet_kern() == local::param_cod::DWT_REV53;
-      else
-      {
+      else {
         assert(atk != NULL);
         return atk->is_reversible();
       }
@@ -879,37 +827,37 @@ namespace ojph
     {
       assert(type == COD_MAIN);
 
-      // marker size excluding header
+      //marker size excluding header
       Lcod = 12;
       Lcod = (ui16)(Lcod + (Scod & 1 ? 1 + SPcod.num_decomp : 0));
 
       ui8 buf[4];
       bool result = true;
 
-      *(ui16 *)buf = JP2K_MARKER::COD;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::COD;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Lcod);
+      *(ui16*)buf = swap_bytes_if_le(Lcod);
       result &= file->write(&buf, 2) == 2;
-      *(ui8 *)buf = Scod;
+      *(ui8*)buf = Scod;
       result &= file->write(&buf, 1) == 1;
-      *(ui8 *)buf = SGCod.prog_order;
+      *(ui8*)buf = SGCod.prog_order;
       result &= file->write(&buf, 1) == 1;
-      *(ui16 *)buf = swap_byte(SGCod.num_layers);
+      *(ui16*)buf = swap_bytes_if_le(SGCod.num_layers);
       result &= file->write(&buf, 2) == 2;
-      *(ui8 *)buf = SGCod.mc_trans;
+      *(ui8*)buf = SGCod.mc_trans;
       result &= file->write(&buf, 1) == 1;
       buf[0] = SPcod.num_decomp;
       buf[1] = SPcod.block_width;
       buf[2] = SPcod.block_height;
       buf[3] = SPcod.block_style;
       result &= file->write(&buf, 4) == 4;
-      *(ui8 *)buf = SPcod.wavelet_trans;
+      *(ui8*)buf = SPcod.wavelet_trans;
       result &= file->write(&buf, 1) == 1;
       if (Scod & 1)
         for (int i = 0; i <= SPcod.num_decomp; ++i)
         {
-          *(ui8 *)buf = SPcod.precinct_size[i];
+          *(ui8*)buf = SPcod.precinct_size[i];
           result &= file->write(&buf, 1) == 1;
         }
 
@@ -936,41 +884,41 @@ namespace ojph
     {
       assert(type == COC_MAIN);
 
-      // marker size excluding header
+      //marker size excluding header
       Lcod = num_comps < 257 ? 9 : 10;
       Lcod = (ui16)(Lcod + (Scod & 1 ? 1 + SPcod.num_decomp : 0));
 
       ui8 buf[4];
       bool result = true;
 
-      *(ui16 *)buf = JP2K_MARKER::COC;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::COC;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Lcod);
+      *(ui16*)buf = swap_bytes_if_le(Lcod);
       result &= file->write(&buf, 2) == 2;
       if (num_comps < 257)
       {
-        *(ui8 *)buf = (ui8)comp_idx;
+        *(ui8*)buf = (ui8)comp_idx;
         result &= file->write(&buf, 1) == 1;
       }
       else
       {
-        *(ui16 *)buf = swap_byte(comp_idx);
+        *(ui16*)buf = swap_bytes_if_le(comp_idx);
         result &= file->write(&buf, 2) == 2;
       }
-      *(ui8 *)buf = Scod;
+      *(ui8*)buf = Scod;
       result &= file->write(&buf, 1) == 1;
       buf[0] = SPcod.num_decomp;
       buf[1] = SPcod.block_width;
       buf[2] = SPcod.block_height;
       buf[3] = SPcod.block_style;
       result &= file->write(&buf, 4) == 4;
-      *(ui8 *)buf = SPcod.wavelet_trans;
+      *(ui8*)buf = SPcod.wavelet_trans;
       result &= file->write(&buf, 1) == 1;
       if (Scod & 1)
         for (int i = 0; i <= SPcod.num_decomp; ++i)
         {
-          *(ui8 *)buf = SPcod.precinct_size[i];
+          *(ui8*)buf = SPcod.precinct_size[i];
           result &= file->write(&buf, 1) == 1;
         }
 
@@ -984,17 +932,15 @@ namespace ojph
 
       if (file->read(&Lcod, 2) != 2)
         OJPH_ERROR(0x00050071, "error reading COD segment");
-      Lcod = swap_byte(Lcod);
+      Lcod = swap_bytes_if_le(Lcod);
       if (file->read(&Scod, 1) != 1)
         OJPH_ERROR(0x00050072, "error reading COD segment");
       if (file->read(&SGCod.prog_order, 1) != 1)
         OJPH_ERROR(0x00050073, "error reading COD segment");
       if (file->read(&SGCod.num_layers, 2) != 2)
-      {
-        OJPH_ERROR(0x00050074, "error reading COD segment");
-      }
+      { OJPH_ERROR(0x00050074, "error reading COD segment"); }
       else
-        SGCod.num_layers = swap_byte(SGCod.num_layers);
+        SGCod.num_layers = swap_bytes_if_le(SGCod.num_layers);
       if (file->read(&SGCod.mc_trans, 1) != 1)
         OJPH_ERROR(0x00050075, "error reading COD segment");
       if (file->read(&SPcod.num_decomp, 1) != 1)
@@ -1007,16 +953,40 @@ namespace ojph
         OJPH_ERROR(0x00050079, "error reading COD segment");
       if (file->read(&SPcod.wavelet_trans, 1) != 1)
         OJPH_ERROR(0x0005007A, "error reading COD segment");
-      if (Scod & 1)
-        for (int i = 0; i <= SPcod.num_decomp; ++i)
+
+      if (get_num_decompositions() > 32
+        || SPcod.block_width > 8
+        || SPcod.block_height > 8
+        || SPcod.block_width + SPcod.block_height > 8
+        || (SPcod.block_style & 0x40) != 0x40
+        || (SPcod.block_style & 0xB7) != 0x00)
+        OJPH_ERROR(0x0005007D, "wrong settings in a COD-SPcod parameter");
+      if ((SPcod.block_style & 0x40) != 0x40
+        || (SPcod.block_style & 0xB7) != 0x00)
+        OJPH_ERROR(0x0005007E, "unsupported settings in a COD-SPcod parameter");
+
+      ui8 num_decompositions =  get_num_decompositions();
+      if (Scod & 1) {
+        for (int i = 0; i <= num_decompositions; ++i) {
           if (file->read(&SPcod.precinct_size[i], 1) != 1)
             OJPH_ERROR(0x0005007B, "error reading COD segment");
+          if (i)
+            if ((SPcod.precinct_size[i] & 0x0F) == 0 ||
+              (SPcod.precinct_size[i] >> 4) == 0)
+              OJPH_ERROR(0x0005007F,
+                "Precinct width or height for resolutions other than the"
+                " coarsest must be larger than 1; here, they are %d and %d,"
+                " respectively.",
+                1 << (SPcod.precinct_size[i] & 0x0F),
+                1 << (SPcod.precinct_size[i] >> 4));
+        }
+      }
       if (Lcod != 12 + ((Scod & 1) ? 1 + SPcod.num_decomp : 0))
         OJPH_ERROR(0x0005007C, "error in COD segment length");
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_cod::read_coc(infile_base *file, ui32 num_comps,
+    void param_cod::read_coc(infile_base* file, ui32 num_comps,
                              param_cod *top_cod)
     {
       assert(type == COC_MAIN);
@@ -1026,25 +996,23 @@ namespace ojph
       this->top_cod = top_cod;
       if (file->read(&Lcod, 2) != 2)
         OJPH_ERROR(0x00050121, "error reading COC segment");
-      Lcod = swap_byte(Lcod);
-      if (num_comps < 257)
-      {
+      Lcod = swap_bytes_if_le(Lcod);
+      if (num_comps < 257) {
         ui8 t;
         if (file->read(&t, 1) != 1)
           OJPH_ERROR(0x00050122, "error reading COC segment");
         comp_idx = t;
       }
-      else
-      {
+      else {
         if (file->read(&comp_idx, 2) != 2)
           OJPH_ERROR(0x00050123, "error reading COC segment");
-        comp_idx = swap_byte(comp_idx);
+        comp_idx = swap_bytes_if_le(comp_idx);
       }
       if (file->read(&Scod, 1) != 1)
         OJPH_ERROR(0x00050124, "error reading COC segment");
       if (Scod & 0xF8)
         OJPH_WARN(0x00050011,
-                  "Unsupported options in Scoc field of the COC segment");
+          "Unsupported options in Scoc field of the COC segment");
       if (file->read(&SPcod.num_decomp, 1) != 1)
         OJPH_ERROR(0x00050125, "error reading COC segment");
       if (file->read(&SPcod.block_width, 1) != 1)
@@ -1055,40 +1023,64 @@ namespace ojph
         OJPH_ERROR(0x00050128, "error reading COC segment");
       if (file->read(&SPcod.wavelet_trans, 1) != 1)
         OJPH_ERROR(0x00050129, "error reading COC segment");
-      if (Scod & 1)
-        for (int i = 0; i <= get_num_decompositions(); ++i)
+
+      if (get_num_decompositions() > 32
+        || SPcod.block_width > 8
+        || SPcod.block_height > 8
+        || SPcod.block_width + SPcod.block_height > 8
+        || (SPcod.block_style & 0x40) != 0x40
+        || (SPcod.block_style & 0xB7) != 0x00)
+        OJPH_ERROR(0x0005012C, "wrong settings in a COC-SPcoc parameter");
+      if ((SPcod.block_style & 0x40) != 0x40
+        || (SPcod.block_style & 0xB7) != 0x00)
+        OJPH_ERROR(0x0005012D, "unsupported settings in a COC-SPcoc parameter");
+
+      ui8 num_decompositions =  get_num_decompositions();
+      if (Scod & 1) {
+        for (int i = 0; i <= num_decompositions; ++i) {
           if (file->read(&SPcod.precinct_size[i], 1) != 1)
             OJPH_ERROR(0x0005012A, "error reading COC segment");
+          if (i)
+            if ((SPcod.precinct_size[i] & 0x0F) == 0 ||
+              (SPcod.precinct_size[i] >> 4) == 0)
+              OJPH_ERROR(0x0005012E,
+                "Precinct width or height for resolutions other than the"
+                " coarsest must be larger than 1; here, they are %d and %d,"
+                " respectively.",
+                1 << (SPcod.precinct_size[i] & 0x0F),
+                1 << (SPcod.precinct_size[i] >> 4));
+        }
+      }
       ui32 t = 9;
       t += num_comps < 257 ? 0 : 1;
-      t += (Scod & 1) ? 1 + get_num_decompositions() : 0;
+      t += (Scod & 1) ? 1 + num_decompositions : 0;
       if (Lcod != t)
         OJPH_ERROR(0x0005012B, "error in COC segment length");
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_cod::update_atk(const param_atk *atk)
+    void param_cod::update_atk(param_atk* atk)
     {
       assert(type == COD_MAIN);
       this->atk = atk->get_atk(SPcod.wavelet_trans);
       if (this->atk == NULL)
         OJPH_ERROR(0x00050131, "A COD segment employs the DWT kernel "
-                               "atk = %d, but a corresponding ATK segment cannot be found.",
-                   SPcod.wavelet_trans);
+          "atk = %d, but a corresponding ATK segment cannot be found.",
+          SPcod.wavelet_trans);
       param_cod *p = next;
       while (p)
       {
         p->atk = atk->get_atk(p->SPcod.wavelet_trans);
         if (p->atk == NULL)
           OJPH_ERROR(0x00050132, "A COC segment employs the DWT kernel "
-                                 "atk = %d, but a corresponding ATK segment cannot be found",
-                     SPcod.wavelet_trans);
+            "atk = %d, but a corresponding ATK segment cannot be found",
+            SPcod.wavelet_trans);
         p = p->next;
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    const param_cod *param_cod::get_coc(ui32 comp_idx) const
+    const param_cod* param_cod::get_coc(ui32 comp_idx) const
     {
       assert(this->type == COD_MAIN || this->top_cod->type == COD_MAIN);
       const param_cod *p, *q;
@@ -1102,22 +1094,29 @@ namespace ojph
     }
 
     ////////////////////////////////////////
-    param_cod *param_cod::get_coc(ui32 comp_idx)
+    param_cod* param_cod::get_coc(ui32 comp_idx)
     {
       // cast object to constant
-      const param_cod *const_p = const_cast<const param_cod *>(this);
+      const param_cod* const_p = const_cast<const param_cod*>(this);
       // call using the constant object, then cast to non-const
-      return const_cast<param_cod *>(const_p->get_coc(comp_idx));
+      return const_cast<param_cod*>(const_p->get_coc(comp_idx));
     }
 
     ////////////////////////////////////////
-    param_cod *param_cod::add_coc_object(ui32 comp_idx)
+    param_cod* param_cod::add_coc_object(ui32 comp_idx)
     {
       assert(type == COD_MAIN);
       param_cod *p = this;
       while (p->next != NULL)
         p = p->next;
-      p->next = new param_cod(this, (ui16)comp_idx);
+      if (avail)
+      {
+        p->next = avail;
+        avail = avail->next;
+        p->next->init(this, (ui16)comp_idx);
+      }
+      else
+        p->next = new param_cod(this, (ui16)comp_idx);
       return p->next;
     }
 
@@ -1130,7 +1129,7 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
-    void param_qcd::check_validity(const param_siz &siz, const param_cod &cod)
+    void param_qcd::check_validity(const param_siz& siz, const param_cod& cod)
     {
       ui32 num_comps = siz.get_num_components();
       trim_non_existing_components(num_comps);
@@ -1161,7 +1160,11 @@ namespace ojph
             }
             else
             {
-              all_same = all_same && (num_decompositions == p->get_num_decompositions()) && (bit_depth == siz.get_bit_depth(c)) && (is_signed == siz.is_signed(c)) && (wavelet_kern == p->get_wavelet_kern());
+              all_same = all_same
+                && (num_decompositions == p->get_num_decompositions())
+                && (bit_depth == siz.get_bit_depth(c))
+                && (is_signed == siz.is_signed(c))
+                && (wavelet_kern == p->get_wavelet_kern());
             }
           }
           else
@@ -1184,11 +1187,13 @@ namespace ojph
         this->num_subbands = 1 + 3 * qcd_num_decompositions;
         if (qcd_wavelet_kern == param_cod::DWT_REV53)
           set_rev_quant(qcd_num_decompositions, qcd_bit_depth,
-                        qcd_component < 3 ? employing_color_transform : false);
+            qcd_component < 3 ? employing_color_transform : false);
         else if (qcd_wavelet_kern == param_cod::DWT_IRV97)
         {
-          if (this->base_delta == -1.0f)
-            this->base_delta = 1.0f / (float)(1 << qcd_bit_depth);
+          if (this->base_delta == -1.0f) {
+            ui32 t = ojph_min(16, qcd_bit_depth);
+            this->base_delta = 1.0f / (float)(1 << t);
+          }
           set_irrev_quant(qcd_num_decompositions);
         }
         else
@@ -1202,7 +1207,10 @@ namespace ojph
         for (ui32 c = 0; c < num_comps; ++c)
         {
           const param_cod *cp = cod.get_coc(c);
-          if (qcd_num_decompositions == cp->get_num_decompositions() && qcd_bit_depth == siz.get_bit_depth(c) && qcd_is_signed == siz.is_signed(c) && qcd_wavelet_kern == cp->get_wavelet_kern())
+          if (qcd_num_decompositions == cp->get_num_decompositions()
+              && qcd_bit_depth == siz.get_bit_depth(c)
+              && qcd_is_signed == siz.is_signed(c)
+              && qcd_wavelet_kern == cp->get_wavelet_kern())
             continue; // captured by QCD
 
           // Does not match QCD, must have QCC
@@ -1215,11 +1223,19 @@ namespace ojph
           ui32 bit_depth = siz.get_bit_depth(c);
           if (cp->get_wavelet_kern() == param_cod::DWT_REV53)
             qp->set_rev_quant(num_decompositions, bit_depth,
-                              c < 3 ? employing_color_transform : false);
+              c < 3 ? employing_color_transform : false);
           else if (cp->get_wavelet_kern() == param_cod::DWT_IRV97)
           {
-            if (qp->base_delta == -1.0f)
-              qp->base_delta = 1.0f / (float)(1 << bit_depth);
+            if (qp->base_delta == -1.0f) {
+              if (qcd_wavelet_kern == param_cod::DWT_IRV97) {
+                assert(this->base_delta != -1.0f);
+                qp->base_delta = this->base_delta;
+              }
+              else {
+                ui32 t = ojph_min(16, qcd_bit_depth);
+                qp->base_delta = 1.0f / (float)(1 << t);
+              }
+            }
             qp->set_irrev_quant(num_decompositions);
           }
           else
@@ -1240,11 +1256,19 @@ namespace ojph
           ui32 bit_depth = siz.get_bit_depth(c);
           if (cp->get_wavelet_kern() == param_cod::DWT_REV53)
             qp->set_rev_quant(num_decompositions, bit_depth,
-                              c < 3 ? employing_color_transform : false);
+              c < 3 ? employing_color_transform : false);
           else if (cp->get_wavelet_kern() == param_cod::DWT_IRV97)
           {
-            if (qp->base_delta == -1.0f)
-              qp->base_delta = 1.0f / (float)(1 << bit_depth);
+            if (qp->base_delta == -1.0f) {
+              if (qcd_wavelet_kern == param_cod::DWT_IRV97) {
+                assert(this->base_delta != -1.0f);
+                qp->base_delta = this->base_delta;
+              }
+              else {
+                ui32 t = ojph_min(16, qcd_bit_depth);
+                qp->base_delta = 1.0f / (float)(1 << t);
+              }
+            }
             qp->set_irrev_quant(num_decompositions);
           }
           else
@@ -1268,32 +1292,31 @@ namespace ojph
                                   bool is_employing_color_transform)
     {
       ui32 B = bit_depth;
-      B += is_employing_color_transform ? 1 : 0; // 1 bit for RCT
+      B += is_employing_color_transform ? 1 : 0; //1 bit for RCT
       int s = 0;
       double bibo_l = bibo_gains::get_bibo_gain_l(num_decomps, true);
-      ui32 X = (ui32)ceil(log(bibo_l * bibo_l) / M_LN2);
+      ui32 X = (ui32) ceil(log(bibo_l * bibo_l) / M_LN2);
       SPqcd.u8[s++] = (ui8)(B + X);
       ui32 max_B_plus_X = (ui32)(B + X);
       for (ui32 d = num_decomps; d > 0; --d)
       {
         double bibo_l = bibo_gains::get_bibo_gain_l(d, true);
         double bibo_h = bibo_gains::get_bibo_gain_h(d - 1, true);
-        X = (ui32)ceil(log(bibo_h * bibo_l) / M_LN2);
+        X = (ui32) ceil(log(bibo_h * bibo_l) / M_LN2);
         SPqcd.u8[s++] = (ui8)(B + X);
         max_B_plus_X = ojph_max(max_B_plus_X, B + X);
         SPqcd.u8[s++] = (ui8)(B + X);
         max_B_plus_X = ojph_max(max_B_plus_X, B + X);
-        X = (ui32)ceil(log(bibo_h * bibo_h) / M_LN2);
+        X = (ui32) ceil(log(bibo_h * bibo_h) / M_LN2);
         SPqcd.u8[s++] = (ui8)(B + X);
         max_B_plus_X = ojph_max(max_B_plus_X, B + X);
       }
 
       if (max_B_plus_X > 38)
         OJPH_ERROR(0x00050151, "The specified combination of bit_depth, "
-                               "colour transform, and type of wavelet transform requires more than "
-                               "38 bits; it requires %d bits. This is beyond what is allowed in "
-                               "the JPEG2000 image coding format.",
-                   max_B_plus_X);
+         "colour transform, and type of wavelet transform requires more than "
+         "38 bits; it requires %d bits. This is beyond what is allowed in "
+         "the JPEG2000 image coding format.", max_B_plus_X);
 
       int guard_bits = ojph_max(1, (si32)max_B_plus_X - 31);
       Sqcd = (ui8)(guard_bits << 5);
@@ -1315,20 +1338,17 @@ namespace ojph
     void param_qcd::set_irrev_quant(ui32 num_decomps)
     {
       int guard_bits = 1;
-      Sqcd = (ui8)((guard_bits << 5) | 0x2); // one guard bit, scalar quantization
+      Sqcd = (ui8)((guard_bits<<5)|0x2);//one guard bit, scalar quantization
       int s = 0;
       float gain_l = sqrt_energy_gains::get_gain_l(num_decomps, false);
       float delta_b = base_delta / (gain_l * gain_l);
       int exp = 0, mantissa;
       while (delta_b < 1.0f)
-      {
-        exp++;
-        delta_b *= 2.0f;
-      }
-      // with rounding, there is a risk of becoming equal to 1<<12
-      //  but that should not happen in reality
-      mantissa = (int)round(delta_b * (float)(1 << 11)) - (1 << 11);
-      mantissa = mantissa < (1 << 11) ? mantissa : 0x7FF;
+      { exp++; delta_b *= 2.0f; }
+      //with rounding, there is a risk of becoming equal to 1<<12
+      // but that should not happen in reality
+      mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
+      mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
       SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
       for (ui32 d = num_decomps; d > 0; --d)
       {
@@ -1339,12 +1359,9 @@ namespace ojph
 
         int exp = 0, mantissa;
         while (delta_b < 1.0f)
-        {
-          exp++;
-          delta_b *= 2.0f;
-        }
-        mantissa = (int)round(delta_b * (float)(1 << 11)) - (1 << 11);
-        mantissa = mantissa < (1 << 11) ? mantissa : 0x7FF;
+        { exp++; delta_b *= 2.0f; }
+        mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
+        mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
         SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
         SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
 
@@ -1352,12 +1369,9 @@ namespace ojph
 
         exp = 0;
         while (delta_b < 1)
-        {
-          exp++;
-          delta_b *= 2.0f;
-        }
-        mantissa = (int)round(delta_b * (float)(1 << 11)) - (1 << 11);
-        mantissa = mantissa < (1 << 11) ? mantissa : 0x7FF;
+        { exp++; delta_b *= 2.0f; }
+        mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
+        mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
         SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
       }
     }
@@ -1370,22 +1384,21 @@ namespace ojph
       const param_qcd *p = this;
       while (p)
       {
-        // this can be written better, but it is only executed once
-        //  this assumes a bi-directional wavelet (conventional DWT)
+        //this can be written better, but it is only executed once
+        // this assumes a bi-directional wavelet (conventional DWT)
         ui32 num_decomps = (p->num_subbands - 1) / 3;
 
         int irrev = p->Sqcd & 0x1F;
-        if (irrev == 0) // reversible
-          for (ui32 i = 0; i < p->num_subbands; ++i)
-          {
+        if (irrev == 0) //reversible
+          for (ui32 i = 0; i < p->num_subbands; ++i) {
             ui32 t = p->decode_SPqcd(p->SPqcd.u8[i]);
             t += p->get_num_guard_bits() - 1u;
             B = ojph_max(B, t);
           }
-        else if (irrev == 2) // scalar expounded
+        else if (irrev == 2) //scalar expounded
           for (ui32 i = 0; i < p->num_subbands; ++i)
           {
-            ui32 nb = num_decomps - (i ? (i - 1) / 3 : 0); // decompsition level
+            ui32 nb = num_decomps - (i ? (i - 1) / 3 : 0); //decompsition level
             ui32 t = (p->SPqcd.u16[i] >> 11) + p->get_num_guard_bits() - nb;
             B = ojph_max(B, t);
           }
@@ -1399,26 +1412,29 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    float param_qcd::get_irrev_delta(const param_dfs *dfs,
-                                     ui32 num_decompositions,
+    float param_qcd::get_irrev_delta(const param_dfs* dfs,
+                                     ui32 num_decompositions, ui32 comp_num,
                                      ui32 resolution, ui32 subband) const
     {
-      float arr[] = {1.0f, 2.0f, 2.0f, 4.0f};
-      assert((Sqcd & 0x1F) == 2);
+      float arr[] = { 1.0f, 2.0f, 2.0f, 4.0f };
+      if ((Sqcd & 0x1F) != 2)
+        OJPH_ERROR(0x00050101, "There is something wrong in the configuration "
+          "of the codestream; for component %d, the codestream defines an "
+          "irreversible transform, for which the codestream provides a "
+          "reversible (no quantization) step sizes in Sqcd/Sqcc.", comp_num);
 
       ui32 idx;
       if (dfs != NULL && dfs->exists())
         idx = dfs->get_subband_idx(num_decompositions, resolution, subband);
       else
         idx = resolution ? (resolution - 1) * 3 + subband : 0;
-      if (idx >= num_subbands)
-      {
+      if (idx >= num_subbands) {
         OJPH_INFO(0x00050101, "Trying to access quantization step size for "
-                              "subband %d when the QCD/QCC marker segment specifies "
-                              "quantization step sizes for %d subbands only.  To continue "
-                              "decoding, we are using the step size for subband %d, which can "
-                              "produce incorrect results",
-                  idx + 1, num_subbands, num_subbands - 1);
+          "subband %d when the QCD/QCC marker segment specifies "
+          "quantization step sizes for %d subbands only.  To continue "
+          "decoding, we are using the step size for subband %d, which can "
+          "produce incorrect results",
+          idx + 1, num_subbands, num_subbands - 1);
         idx = num_subbands - 1;
       }
       int eps = SPqcd.u16[idx] >> 11;
@@ -1430,22 +1446,20 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 param_qcd::propose_precision(const param_cod *cod) const
+    ui32 param_qcd::propose_precision(const param_cod* cod) const
     {
       ui32 comp_idx = cod->get_comp_idx();
       ui32 precision = 0;
       const param_cod *main =
-          cod->get_coc(param_cod::OJPH_COD_DEFAULT);
+        cod->get_coc(param_cod::OJPH_COD_DEFAULT);
       if (main->is_employing_color_transform() && comp_idx < 3)
       {
-        for (ui32 i = 0; i < 3; ++i)
-        {
-          const param_qcd *p = this->get_qcc(i);
+        for (ui32 i = 0; i < 3; ++i) {
+          const param_qcd* p = this->get_qcc(i);
           precision = ojph_max(precision, p->get_largest_Kmax());
         }
       }
-      else
-      {
+      else {
         precision = get_largest_Kmax();
       }
       // ``precision'' now holds the largest K_max, which excludes the sign
@@ -1463,7 +1477,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 param_qcd::get_Kmax(const param_dfs *dfs, ui32 num_decompositions,
+    ui32 param_qcd::get_Kmax(const param_dfs* dfs, ui32 num_decompositions,
                              ui32 resolution, ui32 subband) const
     {
       ui32 idx;
@@ -1471,14 +1485,13 @@ namespace ojph
         idx = dfs->get_subband_idx(num_decompositions, resolution, subband);
       else
         idx = resolution ? (resolution - 1) * 3 + subband : 0;
-      if (idx >= num_subbands)
-      {
+      if (idx >= num_subbands) {
         OJPH_INFO(0x00050111, "Trying to access quantization step size for "
-                              "subband %d when the QCD/QCC marker segment specifies "
-                              "quantization step sizes for %d subbands only.  To continue "
-                              "decoding, we are using the step size for subband %d, which can "
-                              "produce incorrect results",
-                  idx + 1, num_subbands, num_subbands - 1);
+          "subband %d when the QCD/QCC marker segment specifies "
+          "quantization step sizes for %d subbands only.  To continue "
+          "decoding, we are using the step size for subband %d, which can "
+          "produce incorrect results",
+          idx + 1, num_subbands, num_subbands - 1);
         idx = num_subbands - 1;
       }
 
@@ -1491,7 +1504,7 @@ namespace ojph
       }
       else if (irrev == 1)
         assert(0);
-      else if (irrev == 2) // scalar expounded
+      else if (irrev == 2) //scalar expounded
         num_bits = (SPqcd.u16[idx] >> 11) - 1;
       else
         assert(0);
@@ -1506,18 +1519,16 @@ namespace ojph
       ui32 num_bits = 0;
       if (irrev == 0) // reversible; this is (10.22) from the J2K book
       {
-        for (ui32 i = 0; i < num_subbands; ++i)
-        {
+        for (ui32 i = 0; i < num_subbands; ++i) {
           ui32 t = decode_SPqcd(SPqcd.u8[i]);
           num_bits = ojph_max(num_bits, t == 0 ? 0 : t - 1);
         }
       }
       else if (irrev == 1)
         assert(0);
-      else if (irrev == 2) // scalar expounded
+      else if (irrev == 2) //scalar expounded
       {
-        for (ui32 i = 0; i < num_subbands; ++i)
-        {
+        for (ui32 i = 0; i < num_subbands; ++i) {
           ui32 t = (SPqcd.u16[i] >> 11) - 1;
           num_bits = ojph_max(num_bits, t);
         }
@@ -1533,7 +1544,7 @@ namespace ojph
     {
       int irrev = Sqcd & 0x1F;
 
-      // marker size excluding header
+      //marker size excluding header
       Lqcd = 3;
       if (irrev == 0)
         Lqcd = (ui16)(Lqcd + num_subbands);
@@ -1545,24 +1556,24 @@ namespace ojph
       char buf[4];
       bool result = true;
 
-      *(ui16 *)buf = JP2K_MARKER::QCD;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::QCD;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Lqcd);
+      *(ui16*)buf = swap_bytes_if_le(Lqcd);
       result &= file->write(&buf, 2) == 2;
-      *(ui8 *)buf = Sqcd;
+      *(ui8*)buf = Sqcd;
       result &= file->write(&buf, 1) == 1;
 
       if (irrev == 0)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui8 *)buf = SPqcd.u8[i];
+          *(ui8*)buf = SPqcd.u8[i];
           result &= file->write(&buf, 1) == 1;
         }
       else if (irrev == 2)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui16 *)buf = swap_byte(SPqcd.u16[i]);
+          *(ui16*)buf = swap_bytes_if_le(SPqcd.u16[i]);
           result &= file->write(&buf, 2) == 2;
         }
       else
@@ -1591,7 +1602,7 @@ namespace ojph
     {
       int irrev = Sqcd & 0x1F;
 
-      // marker size excluding header
+      //marker size excluding header
       Lqcd = (ui16)(4 + (num_comps < 257 ? 0 : 1));
       if (irrev == 0)
         Lqcd = (ui16)(Lqcd + num_subbands);
@@ -1603,33 +1614,33 @@ namespace ojph
       char buf[4];
       bool result = true;
 
-      *(ui16 *)buf = JP2K_MARKER::QCC;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::QCC;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Lqcd);
+      *(ui16*)buf = swap_bytes_if_le(Lqcd);
       result &= file->write(&buf, 2) == 2;
       if (num_comps < 257)
       {
-        *(ui8 *)buf = (ui8)comp_idx;
+        *(ui8*)buf = (ui8)comp_idx;
         result &= file->write(&buf, 1) == 1;
       }
       else
       {
-        *(ui16 *)buf = swap_byte(comp_idx);
+        *(ui16*)buf = swap_bytes_if_le(comp_idx);
         result &= file->write(&buf, 2) == 2;
       }
-      *(ui8 *)buf = Sqcd;
+      *(ui8*)buf = Sqcd;
       result &= file->write(&buf, 1) == 1;
       if (irrev == 0)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui8 *)buf = SPqcd.u8[i];
+          *(ui8*)buf = SPqcd.u8[i];
           result &= file->write(&buf, 1) == 1;
         }
       else if (irrev == 2)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui16 *)buf = swap_byte(SPqcd.u16[i]);
+          *(ui16*)buf = swap_bytes_if_le(SPqcd.u16[i]);
           result &= file->write(&buf, 2) == 2;
         }
       else
@@ -1656,14 +1667,17 @@ namespace ojph
     {
       if (file->read(&Lqcd, 2) != 2)
         OJPH_ERROR(0x00050081, "error reading QCD marker");
-      Lqcd = swap_byte(Lqcd);
+      Lqcd = swap_bytes_if_le(Lqcd);
       if (file->read(&Sqcd, 1) != 1)
         OJPH_ERROR(0x00050082, "error reading QCD marker");
       if ((Sqcd & 0x1F) == 0)
       {
         num_subbands = (Lqcd - 3);
-        if (Lqcd != 3 + num_subbands)
-          OJPH_ERROR(0x00050083, "wrong Lqcd value in QCD marker");
+        if (num_subbands == 0)
+          OJPH_ERROR(0x0005008A, "QCD marker segment that specifies no "
+            "quantization informtion");
+        if (num_subbands > 97 || Lqcd != 3 + num_subbands)
+          OJPH_ERROR(0x00050083, "wrong Lqcd value of %d in QCD marker", Lqcd);
         for (ui32 i = 0; i < num_subbands; ++i)
           if (file->read(&SPqcd.u8[i], 1) != 1)
             OJPH_ERROR(0x00050084, "error reading QCD marker");
@@ -1672,20 +1686,23 @@ namespace ojph
       {
         num_subbands = 0;
         OJPH_ERROR(0x00050089,
-                   "Scalar derived quantization is not supported yet in QCD marker");
+          "Scalar derived quantization is not supported yet in QCD marker");
         if (Lqcd != 5)
           OJPH_ERROR(0x00050085, "wrong Lqcd value in QCD marker");
       }
       else if ((Sqcd & 0x1F) == 2)
       {
         num_subbands = (Lqcd - 3) / 2;
-        if (Lqcd != 3 + 2 * num_subbands)
-          OJPH_ERROR(0x00050086, "wrong Lqcd value in QCD marker");
+        if (num_subbands == 0)
+          OJPH_ERROR(0x0005008B, "QCD marker segment that specifies no "
+            "quantization informtion");
+        if (num_subbands > 97 || Lqcd != 3 + 2 * num_subbands)
+          OJPH_ERROR(0x00050086, "wrong Lqcd value of %d in QCD marker", Lqcd);
         for (ui32 i = 0; i < num_subbands; ++i)
         {
           if (file->read(&SPqcd.u16[i], 2) != 2)
             OJPH_ERROR(0x00050087, "error reading QCD marker");
-          SPqcd.u16[i] = swap_byte(SPqcd.u16[i]);
+          SPqcd.u16[i] = swap_bytes_if_le(SPqcd.u16[i]);
         }
       }
       else
@@ -1697,7 +1714,7 @@ namespace ojph
     {
       if (file->read(&Lqcd, 2) != 2)
         OJPH_ERROR(0x000500A1, "error reading QCC marker");
-      Lqcd = swap_byte(Lqcd);
+      Lqcd = swap_bytes_if_le(Lqcd);
       if (num_comps < 257)
       {
         ui8 v;
@@ -1709,7 +1726,7 @@ namespace ojph
       {
         if (file->read(&comp_idx, 2) != 2)
           OJPH_ERROR(0x000500A3, "error reading QCC marker");
-        comp_idx = swap_byte(comp_idx);
+        comp_idx = swap_bytes_if_le(comp_idx);
       }
       if (file->read(&Sqcd, 1) != 1)
         OJPH_ERROR(0x000500A4, "error reading QCC marker");
@@ -1717,8 +1734,11 @@ namespace ojph
       if ((Sqcd & 0x1F) == 0)
       {
         num_subbands = (Lqcd - offset);
-        if (Lqcd != offset + num_subbands)
-          OJPH_ERROR(0x000500A5, "wrong Lqcd value in QCC marker");
+        if (num_subbands == 0)
+          OJPH_ERROR(0x000500AC, "QCC marker segment that specifies no "
+            "quantization informtion");
+        if (num_subbands > 97 || Lqcd != offset + num_subbands)
+          OJPH_ERROR(0x000500A5, "wrong Lqcd value of %d in QCC marker", Lqcd);
         for (ui32 i = 0; i < num_subbands; ++i)
           if (file->read(&SPqcd.u8[i], 1) != 1)
             OJPH_ERROR(0x000500A6, "error reading QCC marker");
@@ -1727,20 +1747,23 @@ namespace ojph
       {
         num_subbands = 0;
         OJPH_ERROR(0x000500AB,
-                   "Scalar derived quantization is not supported yet in QCC marker");
+          "Scalar derived quantization is not supported yet in QCC marker");
         if (Lqcd != offset)
           OJPH_ERROR(0x000500A7, "wrong Lqcc value in QCC marker");
       }
       else if ((Sqcd & 0x1F) == 2)
       {
         num_subbands = (Lqcd - offset) / 2;
-        if (Lqcd != offset + 2 * num_subbands)
-          OJPH_ERROR(0x000500A8, "wrong Lqcc value in QCC marker");
+        if (num_subbands == 0)
+          OJPH_ERROR(0x000500AD, "QCC marker segment that specifies no "
+            "quantization informtion");
+        if (num_subbands > 97 || Lqcd != offset + 2 * num_subbands)
+          OJPH_ERROR(0x000500A8, "wrong Lqcc value of %d in QCC marker", Lqcd);
         for (ui32 i = 0; i < num_subbands; ++i)
         {
           if (file->read(&SPqcd.u16[i], 2) != 2)
             OJPH_ERROR(0x000500A9, "error reading QCC marker");
-          SPqcd.u16[i] = swap_byte(SPqcd.u16[i]);
+          SPqcd.u16[i] = swap_bytes_if_le(SPqcd.u16[i]);
         }
       }
       else
@@ -1748,16 +1771,16 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    param_qcd *param_qcd::get_qcc(ui32 comp_idx)
+    param_qcd* param_qcd::get_qcc(ui32 comp_idx)
     {
       // cast object to constant
-      const param_qcd *const_p = const_cast<const param_qcd *>(this);
+      const param_qcd* const_p = const_cast<const param_qcd*>(this);
       // call using the constant object, then cast to non-const
-      return const_cast<param_qcd *>(const_p->get_qcc(comp_idx));
+      return const_cast<param_qcd*>(const_p->get_qcc(comp_idx));
     }
 
     //////////////////////////////////////////////////////////////////////////
-    const param_qcd *param_qcd::get_qcc(ui32 comp_idx) const
+    const param_qcd* param_qcd::get_qcc(ui32 comp_idx) const
     {
       assert(this->type == QCD_MAIN || this->top_qcd->type == QCD_MAIN);
       const param_qcd *p, *q;
@@ -1771,13 +1794,20 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    param_qcd *param_qcd::add_qcc_object(ui32 comp_idx)
+    param_qcd* param_qcd::add_qcc_object(ui32 comp_idx)
     {
       assert(type == QCD_MAIN);
       param_qcd *p = this;
       while (p->next != NULL)
         p = p->next;
-      p->next = new param_qcd(this, (ui16)comp_idx);
+      if (avail)
+      {
+        p->next = avail;
+        avail = avail->next;
+        p->next->init(this, (ui16)comp_idx);
+      }
+      else
+        p->next = new param_qcd(this, (ui16)comp_idx);
       return p->next;
     }
 
@@ -1790,7 +1820,7 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
-    void param_nlt::check_validity(param_siz &siz)
+    void param_nlt::check_validity(param_siz& siz)
     {
       if (is_any_enabled() == false)
         return;
@@ -1808,11 +1838,11 @@ namespace ojph
         // entry (ALL_COMPS) has the same bit_depth/signedness,
         // while doing this, set the BDnlt for components not captured by the
         // default entry (ALL_COMPS)
-        ui32 bit_depth = 0;     // unknown yet
-        bool is_signed = false; // unknown yet
+        ui32 bit_depth = 0;      // unknown yet
+        bool is_signed = false;  // unknown yet
         for (ui32 c = 0; c < num_comps; ++c)
         { // captured by ALL_COMPS
-          param_nlt *p = get_nlt_object(c);
+          param_nlt* p = get_nlt_object(c);
           if (p == NULL || !p->enabled)
           {
             if (bit_depth != 0)
@@ -1845,7 +1875,7 @@ namespace ojph
           this->enabled = false;
           for (ui32 c = 0; c < num_comps; ++c)
           {
-            param_nlt *p = get_nlt_object(c);
+            param_nlt* p = get_nlt_object(c);
             if (p == NULL || !p->enabled)
             { // captured by ALL_COMPS
               if (p == NULL)
@@ -1858,13 +1888,12 @@ namespace ojph
           }
         }
       }
-      else
-      {
+      else {
         // fill NLT segment markers with correct information
         ui32 num_comps = siz.get_num_components();
         for (ui32 c = 0; c < num_comps; ++c)
         { // captured by ALL_COMPS
-          param_nlt *p = get_nlt_object(c);
+          param_nlt* p = get_nlt_object(c);
           if (p != NULL && p->enabled)
           { // can be type 0 or type 3
             p->BDnlt = (ui8)(siz.get_bit_depth(c) - 1);
@@ -1884,10 +1913,10 @@ namespace ojph
     {
       if (nl_type != ojph::param_nlt::OJPH_NLT_NO_NLT &&
           nl_type != ojph::param_nlt::OJPH_NLT_BINARY_COMPLEMENT_NLT)
-        OJPH_ERROR(0x00050171, "Nonliearities other than type 0 "
-                               "(No Nonlinearity) or type  3 (Binary Binary Complement to Sign "
-                               "Magnitude Conversion) are not supported yet");
-      param_nlt *p = get_nlt_object(comp_num);
+      OJPH_ERROR(0x00050171, "Nonliearities other than type 0 "
+        "(No Nonlinearity) or type  3 (Binary Binary Complement to Sign "
+        "Magnitude Conversion) are not supported yet");
+      param_nlt* p = get_nlt_object(comp_num);
       if (p == NULL)
         p = add_object(comp_num);
       p->Tnlt = nl_type;
@@ -1896,11 +1925,11 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     bool
-    param_nlt::get_nonlinear_transform(ui32 comp_num, ui8 &bit_depth,
-                                       bool &is_signed, ui8 &nl_type) const
+    param_nlt::get_nonlinear_transform(ui32 comp_num, ui8& bit_depth,
+                                       bool& is_signed, ui8& nl_type) const
     {
       assert(Cnlt == special_comp_num::ALL_COMPS);
-      const param_nlt *p = get_nlt_object(comp_num);
+      const param_nlt* p = get_nlt_object(comp_num);
       p = (p && p->enabled) ? p : this;
       if (p->enabled)
       {
@@ -1914,24 +1943,24 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    bool param_nlt::write(outfile_base *file) const
+    bool param_nlt::write(outfile_base* file) const
     {
       if (is_any_enabled() == false)
         return true;
 
       char buf[2];
       bool result = true;
-      const param_nlt *p = this;
+      const param_nlt* p = this;
       while (p)
       {
         if (p->enabled)
         {
-          *(ui16 *)buf = JP2K_MARKER::NLT;
-          *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+          *(ui16*)buf = JP2K_MARKER::NLT;
+          *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
           result &= file->write(&buf, 2) == 2;
-          *(ui16 *)buf = swap_byte(p->Lnlt);
+          *(ui16*)buf = swap_bytes_if_le(p->Lnlt);
           result &= file->write(&buf, 2) == 2;
-          *(ui16 *)buf = swap_byte(p->Cnlt);
+          *(ui16*)buf = swap_bytes_if_le(p->Cnlt);
           result &= file->write(&buf, 2) == 2;
           result &= file->write(&p->BDnlt, 1) == 1;
           result &= file->write(&p->Tnlt, 1) == 1;
@@ -1942,19 +1971,19 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_nlt::read(infile_base *file)
+    void param_nlt::read(infile_base* file)
     {
       ui8 buf[6];
 
       if (file->read(buf, 6) != 6)
         OJPH_ERROR(0x00050141, "error reading NLT marker segment");
 
-      ui16 length = swap_byte(*(ui16 *)buf);
+      ui16 length = swap_bytes_if_le(*(ui16*)buf);
       if (length != 6 || (buf[5] != 3 && buf[5] != 0)) // wrong length or type
         OJPH_ERROR(0x00050142, "Unsupported NLT type %d\n", buf[5]);
 
-      ui16 comp = swap_byte(*(ui16 *)(buf + 2));
-      param_nlt *p = get_nlt_object(comp);
+      ui16 comp = swap_bytes_if_le(*(ui16*)(buf + 2));
+      param_nlt* p = get_nlt_object(comp);
       if (p == NULL)
         p = add_object(comp);
       p->enabled = true;
@@ -1964,36 +1993,41 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    param_nlt *param_nlt::get_nlt_object(ui32 comp_num)
+    param_nlt* param_nlt::get_nlt_object(ui32 comp_num)
     {
       // cast object to constant
-      const param_nlt *const_p = const_cast<const param_nlt *>(this);
+      const param_nlt* const_p = const_cast<const param_nlt*>(this);
       // call using the constant object, then cast to non-const
-      return const_cast<param_nlt *>(const_p->get_nlt_object(comp_num));
+      return const_cast<param_nlt*>(const_p->get_nlt_object(comp_num));
     }
 
     //////////////////////////////////////////////////////////////////////////
-    const param_nlt *param_nlt::get_nlt_object(ui32 comp_num) const
+    const param_nlt* param_nlt::get_nlt_object(ui32 comp_num) const
     {
-      const param_nlt *p = this;
+      const param_nlt* p = this;
       while (p && p->Cnlt != comp_num)
         p = p->next;
       return p;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    param_nlt *param_nlt::add_object(ui32 comp_num)
+    param_nlt* param_nlt::add_object(ui32 comp_num)
     {
       assert(comp_num != special_comp_num::ALL_COMPS);
       assert(Cnlt == special_comp_num::ALL_COMPS);
-      param_nlt *p = this;
-      while (p->next != NULL)
-      {
+      param_nlt* p = this;
+      while (p->next != NULL) {
         assert(p->Cnlt != comp_num);
         p = p->next;
       }
-      p->next = new param_nlt;
-      p->alloced_next = true;
+      if (avail)
+      {
+        p->next = avail;
+        avail = avail->next;
+        p->next->init();
+      }
+      else
+        p->next = new param_nlt;
       p = p->next;
       p->Cnlt = (ui16)comp_num;
       return p;
@@ -2003,7 +2037,7 @@ namespace ojph
     bool param_nlt::is_any_enabled() const
     {
       // check if any field is enabled
-      const param_nlt *p = this;
+      const param_nlt* p = this;
       while (p && p->enabled == false)
         p = p->next;
       return (p != NULL);
@@ -2012,19 +2046,17 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     void param_nlt::trim_non_existing_components(ui32 num_comps)
     {
-      param_nlt *p = this->next;
-      while (p)
-      {
-        if (p->enabled == true && p->Cnlt >= num_comps)
-        {
-          p->enabled = false;
-          OJPH_INFO(0x00050161, "The NLT marker segment for the "
-                                "non-existing component %d has been removed.",
-                    p->Cnlt);
-        }
+      param_nlt* p = this->next;
+      while (p) {
+          if (p->enabled == true && p->Cnlt >= num_comps) {
+            p->enabled = false;
+            OJPH_INFO(0x00050161, "The NLT marker segment for the "
+              "non-existing component %d has been removed.", p->Cnlt);
+          }
         p = p->next;
       }
     }
+
 
     //////////////////////////////////////////////////////////////////////////
     //
@@ -2040,16 +2072,16 @@ namespace ojph
       char buf[4];
       bool result = true;
 
-      this->Psot = payload_len + 14; // inc. SOT marker, field & SOD
+      this->Psot = payload_len + 14; //inc. SOT marker, field & SOD
 
-      *(ui16 *)buf = JP2K_MARKER::SOT;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::SOT;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Lsot);
+      *(ui16*)buf = swap_bytes_if_le(Lsot);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Isot);
+      *(ui16*)buf = swap_bytes_if_le(Isot);
       result &= file->write(&buf, 2) == 2;
-      *(ui32 *)buf = swap_byte(Psot);
+      *(ui32*)buf = swap_bytes_if_le(Psot);
       result &= file->write(&buf, 4) == 4;
       result &= file->write(&TPsot, 1) == 1;
       result &= file->write(&TNsot, 1) == 1;
@@ -2064,14 +2096,14 @@ namespace ojph
       char buf[4];
       bool result = true;
 
-      *(ui16 *)buf = JP2K_MARKER::SOT;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::SOT;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Lsot);
+      *(ui16*)buf = swap_bytes_if_le(Lsot);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Isot);
+      *(ui16*)buf = swap_bytes_if_le(Isot);
       result &= file->write(&buf, 2) == 2;
-      *(ui32 *)buf = swap_byte(payload_len + 14);
+      *(ui32*)buf = swap_bytes_if_le(payload_len + 14);
       result &= file->write(&buf, 4) == 4;
       result &= file->write(&TPsot, 1) == 1;
       result &= file->write(&TNsot, 1) == 1;
@@ -2087,74 +2119,46 @@ namespace ojph
         if (file->read(&Lsot, 2) != 2)
         {
           OJPH_INFO(0x00050091, "error reading SOT marker");
-          Lsot = 0;
-          Isot = 0;
-          Psot = 0;
-          TPsot = 0;
-          TNsot = 0;
+          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
-        Lsot = swap_byte(Lsot);
+        Lsot = swap_bytes_if_le(Lsot);
         if (Lsot != 10)
         {
           OJPH_INFO(0x00050092, "error in SOT length");
-          Lsot = 0;
-          Isot = 0;
-          Psot = 0;
-          TPsot = 0;
-          TNsot = 0;
+          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
         if (file->read(&Isot, 2) != 2)
         {
           OJPH_INFO(0x00050093, "error reading tile index");
-          Lsot = 0;
-          Isot = 0;
-          Psot = 0;
-          TPsot = 0;
-          TNsot = 0;
+          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
-        Isot = swap_byte(Isot);
+        Isot = swap_bytes_if_le(Isot);
         if (Isot == 0xFFFF)
         {
           OJPH_INFO(0x00050094, "tile index in SOT marker cannot be 0xFFFF");
-          Lsot = 0;
-          Isot = 0;
-          Psot = 0;
-          TPsot = 0;
-          TNsot = 0;
+          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
         if (file->read(&Psot, 4) != 4)
         {
           OJPH_INFO(0x00050095, "error reading SOT marker");
-          Lsot = 0;
-          Isot = 0;
-          Psot = 0;
-          TPsot = 0;
-          TNsot = 0;
+          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
-        Psot = swap_byte(Psot);
+        Psot = swap_bytes_if_le(Psot);
         if (file->read(&TPsot, 1) != 1)
         {
           OJPH_INFO(0x00050096, "error reading SOT marker");
-          Lsot = 0;
-          Isot = 0;
-          Psot = 0;
-          TPsot = 0;
-          TNsot = 0;
+          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
         if (file->read(&TNsot, 1) != 1)
         {
           OJPH_INFO(0x00050097, "error reading SOT marker");
-          Lsot = 0;
-          Isot = 0;
-          Psot = 0;
-          TPsot = 0;
-          TNsot = 0;
+          Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
       }
@@ -2162,17 +2166,17 @@ namespace ojph
       {
         if (file->read(&Lsot, 2) != 2)
           OJPH_ERROR(0x00050091, "error reading SOT marker");
-        Lsot = swap_byte(Lsot);
+        Lsot = swap_bytes_if_le(Lsot);
         if (Lsot != 10)
           OJPH_ERROR(0x00050092, "error in SOT length");
         if (file->read(&Isot, 2) != 2)
           OJPH_ERROR(0x00050093, "error reading SOT tile index");
-        Isot = swap_byte(Isot);
+        Isot = swap_bytes_if_le(Isot);
         if (Isot == 0xFFFF)
           OJPH_ERROR(0x00050094, "tile index in SOT marker cannot be 0xFFFF");
         if (file->read(&Psot, 4) != 4)
           OJPH_ERROR(0x00050095, "error reading SOT marker");
-        Psot = swap_byte(Psot);
+        Psot = swap_bytes_if_le(Psot);
         if (file->read(&TPsot, 1) != 1)
           OJPH_ERROR(0x00050096, "error reading SOT marker");
         if (file->read(&TNsot, 1) != 1)
@@ -2194,10 +2198,10 @@ namespace ojph
     {
       if (4 + 6 * num_pairs > 65535)
         OJPH_ERROR(0x000500B1, "Trying to allocate more than 65535 bytes for "
-                               "a TLM marker; this can be resolved by having more than "
-                               "one TLM marker, but the code does not support this. "
-                               "In any case, this limit means that we have 10922 "
-                               "tileparts or more, which is a huge number.");
+                   "a TLM marker; this can be resolved by having more than "
+                   "one TLM marker, but the code does not support this. "
+                   "In any case, this limit means that we have 10922 "
+                   "tileparts or more, which is a huge number.");
       this->num_pairs = num_pairs;
       pairs = store;
       Ltlm = (ui16)(4 + 6 * num_pairs);
@@ -2221,18 +2225,18 @@ namespace ojph
       char buf[4];
       bool result = true;
 
-      *(ui16 *)buf = JP2K_MARKER::TLM;
-      *(ui16 *)buf = swap_byte(*(ui16 *)buf);
+      *(ui16*)buf = JP2K_MARKER::TLM;
+      *(ui16*)buf = swap_bytes_if_le(*(ui16*)buf);
       result &= file->write(&buf, 2) == 2;
-      *(ui16 *)buf = swap_byte(Ltlm);
+      *(ui16*)buf = swap_bytes_if_le(Ltlm);
       result &= file->write(&buf, 2) == 2;
       result &= file->write(&Ztlm, 1) == 1;
       result &= file->write(&Stlm, 1) == 1;
       for (ui32 i = 0; i < num_pairs; ++i)
       {
-        *(ui16 *)buf = swap_byte(pairs[i].Ttlm);
+        *(ui16*)buf = swap_bytes_if_le(pairs[i].Ttlm);
         result &= file->write(&buf, 2) == 2;
-        *(ui32 *)buf = swap_byte(pairs[i].Ptlm);
+        *(ui32*)buf = swap_bytes_if_le(pairs[i].Ptlm);
         result &= file->write(&buf, 4) == 4;
       }
       return result;
@@ -2247,9 +2251,9 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
-    const param_dfs *param_dfs::get_dfs(int index) const
+    const param_dfs* param_dfs::get_dfs(int index) const
     {
-      const param_dfs *p = this;
+      const param_dfs* p = this;
       while (p && p->Sdfs != index)
         p = p->next;
       return p;
@@ -2259,9 +2263,9 @@ namespace ojph
     param_dfs::dfs_dwt_type param_dfs::get_dwt_type(ui32 decomp_level) const
     {
       decomp_level = ojph_min(decomp_level, Ids);
-      ui32 d = decomp_level - 1; // decomp_level starts from 1
-      ui32 idx = d >> 2;         // complete bytes
-      ui32 bits = d & 0x3;       // bit within the bytes
+      ui32 d = decomp_level - 1;          // decomp_level starts from 1
+      ui32 idx = d >> 2;                  // complete bytes
+      ui32 bits = d & 0x3;                // bit within the bytes
       ui32 val = (Ddfs[idx] >> (6 - 2 * bits)) & 0x3;
       return (dfs_dwt_type)val;
     }
@@ -2271,9 +2275,9 @@ namespace ojph
                                     ui32 subband) const
     {
       assert((resolution == 0 && subband == 0) ||
-             (resolution > 0 && subband > 0 && subband < 4));
+              (resolution > 0 && subband > 0 && subband < 4));
 
-      ui32 ns[4] = {0, 3, 1, 1};
+      ui32 ns[4] = { 0, 3, 1, 1 };
 
       ui32 idx = 0;
       if (resolution > 0)
@@ -2300,10 +2304,7 @@ namespace ojph
       {
         param_dfs::dfs_dwt_type type = get_dwt_type(decomp_level);
         if (type == BIDIR_DWT)
-        {
-          factor.x *= 2;
-          factor.y *= 2;
-        }
+        { factor.x *= 2; factor.y *= 2; }
         else if (type == HORZ_DWT)
           factor.x *= 2;
         else if (type == VERT_DWT)
@@ -2318,35 +2319,43 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     bool param_dfs::read(infile_base *file)
     {
-      if (Ldfs != 0)
-      { // this param_dfs is used
-        param_dfs *p = this;
+      if (Ldfs != 0) { // this param_dfs is used
+        param_dfs* p = this;
         while (p->next != NULL)
           p = p->next;
-        p->next = new param_dfs;
+        if (avail)
+        {
+          p->next = avail;
+          avail = avail->next;
+          p->next->init();
+        }
+        else
+          p->next = new param_dfs;
         p = p->next;
         return p->read(file);
       }
 
       if (file->read(&Ldfs, 2) != 2)
         OJPH_ERROR(0x000500D1, "error reading DFS-Ldfs parameter");
-      Ldfs = swap_byte(Ldfs);
+      Ldfs = swap_bytes_if_le(Ldfs);
       if (file->read(&Sdfs, 2) != 2)
         OJPH_ERROR(0x000500D2, "error reading DFS-Sdfs parameter");
-      Sdfs = swap_byte(Sdfs);
+      Sdfs = swap_bytes_if_le(Sdfs);
       if (Sdfs > 15)
         OJPH_ERROR(0x000500D3, "The DFS-Sdfs parameter is %d, which is "
-                               "larger than the permissible 15",
-                   Sdfs);
+          "larger than the permissible 15", Sdfs);
       ui8 t, l_Ids = 0;
       if (file->read(&l_Ids, 1) != 1)
         OJPH_ERROR(0x000500D4, "error reading DFS-Ids parameter");
+      if (l_Ids == 0)
+        OJPH_ERROR(0x000500D8,
+          "The value of the Ids member in the DFS marker segment cannot be 0");
       constexpr int max_Ddfs = sizeof(Ddfs) * 4;
       if (l_Ids > max_Ddfs)
         OJPH_INFO(0x000500D5, "The DFS-Ids parameter is %d; while this is "
-                              "valid, the number is unnessarily large -- you do not need more "
-                              "than %d.  Please contact me regarding this issue.",
-                  l_Ids, max_Ddfs);
+          "valid, the number is unnessarily large -- you do not need more "
+          "than %d.  Please contact me regarding this issue.",
+          l_Ids, max_Ddfs);
       Ids = l_Ids < max_Ddfs ? l_Ids : max_Ddfs;
       for (int i = 0; i < Ids; i += 4)
         if (file->read(&Ddfs[i / 4], 1) != 1)
@@ -2366,78 +2375,94 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
-    const param_atk *param_atk::get_atk(int index) const
+    param_atk* param_atk::get_atk(int index)
     {
-      const param_atk *p = this;
+      assert(top_atk == NULL);
+
+      if (Latk == 0)
+      {
+        // This atk object is not used, initialize it to either 0 (irv97)
+        // or 1 (rev53), and use it.  If index is not 0 nor 1, then index
+        // must have been read from file previously, otherwise it is an
+        // error.
+        if (index == 0) { this->init_irv97(); return this; }
+        else if (index == 1) { this->init_rev53(); return this; }
+      }
+
+      param_atk* p = this;
       while (p && p->get_index() != index)
         p = p->next;
+
+      if (p == NULL && (index == 0 || index == 1))
+      {
+        // The index was not found, add an atk object only if the index is
+        // either 0 or 1
+        p = add_object();
+        if (index == 0)
+          p->init_irv97();
+        else if (index == 1)
+          p->init_rev53();
+      }
+
       return p;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    bool param_atk::read_coefficient(infile_base *file, float &K)
+    bool param_atk::read_coefficient(infile_base *file, float &K, si32& bytes)
     {
       int coeff_type = get_coeff_type();
-      if (coeff_type == 0)
-      { // 8bit
+      if (coeff_type == 0) { // 8bit
         ui8 v;
-        if (file->read(&v, 1) != 1)
-          return false;
+        if (file->read(&v, 1) != 1) return false;
+        bytes -= 1;
         K = v;
       }
-      else if (coeff_type == 1)
-      { // 16bit
+      else if (coeff_type == 1) { // 16bit
         ui16 v;
-        if (file->read(&v, 2) != 2)
-          return false;
-        K = swap_byte(v);
+        if (file->read(&v, 2) != 2) return false;
+        bytes -= 2;
+        K = swap_bytes_if_le(v);
       }
-      else if (coeff_type == 2)
-      { // float
-        union
-        {
+      else if (coeff_type == 2) { // float
+        union {
           float f;
           ui32 i;
         } v;
-        if (file->read(&v.i, 4) != 4)
-          return false;
-        v.i = swap_byte(v.i);
+        if (file->read(&v.i, 4) != 4) return false;
+        bytes -= 4;
+        v.i = swap_bytes_if_le(v.i);
         K = v.f;
       }
-      else if (coeff_type == 3)
-      { // double
-        union
-        {
+      else if (coeff_type == 3) { // double
+        union {
           double d;
           ui64 i;
         } v;
-        if (file->read(&v.i, 8) != 8)
-          return false;
-        v.i = swap_byte(v.i);
+        if (file->read(&v.i, 8) != 8) return false;
+        bytes -= 8;
+        v.i = swap_bytes_if_le(v.i);
         K = (float)v.d;
       }
-      else if (coeff_type == 4)
-      { // 128 bit float
+      else if (coeff_type == 4) { // 128 bit float
         ui64 v, v1;
-        if (file->read(&v, 8) != 8)
-          return false;
-        if (file->read(&v1, 8) != 8)
-          return false; // v1 not needed
-        v = swap_byte(v);
+        if (file->read(&v, 8) != 8) return false;
+        bytes -= 8;
+        if (file->read(&v1, 8) != 8) return false; // v1 not needed
+        bytes -= 8;
+        v = swap_bytes_if_le(v);
 
-        union
-        {
+        union {
           float f;
           ui32 i;
         } s;
         // convert the MSB of 128b float to 32b float
         // 32b float has 1 sign bit, 8 exponent (offset 127), 23 mantissa
         // 128b float has 1 sign bit, 15 exponent (offset 16383), 112 mantissa
-        si32 e = (si32)((v >> 48) & 0x7FFF); // exponent
+        si32 e = (si32)((v >> 48) & 0x7FFF);   // exponent
         e -= 16383;
         e += 127;
-        e = e & 0xFF; // removes MSBs if negative
-        e <<= 23;     // move bits to their location
+        e = e & 0xFF;                          // removes MSBs if negative
+        e <<= 23;                              // move bits to their location
         s.i = 0;
         s.i |= ((ui32)(v >> 32) & 0x80000000); // copy sign bit
         s.i |= (ui32)e;                        // copy exponent
@@ -2447,23 +2472,22 @@ namespace ojph
       return true;
     }
 
+
     //////////////////////////////////////////////////////////////////////////
-    bool param_atk::read_coefficient(infile_base *file, si16 &K)
+    bool param_atk::read_coefficient(infile_base *file, si16 &K, si32& bytes)
     {
       int coeff_type = get_coeff_type();
-      if (coeff_type == 0)
-      {
+      if (coeff_type == 0) {
         si8 v;
-        if (file->read(&v, 1) != 1)
-          return false;
+        if (file->read(&v, 1) != 1) return false;
+        bytes -= 1;
         K = v;
       }
-      else if (coeff_type == 1)
-      {
+      else if (coeff_type == 1) {
         si16 v;
-        if (file->read(&v, 2) != 2)
-          return false;
-        K = (si16)swap_byte((ui16)v);
+        if (file->read(&v, 2) != 2) return false;
+        bytes -= 2;
+        K = (si16)swap_bytes_if_le((ui16)v);
       }
       else
         return false;
@@ -2473,43 +2497,47 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     bool param_atk::read(infile_base *file)
     {
-      if (Latk != 0)
-      { // this param_atk is used
-        param_atk *p = this;
-        while (p->next != NULL)
-          p = p->next;
-        p->next = new param_atk;
-        p->alloced_next = true;
-        p = p->next;
-        return p->read(file);
-      }
+      if (Latk != 0) // this param_atk is used
+        return add_object()->read(file);
 
       if (file->read(&Latk, 2) != 2)
         OJPH_ERROR(0x000500E1, "error reading ATK-Latk parameter");
-      Latk = swap_byte(Latk);
-      if (file->read(&Satk, 2) != 2)
+      Latk = swap_bytes_if_le(Latk);
+      si32 bytes = Latk - 2;
+      ojph::ui16 temp_Satk;
+      if (file->read(&temp_Satk, 2) != 2)
         OJPH_ERROR(0x000500E2, "error reading ATK-Satk parameter");
-      Satk = swap_byte(Satk);
-      if (is_m_init0() == false) // only even-indexed is supported
+      bytes -= 2;
+      temp_Satk = swap_bytes_if_le(temp_Satk);
+      int tmp_idx = temp_Satk & 0xFF;
+      if ((top_atk && top_atk->get_atk(tmp_idx) != NULL)
+        || tmp_idx == 0 || tmp_idx == 1)
+        OJPH_ERROR(0x000500F3, "ATK-Satk parameter sets ATK marker index to "
+          "the illegal value of %d. ATK-Satk should be in (2-255) and, I "
+          "believe, must not be repeated; otherwise, it would be unclear "
+          "what marker segment must be employed when an index is repeated.",
+          tmp_idx);
+      Satk = temp_Satk;
+      if (is_m_init0() == false)  // only even-indexed is supported
         OJPH_ERROR(0x000500E3, "ATK-Satk parameter sets m_init to 1, "
-                               "requiring odd-indexed subsequence in first reconstruction step, "
-                               "which is not supported yet.");
-      if (is_whole_sample() == false) // ARB filter not supported
+          "requiring odd-indexed subsequence in first reconstruction step, "
+          "which is not supported yet.");
+      if (is_whole_sample() == false)  // ARB filter not supported
         OJPH_ERROR(0x000500E4, "ATK-Satk parameter specified ARB filter, "
-                               "which is not supported yet.");
+          "which is not supported yet.");
       if (is_reversible() && get_coeff_type() >= 2) // reversible & float
         OJPH_ERROR(0x000500E5, "ATK-Satk parameter does not make sense. "
-                               "It employs floats with reversible filtering.");
-      if (is_using_ws_extension() == false) // only sym. ext is supported
+          "It employs floats with reversible filtering.");
+      if (is_using_ws_extension() == false)  // only sym. ext is supported
         OJPH_ERROR(0x000500E6, "ATK-Satk parameter requires constant "
-                               "boundary extension, which is not supported yet.");
+          "boundary extension, which is not supported yet.");
       if (is_reversible() == false)
-        if (read_coefficient(file, Katk) == false)
+        if (read_coefficient(file, Katk, bytes) == false)
           OJPH_ERROR(0x000500E7, "error reading ATK-Katk parameter");
       if (file->read(&Natk, 1) != 1)
         OJPH_ERROR(0x000500E8, "error reading ATK-Natk parameter");
-      if (Natk > max_steps)
-      {
+      bytes -= 1;
+      if (Natk > max_steps) {
         if (d != d_store) // was this allocated -- very unlikely
           delete[] d;
         d = new lifting_step[Natk];
@@ -2522,19 +2550,22 @@ namespace ojph
         {
           if (file->read(&d[s].rev.Eatk, 1) != 1)
             OJPH_ERROR(0x000500E9, "error reading ATK-Eatk parameter");
+          bytes -= 1;
           if (file->read(&d[s].rev.Batk, 2) != 2)
             OJPH_ERROR(0x000500EA, "error reading ATK-Batk parameter");
-          d[s].rev.Batk = (si16)swap_byte((ui16)d[s].rev.Batk);
+          bytes -= 2;
+          d[s].rev.Batk = (si16)swap_bytes_if_le((ui16)d[s].rev.Batk);
           ui8 LCatk;
           if (file->read(&LCatk, 1) != 1)
             OJPH_ERROR(0x000500EB, "error reading ATK-LCatk parameter");
+          bytes -= 1;
           if (LCatk == 0)
             OJPH_ERROR(0x000500EC, "Encountered a ATK-LCatk value of zero; "
-                                   "something is wrong.");
+              "something is wrong.");
           if (LCatk > 1)
             OJPH_ERROR(0x000500ED, "ATK-LCatk value greater than 1; "
-                                   "that is, a multitap filter is not supported");
-          if (read_coefficient(file, d[s].rev.Aatk) == false)
+              "that is, a multitap filter is not supported");
+          if (read_coefficient(file, d[s].rev.Aatk, bytes) == false)
             OJPH_ERROR(0x000500EE, "Error reding ATK-Aatk parameter");
         }
       }
@@ -2545,16 +2576,20 @@ namespace ojph
           ui8 LCatk;
           if (file->read(&LCatk, 1) != 1)
             OJPH_ERROR(0x000500EF, "error reading ATK-LCatk parameter");
+          bytes -= 1;
           if (LCatk == 0)
             OJPH_ERROR(0x000500F0, "Encountered a ATK-LCatk value of zero; "
-                                   "something is wrong.");
+              "something is wrong.");
           if (LCatk > 1)
             OJPH_ERROR(0x000500F1, "ATK-LCatk value greater than 1; "
-                                   "that is, a multitap filter is not supported.");
-          if (read_coefficient(file, d[s].irv.Aatk) == false)
+              "that is, a multitap filter is not supported.");
+          if (read_coefficient(file, d[s].irv.Aatk, bytes) == false)
             OJPH_ERROR(0x000500F2, "Error reding ATK-Aatk parameter");
         }
       }
+      if (bytes != 0)
+        OJPH_ERROR(0x000500F3, "The length of an ATK marker segment "
+          "(ATK-Latk) is not correct");
 
       return true;
     }
@@ -2562,7 +2597,7 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     void param_atk::init_irv97()
     {
-      Satk = 0x4a00; // illegal because ATK = 0
+      Satk = 0x4a00;     // illegal because ATK = 0
       Katk = (float)1.230174104914001;
       Natk = 4;
       // next is (A-4) in T.801 second line
@@ -2576,7 +2611,7 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     void param_atk::init_rev53()
     {
-      Satk = 0x5801; // illegal because ATK = 1
+      Satk = 0x5801;     // illegal because ATK = 1
       Natk = 2;
       // next is (A-4) in T.801 fourth line
       Latk = (ui16)(5 + 2 * Natk + sizeof(ui8) * (Natk + Natk));
@@ -2588,5 +2623,24 @@ namespace ojph
       d[1].rev.Eatk = 1;
     }
 
+    //////////////////////////////////////////////////////////////////////////
+    param_atk* param_atk::add_object()
+    {
+      assert(top_atk == NULL);
+      param_atk *p = this;
+      while (p->next != NULL)
+        p = p->next;
+      if (avail)
+      {
+        p->next = avail;
+        avail = avail->next;
+      }
+      else
+        p->next = new param_atk;
+      p = p->next;
+      p->init(this);
+      return p;
+    }
+
   } // !local namespace
-} // !ojph namespace
+}  // !ojph namespace

--- a/Native/Common/OpenJPH/codestream/ojph_params_local.h
+++ b/Native/Common/OpenJPH/codestream/ojph_params_local.h
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_PARAMS_LOCAL_H
 #define OJPH_PARAMS_LOCAL_H
 
@@ -46,8 +47,7 @@
 #include "ojph_arch.h"
 #include "ojph_message.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
   class outfile_base;
@@ -95,19 +95,17 @@ namespace ojph
   const char OJPH_PN_STRING_IMF[] = "IMF";
 
   ////////////////////////////////////////////////////////////////////////////
-  enum OJPH_TILEPART_DIVISIONS : ui32
-  {
+  enum OJPH_TILEPART_DIVISIONS: ui32 {
     OJPH_TILEPART_NO_DIVISIONS = 0x0, // no divisions to tile parts
-    OJPH_TILEPART_RESOLUTIONS = 0x1,
-    OJPH_TILEPART_COMPONENTS = 0x2,
-    OJPH_TILEPART_LAYERS = 0x4, // these are meaningless with HTJ2K
-    OJPH_TILEPART_MASK = 0x3,   // mask used for testing
+    OJPH_TILEPART_RESOLUTIONS  = 0x1,
+    OJPH_TILEPART_COMPONENTS   = 0x2,
+    OJPH_TILEPART_LAYERS       = 0x4, // these are meaningless with HTJ2K
+    OJPH_TILEPART_MASK         = 0x3, // mask used for testing
   };
 
-  namespace local
-  {
+  namespace local {
 
-    // defined here
+    //defined here
     struct param_siz;
     struct param_cod;
     struct param_qcd;
@@ -120,33 +118,33 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     enum JP2K_MARKER : ui16
     {
-      SOC = 0xFF4F, // start of codestream (required)
-      CAP = 0xFF50, // extended capability
-      SIZ = 0xFF51, // image and tile size (required)
-      COD = 0xFF52, // coding style default (required)
-      COC = 0xFF53, // coding style component
-      TLM = 0xFF55, // tile-part lengths
-      PRF = 0xFF56, // profile
-      PLM = 0xFF57, // packet length, main header
-      PLT = 0xFF58, // packet length, tile-part header
-      CPF = 0xFF59, // corresponding profile values
-      QCD = 0xFF5C, // qunatization default (required)
-      QCC = 0xFF5D, // quantization component
-      RGN = 0xFF5E, // region of interest
-      POC = 0xFF5F, // progression order change
-      PPM = 0xFF60, // packed packet headers, main header
-      PPT = 0xFF61, // packed packet headers, tile-part header
-      CRG = 0xFF63, // component registration
-      COM = 0xFF64, // comment
-      DFS = 0xFF72, // downsampling factor styles
-      ADS = 0xFF73, // arbitrary decomposition styles
-      NLT = 0xFF76, // non-linearity point transformation
-      ATK = 0xFF79, // arbitrary transformation kernels
-      SOT = 0xFF90, // start of tile-part
-      SOP = 0xFF91, // start of packet
-      EPH = 0xFF92, // end of packet
-      SOD = 0xFF93, // start of data
-      EOC = 0xFFD9, // end of codestream (required)
+      SOC = 0xFF4F, //start of codestream (required)
+      CAP = 0xFF50, //extended capability
+      SIZ = 0xFF51, //image and tile size (required)
+      COD = 0xFF52, //coding style default (required)
+      COC = 0xFF53, //coding style component
+      TLM = 0xFF55, //tile-part lengths
+      PRF = 0xFF56, //profile
+      PLM = 0xFF57, //packet length, main header
+      PLT = 0xFF58, //packet length, tile-part header
+      CPF = 0xFF59, //corresponding profile values
+      QCD = 0xFF5C, //qunatization default (required)
+      QCC = 0xFF5D, //quantization component
+      RGN = 0xFF5E, //region of interest
+      POC = 0xFF5F, //progression order change
+      PPM = 0xFF60, //packed packet headers, main header
+      PPT = 0xFF61, //packed packet headers, tile-part header
+      CRG = 0xFF63, //component registration
+      COM = 0xFF64, //comment
+      DFS = 0xFF72, //downsampling factor styles
+      ADS = 0xFF73, //arbitrary decomposition styles
+      NLT = 0xFF76, //non-linearity point transformation
+      ATK = 0xFF79, //arbitrary transformation kernels
+      SOT = 0xFF90, //start of tile-part
+      SOP = 0xFF91, //start of packet
+      EPH = 0xFF92, //end of packet
+      SOD = 0xFF93, //start of data
+      EOC = 0xFFD9, //end of codestream (required)
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -169,15 +167,17 @@ namespace ojph
       friend ::ojph::param_siz;
 
     public:
-      enum : ui16
-      {
-        RSIZ_NLT_FLAG = 0x200,
-        RSIZ_HT_FLAG = 0x4000,
-        RSIZ_EXT_FLAG = 0x8000,
+      enum : ui16 {
+        RSIZ_NLT_FLAG  =  0x200,
+        RSIZ_HT_FLAG   = 0x4000,
+        RSIZ_EXT_FLAG  = 0x8000,
       };
 
     public:
-      param_siz()
+      param_siz() { init(); }
+      ~param_siz() { destroy(); }
+
+      void init()
       {
         Lsiz = Csiz = 0;
         Xsiz = Ysiz = XOsiz = YOsiz = XTsiz = YTsiz = XTOsiz = YTOsiz = 0;
@@ -188,14 +188,11 @@ namespace ojph
         dfs = NULL;
         Rsiz = RSIZ_HT_FLAG;
         cptr = store;
-        old_Csiz = 4;
+        old_Csiz = sizeof(store) / sizeof(siz_comp_info);
       }
 
-      ~param_siz()
-      {
-        if (cptr != store)
-          delete[] cptr;
-      }
+      void destroy()
+      { if (cptr != store) { delete[] cptr; cptr = NULL; } }
 
       void set_num_components(ui32 num_comps)
       {
@@ -210,7 +207,7 @@ namespace ojph
         memset(cptr, 0, sizeof(local::siz_comp_info) * num_comps);
       }
 
-      void set_comp_info(ui32 comp_num, const point &downsampling,
+      void set_comp_info(ui32 comp_num, const point& downsampling,
                          ui32 bit_depth, bool is_signed)
       {
         assert(comp_num < Csiz);
@@ -220,24 +217,35 @@ namespace ojph
         cptr[comp_num].YRsiz = (ui8)downsampling.y;
       }
 
-      void check_validity(const param_cod &cod)
-      {
-        this->cod = &cod;
+      void set_image_extent(point dims) { Xsiz = dims.x; Ysiz = dims.y; }
+      point get_image_extent() const { return point(Xsiz, Ysiz); }
+      void set_tile_size(size s) { XTsiz = s.w; YTsiz = s.h; }
+      size get_tile_size() const { return size(XTsiz, YTsiz); }
+      void set_image_offset(point offset)
+      { XOsiz = offset.x; YOsiz = offset.y; }
+      point get_image_offset() const
+      { return point(XOsiz, YOsiz); }
+      void set_tile_offset(point offset)
+      { XTOsiz = offset.x; YTOsiz = offset.y; }
+      point get_tile_offset() const
+      { return point(XTOsiz, YTOsiz); }
 
-        if (XTsiz == 0 && YTsiz == 0)
-        {
-          XTsiz = Xsiz + XOsiz;
-          YTsiz = Ysiz + YOsiz;
-        }
+      void set_cod(const param_cod& cod) { this->cod = &cod; }
+
+      void check_validity()
+      {
         if (Xsiz == 0 || Ysiz == 0 || XTsiz == 0 || YTsiz == 0)
           OJPH_ERROR(0x00040001,
-                     "You cannot set image extent nor tile size to zero");
+            "Image extent and/or tile size cannot be zero");
         if (XTOsiz > XOsiz || YTOsiz > YOsiz)
           OJPH_ERROR(0x00040002,
-                     "tile offset has to be smaller than image offset");
+            "Tile offset has to be smaller than the image offset");
         if (XTsiz + XTOsiz <= XOsiz || YTsiz + YTOsiz <= YOsiz)
           OJPH_ERROR(0x00040003,
-                     "the top left tile must intersect with the image");
+            "The top left tile must intersect with the image");
+        if (Xsiz <= XOsiz || Ysiz <= YOsiz)
+          OJPH_ERROR(0x00040004,
+            "The image extent must be larger than the image offset");
       }
 
       ui16 get_num_components() const { return Csiz; }
@@ -260,20 +268,14 @@ namespace ojph
       bool write(outfile_base *file);
       void read(infile_base *file);
 
-      void link(const param_cod *cod)
-      {
-        this->cod = cod;
-      }
+      void link(const param_cod* cod)
+      { this->cod = cod; }
 
-      void link(const param_dfs *dfs)
-      {
-        this->dfs = dfs;
-      }
+      void link(const param_dfs* dfs)
+      { this->dfs = dfs; }
 
       void set_skipped_resolutions(ui32 skipped_resolutions)
-      {
-        this->skipped_resolutions = skipped_resolutions;
-      }
+      { this->skipped_resolutions = skipped_resolutions; }
 
       ui32 get_width(ui32 comp_num) const
       {
@@ -294,25 +296,17 @@ namespace ojph
       point get_recon_downsampling(ui32 comp_num) const;
       point get_recon_size(ui32 comp_num) const;
       ui32 get_recon_width(ui32 comp_num) const
-      {
-        return get_recon_size(comp_num).x;
-      }
+      { return get_recon_size(comp_num).x; }
       ui32 get_recon_height(ui32 comp_num) const
-      {
-        return get_recon_size(comp_num).y;
-      }
+      { return get_recon_size(comp_num).y; }
 
       bool is_ws_kern_support_needed() { return ws_kern_support_needed; }
       bool is_dfs_support_needed() { return dfs_support_needed; }
 
       void set_Rsiz_flag(ui16 flag)
-      {
-        Rsiz |= flag;
-      }
+      { Rsiz |= flag; }
       void reset_Rsiz_flag(ui16 flag)
-      {
-        Rsiz = (ui16)(Rsiz & ~flag);
-      }
+      { Rsiz = (ui16)(Rsiz & ~flag); }
 
     private:
       ui16 Lsiz;
@@ -326,7 +320,7 @@ namespace ojph
       ui32 XTOsiz;
       ui32 YTOsiz;
       ui16 Csiz;
-      siz_comp_info *cptr;
+      siz_comp_info* cptr;
 
     private:
       ui32 skipped_resolutions;
@@ -334,10 +328,10 @@ namespace ojph
       siz_comp_info store[4];
       bool ws_kern_support_needed;
       bool dfs_support_needed;
-      const param_cod *cod;
-      const param_dfs *dfs;
-      param_siz(const param_siz &) = delete;            // prevent copy constructor
-      param_siz &operator=(const param_siz &) = delete; // prevent copy
+      const param_cod* cod;
+      const param_dfs* dfs;
+      param_siz(const param_siz&) = delete; //prevent copy constructor
+      param_siz& operator=(const param_siz&) = delete; //prevent copy
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -349,8 +343,7 @@ namespace ojph
     ///////////////////////////////////////////////////////////////////////////
     struct cod_SPcod
     {
-      cod_SPcod()
-      {
+      cod_SPcod() {
         num_decomp = 5;
         block_width = 4;    // 64
         block_height = 4;   // 64
@@ -364,17 +357,12 @@ namespace ojph
       ui8 block_height;
       ui8 block_style;
       ui8 wavelet_trans;
-      ui8 precinct_size[33]; // num_decomp is in [0,32]
+      ui8 precinct_size[33]; //num_decomp is in [0,32]
 
       size get_log_block_dims() const
-      {
-        return size(block_width + 2, block_height + 2);
-      }
+      { return size(block_width + 2, block_height + 2); }
       size get_block_dims() const
-      {
-        size t = get_log_block_dims();
-        return size(1 << t.w, 1 << t.h);
-      }
+      { size t = get_log_block_dims(); return size(1 << t.w, 1 << t.h); }
       size get_log_precinct_size(ui32 res_num) const
       {
         assert(res_num <= num_decomp);
@@ -397,55 +385,43 @@ namespace ojph
     {
       // serves for both COD and COC markers
       friend ::ojph::param_cod;
-      enum default_comp_num : ui16
-      {
+      enum default_comp_num : ui16 {
         OJPH_COD_UNKNOWN = 65534,
         OJPH_COD_DEFAULT = 65535
       };
 
       ////////////////////////////////////////
-      enum BLOCK_CODING_STYLES
-      {
+      enum BLOCK_CODING_STYLES {
         VERT_CAUSAL_MODE = 0x8,
         HT_MODE = 0x40
       };
       ////////////////////////////////////////
-      enum cod_type : ui8
-      {
+      enum cod_type : ui8 {
         UNDEFINED = 0,
-        COD_MAIN = 1,
-        COC_MAIN = 2,
-        COD_TILE = 3, // not implemented
-        COC_TILE = 4  // not implemented
+        COD_MAIN  = 1,
+        COC_MAIN  = 2,
+        COD_TILE  = 3,  // not implemented
+        COC_TILE  = 4   // not implemented
       };
       ////////////////////////////////////////
-      enum dwt_type : ui8
-      {
+      enum dwt_type : ui8 {
         DWT_IRV97 = 0,
         DWT_REV53 = 1,
       };
 
     public: // COD_MAIN and COC_MAIN common functions
-      ////////////////////////////////////////
-      param_cod(param_cod *top_cod = NULL, ui16 comp_idx = OJPH_COD_DEFAULT)
-      {
-        type = top_cod ? COC_MAIN : COD_MAIN;
-        Lcod = 0;
-        Scod = 0;
-        next = NULL;
-        atk = NULL;
-        this->top_cod = top_cod;
-        this->comp_idx = comp_idx;
-      }
+      param_cod(param_cod* top_cod = NULL, ui16 comp_idx = OJPH_COD_DEFAULT)
+      { avail = NULL; init(top_cod, comp_idx); }
+      ~param_cod() { destroy(); }
 
       ////////////////////////////////////////
-      ~param_cod()
+      void restart()
       {
-        if (next)
-        {
-          delete next;
-          next = NULL;
-        }
+        param_cod** p = &avail; // move next to the end of avail
+        while (*p != NULL)
+          p = &((*p)->next);
+        *p = next;
+        this->init(top_cod, OJPH_COD_DEFAULT);
       }
 
       ////////////////////////////////////////
@@ -464,17 +440,17 @@ namespace ojph
       }
 
       ////////////////////////////////////////
-      void check_validity(const param_siz &siz)
+      void check_validity(const param_siz& siz)
       {
         assert(type == COD_MAIN);
 
-        // check that colour transform and match number of components and
-        //  downsampling
+        //check that colour transform and match number of components and
+        // downsampling
         int num_comps = siz.get_num_components();
         if (SGCod.mc_trans == 1 && num_comps < 3)
           OJPH_ERROR(0x00040011,
-                     "color transform can only be employed when the image has 3 or "
-                     "more color components");
+            "color transform can only be employed when the image has 3 or "
+            "more color components");
 
         if (SGCod.mc_trans == 1)
         {
@@ -487,25 +463,29 @@ namespace ojph
           for (ui32 i = 1; i < 3; ++i)
           {
             point p1 = siz.get_downsampling(i);
-            test_downsampling = test_downsampling || (p.x != p1.x || p.y != p1.y);
-            test_bit_depth = test_bit_depth || (bit_depth != siz.get_bit_depth(i));
-            test_signedness = test_signedness || (is_signed != siz.is_signed(i));
+            test_downsampling = test_downsampling
+              || (p.x != p1.x || p.y != p1.y);
+            test_bit_depth = test_bit_depth
+              || (bit_depth != siz.get_bit_depth(i));
+            test_signedness = test_signedness
+              || (is_signed != siz.is_signed(i));
           }
           if (test_downsampling)
             OJPH_ERROR(0x00040012,
-                       "when color transform is used, the first 3 colour components "
-                       "must have the same downsampling factor.");
+              "when color transform is used, the first 3 colour components "
+              "must have the same downsampling factor.");
           if (test_bit_depth)
             OJPH_ERROR(0x00040014,
-                       "when color transform is used, the first 3 colour components "
-                       "must have the same bit depth.");
+              "when color transform is used, the first 3 colour components "
+              "must have the same bit depth.");
           if (test_signedness)
             OJPH_ERROR(0x00040015,
-                       "when color transform is used, the first 3 colour components "
-                       "must have the same signedness (signed or unsigned).");
+              "when color transform is used, the first 3 colour components "
+              "must have the same signedness (signed or unsigned).");
+
         }
 
-        // check the progression order matches downsampling
+        //check the progression order matches downsampling
         if (SGCod.prog_order == OJPH_PO_RPCL ||
             SGCod.prog_order == OJPH_PO_PCRL)
         {
@@ -515,7 +495,7 @@ namespace ojph
             point r = siz.get_downsampling(i);
             if (r.x & (r.x - 1) || r.y & (r.y - 1))
               OJPH_ERROR(0x00040013, "For RPCL and PCRL progression orders,"
-                                     "component downsampling factors have to be powers of 2");
+                "component downsampling factors have to be powers of 2");
           }
         }
       }
@@ -532,8 +512,7 @@ namespace ojph
           else
             return SPcod.num_decomp;
         }
-        else
-        {
+        else {
           assert(0);
           return 0; // just in case
         }
@@ -541,21 +520,15 @@ namespace ojph
 
       ////////////////////////////////////////
       size get_block_dims() const
-      {
-        return SPcod.get_block_dims();
-      }
+      { return SPcod.get_block_dims(); }
 
       ////////////////////////////////////////
       size get_log_block_dims() const
-      {
-        return SPcod.get_log_block_dims();
-      }
+      { return SPcod.get_log_block_dims(); }
 
       ////////////////////////////////////////
       ui8 get_wavelet_kern() const
-      {
-        return SPcod.wavelet_trans;
-      }
+      { return SPcod.wavelet_trans; }
 
       ////////////////////////////////////////
       bool is_reversible() const;
@@ -603,9 +576,7 @@ namespace ojph
 
       ////////////////////////////////////////
       bool get_block_vertical_causality() const
-      {
-        return (SPcod.block_style & local::param_cod::VERT_CAUSAL_MODE) != 0;
-      }
+      { return (SPcod.block_style & local::param_cod::VERT_CAUSAL_MODE) != 0; }
 
       ////////////////////////////////////////
       bool write(outfile_base *file);
@@ -617,35 +588,31 @@ namespace ojph
       void read(infile_base *file);
 
       ////////////////////////////////////////
-      void read_coc(infile_base *file, ui32 num_comps, param_cod *top_cod);
+      void read_coc(infile_base* file, ui32 num_comps, param_cod* top_cod);
 
       ////////////////////////////////////////
-      void update_atk(const param_atk *atk);
+      void update_atk(param_atk* atk);
 
       ////////////////////////////////////////
-      const param_cod *get_coc(ui32 comp_idx) const;
+      const param_cod* get_coc(ui32 comp_idx) const;
 
       ////////////////////////////////////////
-      param_cod *get_coc(ui32 comp_idx);
+      param_cod* get_coc(ui32 comp_idx);
 
       ////////////////////////////////////////
-      param_cod *add_coc_object(ui32 comp_idx);
+      param_cod* add_coc_object(ui32 comp_idx);
 
       ////////////////////////////////////////
-      const param_atk *access_atk() const { return atk; }
+      const param_atk* access_atk() const { return atk; }
 
     public: // COC_MAIN only functions
       ////////////////////////////////////////
       bool is_dfs_defined() const
-      {
-        return (SPcod.num_decomp & 0x80) != 0;
-      }
+      { return (SPcod.num_decomp & 0x80) != 0; }
 
       ////////////////////////////////////////
-      ui16 get_dfs_index() const // cannot be more than 15
-      {
-        return SPcod.num_decomp & 0xF;
-      }
+      ui16 get_dfs_index() const  // cannot be more than 15
+      { return SPcod.num_decomp & 0xF; }
 
       ////////////////////////////////////////
       ui32 get_comp_idx() const
@@ -656,21 +623,47 @@ namespace ojph
       }
 
     private:
-      bool internal_write_coc(outfile_base *file, ui32 num_comps);
+      ////////////////////////////////////////
+      void init(param_cod* top_cod, ui16 comp_idx)
+      {
+        type = top_cod ? COC_MAIN : COD_MAIN;
+        Lcod = 0;
+        Scod = 0;
+        next = NULL;
+        atk = NULL;
+        this->top_cod = top_cod;
+        this->comp_idx = comp_idx;
+      }
 
       ////////////////////////////////////////
-    private:                // Common variables
+      void destroy() {
+        if (avail)
+          delete avail;
+        if (next) {
+          delete next;
+          next = NULL;
+        }
+      }
+
+    private:
+      bool internal_write_coc(outfile_base *file, ui32 num_comps);
+
+    ////////////////////////////////////////
+    private: // Common variables
       cod_type type;        // The type of this cod structure
       ui16 Lcod;            // serves as Lcod and Scod
       ui8 Scod;             // serves as Scod and Scoc
       cod_SGcod SGCod;      // Used in COD and copied to COC
       cod_SPcod SPcod;      // serves as SPcod and SPcoc
-      param_cod *next;      // to chain coc parameters to cod
-      const param_atk *atk; // used to read transform information
+      param_cod* next;      // to chain coc parameters to cod
+      const param_atk* atk; // used to read transform information
 
-    private:              // COC only variables
-      param_cod *top_cod; // parent COD structure
-      ui16 comp_idx;      // component index of this COC structure
+    private: // COC only variables
+      param_cod* top_cod;   // parent COD structure
+      ui16 comp_idx;        // component index of this COC structure
+
+    private: // on restart, already allocated param_cod objs are stored here
+      param_cod* avail;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -684,24 +677,59 @@ namespace ojph
     {
       // serves for both QCD and QCC markers
       friend ::ojph::param_qcd;
-      enum default_comp_num : ui16
-      {
+      enum default_comp_num : ui16 {
         OJPH_QCD_UNKNOWN = 65534,
         OJPH_QCD_DEFAULT = 65535
       };
 
       ////////////////////////////////////////
-      enum qcd_type : ui8
-      {
+      enum qcd_type : ui8 {
         UNDEFINED = 0,
-        QCD_MAIN = 1,
-        QCC_MAIN = 2,
-        QCD_TILE = 3, // not implemented
-        QCC_TILE = 4  // not implemented
+        QCD_MAIN  = 1,
+        QCC_MAIN  = 2,
+        QCD_TILE  = 3,  // not implemented
+        QCC_TILE  = 4   // not implemented
       };
 
     public:
-      param_qcd(param_qcd *top_qcd = NULL, ui16 comp_idx = OJPH_QCD_DEFAULT)
+      param_qcd(param_qcd* top_qcd = NULL, ui16 comp_idx = OJPH_QCD_DEFAULT)
+      { avail = NULL; init(top_qcd, comp_idx); }
+      ~param_qcd() { destroy(); }
+
+      ////////////////////////////////////////
+      void restart()
+      {
+        param_qcd** p = &avail; // move next to the end of avail
+        while (*p != NULL)
+          p = &((*p)->next);
+        *p = next;
+        this->init(top_qcd, OJPH_QCD_DEFAULT);
+      }
+
+      void check_validity(const param_siz& siz, const param_cod& cod);
+      void set_delta(float delta) { base_delta = delta; }
+      void set_delta(ui32 comp_idx, float delta);
+      ui32 get_num_guard_bits() const;
+      ui32 get_MAGB() const;
+      ui32 get_Kmax(const param_dfs* dfs, ui32 num_decompositions,
+                    ui32 resolution, ui32 subband) const;
+      ui32 propose_precision(const param_cod* cod) const;
+      float get_irrev_delta(const param_dfs* dfs,
+                            ui32 num_decompositions, ui32 comp_num,
+                            ui32 resolution, ui32 subband) const;
+      bool write(outfile_base *file);
+      bool write_qcc(outfile_base *file, ui32 num_comps);
+      void read(infile_base *file);
+      void read_qcc(infile_base *file, ui32 num_comps);
+
+      param_qcd* get_qcc(ui32 comp_idx);
+      const param_qcd* get_qcc(ui32 comp_idx) const;
+      param_qcd* add_qcc_object(ui32 comp_idx);
+      ui16 get_comp_idx() const { return comp_idx; }
+
+    private:
+      ////////////////////////////////////////
+      void init(param_qcd* top_qcd, ui16 comp_idx)
       {
         type = top_qcd ? QCC_MAIN : QCD_MAIN;
         Lqcd = 0;
@@ -714,35 +742,17 @@ namespace ojph
         this->top_qcd = top_qcd;
         this->comp_idx = comp_idx;
       }
-      ~param_qcd()
-      {
+
+      ////////////////////////////////////////
+      void destroy() {
+        if (avail)
+          delete avail;
         if (next)
         {
           delete next;
           next = NULL;
         }
       }
-
-      void check_validity(const param_siz &siz, const param_cod &cod);
-      void set_delta(float delta) { base_delta = delta; }
-      void set_delta(ui32 comp_idx, float delta);
-      ui32 get_num_guard_bits() const;
-      ui32 get_MAGB() const;
-      ui32 get_Kmax(const param_dfs *dfs, ui32 num_decompositions,
-                    ui32 resolution, ui32 subband) const;
-      ui32 propose_precision(const param_cod *cod) const;
-      float get_irrev_delta(const param_dfs *dfs,
-                            ui32 num_decompositions,
-                            ui32 resolution, ui32 subband) const;
-      bool write(outfile_base *file);
-      bool write_qcc(outfile_base *file, ui32 num_comps);
-      void read(infile_base *file);
-      void read_qcc(infile_base *file, ui32 num_comps);
-
-      param_qcd *get_qcc(ui32 comp_idx);
-      const param_qcd *get_qcc(ui32 comp_idx) const;
-      param_qcd *add_qcc_object(ui32 comp_idx);
-      ui16 get_comp_idx() const { return comp_idx; }
 
     private:
       void set_rev_quant(ui32 num_decomps, ui32 bit_depth,
@@ -753,13 +763,9 @@ namespace ojph
       void trim_non_existing_components(ui32 num_comps);
 
       ui8 decode_SPqcd(ui8 v) const
-      {
-        return (ui8)(v >> 3);
-      }
+      { return (ui8)(v >> 3); }
       ui8 encode_SPqcd(ui8 v) const
-      {
-        return (ui8)(v << 3);
-      }
+      { return (ui8)(v << 3); }
 
     private: // QCD variables
       qcd_type type;
@@ -779,6 +785,9 @@ namespace ojph
 
     private: // QCC only variables
       ui16 comp_idx;
+
+    private:  // on restart, already allocated param_qcd objs are stored here
+      param_qcd* avail;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -793,40 +802,53 @@ namespace ojph
     {
       using special_comp_num = ojph::param_nlt::special_comp_num;
       using nonlinearity = ojph::param_nlt::nonlinearity;
-
     public:
-      param_nlt()
+      param_nlt() { avail = NULL; init(); }
+      ~param_nlt() { destroy(); }
+
+      ////////////////////////////////////////
+      void restart()
+      {
+        param_nlt** p = &avail; // move next to the end of avail
+        while (*p != NULL)
+          p = &((*p)->next);
+        *p = next;
+        this->init();
+      }
+
+      void check_validity(param_siz& siz);
+      void set_nonlinear_transform(ui32 comp_num, ui8 nl_type);
+      bool get_nonlinear_transform(ui32 comp_num, ui8& bit_depth,
+                                   bool& is_signed, ui8& nl_type) const;
+      bool write(outfile_base* file) const;
+      void read(infile_base* file);
+
+    private:
+      ////////////////////////////////////////
+      void init()
       {
         Lnlt = 6;
         Cnlt = special_comp_num::ALL_COMPS; // default
         BDnlt = 0;
         Tnlt = nonlinearity::OJPH_NLT_UNDEFINED;
-        enabled = false;
-        next = NULL;
-        alloced_next = false;
+        enabled = false; next = NULL;
       }
 
-      ~param_nlt()
+      ////////////////////////////////////////
+      void destroy()
       {
-        if (next && alloced_next)
-        {
+        if (avail)
+          delete avail;
+        if (next) {
           delete next;
-          alloced_next = false;
           next = NULL;
         }
       }
 
-      void check_validity(param_siz &siz);
-      void set_nonlinear_transform(ui32 comp_num, ui8 nl_type);
-      bool get_nonlinear_transform(ui32 comp_num, ui8 &bit_depth,
-                                   bool &is_signed, ui8 &nl_type) const;
-      bool write(outfile_base *file) const;
-      void read(infile_base *file);
-
     private:
-      const param_nlt *get_nlt_object(ui32 comp_num) const;
-      param_nlt *get_nlt_object(ui32 comp_num);
-      param_nlt *add_object(ui32 comp_num);
+      const param_nlt* get_nlt_object(ui32 comp_num) const;
+      param_nlt* get_nlt_object(ui32 comp_num);
+      param_nlt* add_object(ui32 comp_num);
       bool is_any_enabled() const;
       void trim_non_existing_components(ui32 num_comps);
 
@@ -836,14 +858,15 @@ namespace ojph
       ui8 BDnlt;         // Decoded image component bit depth parameter
       ui8 Tnlt;          // Type of non-linearity
       bool enabled;      // true if this object is used
-      param_nlt *next;   // for chaining NLT markers
-      bool alloced_next; // true if next was allocated, not just set to an
-                         // existing object
+      param_nlt* next;   // for chaining NLT markers
 
       // The top level param_nlt object is not allocated, but as part of
       // codestream, and is used to manage allocated next objects.
       // next holds a list of param_nlt objects, which are managed by the top
       // param_nlt object.
+
+    private: // on restart, already allocated param_nlt objs are stored here
+      param_nlt* avail;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -860,10 +883,10 @@ namespace ojph
       {
         memset(this, 0, sizeof(param_cap));
         Lcap = 8;
-        Pcap = 0x00020000; // for jph, Pcap^15 must be set, the 15th MSB
+        Pcap = 0x00020000; //for jph, Pcap^15 must be set, the 15th MSB
       }
 
-      void check_validity(const param_cod &cod, const param_qcd &qcd)
+      void check_validity(const param_cod& cod, const param_qcd& qcd)
       {
         if (cod.get_wavelet_kern() == param_cod::DWT_REV53)
           Ccap[0] &= 0xFFDF;
@@ -887,8 +910,9 @@ namespace ojph
     private:
       ui16 Lcap;
       ui32 Pcap;
-      ui16 Ccap[32]; // a maximum of 32
+      ui16 Ccap[32]; //a maximum of 32
     };
+
 
     ///////////////////////////////////////////////////////////////////////////
     //
@@ -904,7 +928,7 @@ namespace ojph
                 ui8 tile_part_index = 0, ui8 num_tile_parts = 0)
       {
         Lsot = 10;
-        Psot = payload_length + 12; // total = payload + SOT marker
+        Psot = payload_length + 12; //total = payload + SOT marker
         Isot = tile_idx;
         TPsot = tile_part_index;
         TNsot = num_tile_parts;
@@ -916,8 +940,8 @@ namespace ojph
 
       ui16 get_tile_index() const { return Isot; }
       ui32 get_payload_length() const { return Psot > 0 ? Psot - 12 : 0; }
-      ui8 get_tile_part_index() const { return TPsot; }
-      ui8 get_num_tile_parts() const { return TNsot; }
+      ui8  get_tile_part_index() const { return TPsot; }
+      ui8  get_num_tile_parts() const { return TNsot; }
 
     private:
       ui16 Lsot;
@@ -943,13 +967,8 @@ namespace ojph
       };
 
     public:
-      param_tlm()
-      {
-        pairs = NULL;
-        num_pairs = 0;
-        next_pair_index = 0;
-      };
-      void init(ui32 num_pairs, Ttlm_Ptlm_pair *store);
+      param_tlm() { pairs = NULL; num_pairs = 0; next_pair_index = 0; };
+      void init(ui32 num_pairs, Ttlm_Ptlm_pair* store);
 
       void set_next_pair(ui16 Ttlm, ui32 Ptlm);
       bool write(outfile_base *file);
@@ -958,7 +977,7 @@ namespace ojph
       ui16 Ltlm;
       ui8 Ztlm;
       ui8 Stlm;
-      Ttlm_Ptlm_pair *pairs;
+      Ttlm_Ptlm_pair* pairs;
       ui32 num_pairs;
       ui32 next_pair_index;
     };
@@ -973,32 +992,32 @@ namespace ojph
     struct param_dfs
     {
     public:
-      enum dfs_dwt_type : ui8
-      {
-        NO_DWT = 0,    // no wavelet transform
-        BIDIR_DWT = 1, // bidirectional DWT (this the conventional DWT)
-        HORZ_DWT = 2,  // horizontal only DWT transform
-        VERT_DWT = 3,  // vertical only DWT transform
+      enum dfs_dwt_type : ui8 {
+        NO_DWT    = 0,  // no wavelet transform
+        BIDIR_DWT = 1,  // bidirectional DWT (this the conventional DWT)
+        HORZ_DWT  = 2,  // horizontal only DWT transform
+        VERT_DWT  = 3,  // vertical only DWT transform
       };
 
     public: // member functions
-      param_dfs() { init(); }
-      ~param_dfs()
+      param_dfs() { avail = NULL; init(); }
+      ~param_dfs() { destroy(); }
+
+      ////////////////////////////////////////
+      void restart()
       {
-        if (next)
-          delete next;
+        param_dfs** p = &avail; // move next to the end of avail
+        while (*p != NULL)
+          p = &((*p)->next);
+        *p = next;
+        this->init();
       }
-      void init()
-      {
-        Ldfs = Sdfs = Ids = 0;
-        memset(Ddfs, 0, sizeof(Ddfs));
-        next = NULL;
-      }
+
       bool read(infile_base *file);
       bool exists() const { return Ldfs != 0; }
 
       // get_dfs return a dfs structure Sdfs == index, or NULL if not found
-      const param_dfs *get_dfs(int index) const;
+      const param_dfs* get_dfs(int index) const;
       // decomp_level is the decomposition level, starting from 1 for highest
       // resolution to num_decomps for the coarsest resolution
       dfs_dwt_type get_dwt_type(ui32 decomp_level) const;
@@ -1006,13 +1025,32 @@ namespace ojph
                            ui32 subband) const;
       point get_res_downsamp(ui32 skipped_resolutions) const;
 
-    private:           // member variables
+    private:
+      ////////////////////////////////////////
+      void init()
+      { Ldfs = Sdfs = Ids = 0; memset(Ddfs, 0, sizeof(Ddfs)); next = NULL; }
+
+      ////////////////////////////////////////
+      void destroy()
+      {
+        if (avail)
+          delete avail;
+        if (next) {
+          delete next;
+          next = NULL;
+        }
+      }
+
+    private: // member variables
       ui16 Ldfs;       // length of the segment marker
       ui16 Sdfs;       // index of this DFS marker segment
       ui8 Ids;         // number of elements in Ddfs, 2 bits per sub-level
       ui8 Ddfs[8];     // a string defining number of decomposition sub-levels
                        // 8 bytes should be enough for 32 levels
-      param_dfs *next; // used for linking other dfs segments
+      param_dfs* next; // used for linking other dfs segments
+
+    private: // on restart, already allocated param_dfs objs are stored here
+      param_dfs* avail;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1024,22 +1062,19 @@ namespace ojph
     ///////////////////////////////////////////////////////////////////////////
     // data structures used by param_atk
 
-    union lifting_step
-    {
-      struct irv_data
-      {
+    union lifting_step {
+      struct irv_data {
         // si8 Oatk;     // only for arbitrary filter
         // ui8 LCatk;    // number of lifting coefficients in a step
-        float Aatk; // lifting coefficient
+        float Aatk;      // lifting coefficient
       };
 
-      struct rev_data
-      {
+      struct rev_data {
         // si8 Oatk;     // only for arbitrary filter, offset of filter
-        ui8 Eatk;  // only for reversible, epsilon, the power of 2
-        si16 Batk; // only for reversible, beta, the additive residue
+        ui8 Eatk;        // only for reversible, epsilon, the power of 2
+        si16 Batk;       // only for reversible, beta, the additive residue
         // ui8 LCatk;    // number of lifting coefficients in a step
-        si16 Aatk; // lifting coefficient
+        si16 Aatk;       // lifting coefficient
       };
 
       irv_data irv;
@@ -1050,53 +1085,56 @@ namespace ojph
     {
       // Limitations:
       // Arbitrary filters (ARB) are not supported
-      // Up to 6 steps are supported -- more than 6 are not supported
       // Only one coefficient per step -- first order filter
       // Only even-indexed subsequence in first reconstruction step,
       //   m_init = 0 is supported
-
     public: // member functions
-      param_atk() { init(); }
+      param_atk()
+      {
+        d = d_store;
+        max_steps = sizeof(d_store) / sizeof(lifting_step);
+        init(NULL);
+      }
       ~param_atk()
       {
-        if (next && alloced_next)
-        {
+        if (avail) {
+          delete avail;
+          avail = NULL;
+        }
+        if (next) {
           delete next;
           next = NULL;
         }
-        if (d != NULL && d != d_store)
-        {
+        if (d != NULL && d != d_store) {
           delete[] d;
-          init(false);
+          d = d_store;
+          max_steps = sizeof(d_store) / sizeof(lifting_step);
         }
       }
+
+      ////////////////////////////////////////
+      void restart()
+      {
+        assert(top_atk == NULL);
+
+        Latk = Satk = 0;
+        Katk = 0.0f;
+        Natk = 0;
+        if (d == NULL || d == d_store) {
+          d = d_store;
+          max_steps = sizeof(d_store) / sizeof(lifting_step);
+        }
+        memset(d, 0, max_steps * sizeof(lifting_step));
+
+        param_atk** p = &avail; // move next to the end of avail
+        while (*p != NULL)
+          p = &((*p)->next);
+        *p = next;
+
+        next = NULL;
+      }
+
       bool read(infile_base *file);
-      bool read_coefficient(infile_base *file, float &K);
-      bool read_coefficient(infile_base *file, si16 &K);
-      void init(bool clear_all = true)
-      {
-        if (clear_all)
-        {
-          Latk = Satk = 0;
-          Katk = 0.0f;
-          Natk = 0;
-          d = NULL;
-          max_steps = 0;
-          memset(d_store, 0, sizeof(d_store));
-          next = NULL;
-          alloced_next = false;
-        }
-        d = d_store;
-        max_steps = sizeof(d_store) / sizeof(lifting_step);
-      }
-      void init_irv97();
-      void init_rev53();
-      void link(param_atk *next)
-      {
-        assert(this->next == NULL);
-        this->next = next;
-        alloced_next = false;
-      }
 
       ui8 get_index() const { return (ui8)(Satk & 0xFF); }
       int get_coeff_type() const { return (Satk >> 8) & 0x7; }
@@ -1104,27 +1142,51 @@ namespace ojph
       bool is_reversible() const { return (Satk & 0x1000) != 0; }
       bool is_m_init0() const { return (Satk & 0x2000) == 0; }
       bool is_using_ws_extension() const { return (Satk & 0x4000) != 0; }
-      const param_atk *get_atk(int index) const;
-      const lifting_step *get_step(ui32 s) const
-      {
-        assert(s < Natk);
-        return d + s;
-      }
+      param_atk* get_atk(int index);
+      const lifting_step* get_step(ui32 s) const
+      { assert(s < Natk); return d + s; }
       ui32 get_num_steps() const { return Natk; }
       float get_K() const { return Katk; }
 
-    private:                   // member variables
-      ui16 Latk;               // structure length
-      ui16 Satk;               // carries a variety of information
-      float Katk;              // only for irreversible scaling factor K
-      ui8 Natk;                // number of lifting steps
-      lifting_step *d;         // pointer to data, initialized to d_store
-      int max_steps;           // maximum number of steps without memory allocation
-      lifting_step d_store[6]; // lifting step coefficient
-      param_atk *next;         // used for chaining if more than one atk segment
-                               // exist in the codestream
-      bool alloced_next;       // true if next was allocated, not just set to an
-                               // existing object
+  private:
+      /////////////////////////////////////
+      void init(param_atk* top_atk)
+      {
+        Latk = Satk = 0;
+        Katk = 0.0f;
+        Natk = 0;
+        if (d == NULL || d == d_store) {
+          d = d_store;
+          max_steps = sizeof(d_store) / sizeof(lifting_step);
+        }
+        memset(d, 0, max_steps * sizeof(lifting_step));
+        next = NULL;
+        this->top_atk = top_atk;
+        avail = NULL;
+      }
+  private:
+      bool read_coefficient(infile_base *file, float &K, si32& bytes);
+      bool read_coefficient(infile_base *file, si16 &K, si32& bytes);
+
+      void init_irv97();
+      void init_rev53();
+      param_atk* add_object();
+
+    private: // member variables
+      ui16 Latk;         // structure length
+      ui16 Satk;         // carries a variety of information
+      float Katk;        // only for irreversible scaling factor K
+      ui8 Natk;          // number of lifting steps
+      lifting_step* d;   // pointer to data, initialized to d_store
+      ui32 max_steps;    // maximum number of steps without memory allocation
+      lifting_step d_store[6];   // lifting step coefficient
+      param_atk* next;   // used for chaining if more than one atk segment
+                         // exist in the codestream
+      param_atk* top_atk;// This is the top level atk, from which all atk
+                         // objects are derived
+
+    private: // on restart, already allocated param_atk objs are stored here
+      param_atk* avail;
     };
   } // !local namespace
 } // !ojph namespace

--- a/Native/Common/OpenJPH/codestream/ojph_precinct.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_precinct.cpp
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 
@@ -47,8 +48,8 @@
 #include "ojph_bitbuffer_write.h"
 #include "ojph_bitbuffer_read.h"
 
-namespace ojph
-{
+
+namespace ojph {
 
   namespace local
   {
@@ -56,12 +57,12 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     struct tag_tree
     {
-      void init(ui8 *buf, ui32 *lev_idx, ui32 num_levels, size s, int init_val)
+      void init(ui8* buf, ui32 *lev_idx, ui32 num_levels, size s, int init_val)
       {
-        for (ui32 i = 0; i <= num_levels; ++i) // on extra level
+        for (ui32 i = 0; i <= num_levels; ++i) //on extra level
           levs[i] = buf + lev_idx[i];
         for (ui32 i = num_levels + 1; i < 16; ++i)
-          levs[i] = (ui8 *)INT_MAX; // make it crash on error
+          levs[i] = (ui8*)INT_MAX; //make it crash on error
         width = s.w;
         height = s.h;
         for (ui32 i = 0; i < num_levels; ++i)
@@ -73,13 +74,13 @@ namespace ojph
         this->num_levels = num_levels;
       }
 
-      ui8 *get(ui32 x, ui32 y, ui32 lev)
+      ui8* get(ui32 x, ui32 y, ui32 lev)
       {
         return levs[lev] + (x + y * ((width + (1 << lev) - 1) >> lev));
       }
 
       ui32 width, height, num_levels;
-      ui8 *levs[16]; // you cannot have this high number of levels
+      ui8* levs[16]; // you cannot have this high number of levels
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -90,13 +91,13 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    ui32 precinct::prepare_precinct(int tag_tree_size, ui32 *lev_idx,
-                                    mem_elastic_allocator *elastic)
+    ui32 precinct::prepare_precinct(int tag_tree_size, ui32* lev_idx,
+                                    mem_elastic_allocator* elastic)
     {
       bit_write_buf bb;
       coded_lists *cur_coded_list = NULL;
-      ui32 cb_bytes = 0; // cb_bytes;
-      ui32 ph_bytes = 0; // precinct header size
+      ui32 cb_bytes = 0; //cb_bytes;
+      ui32 ph_bytes = 0; //precinct header size
       int num_skipped_subbands = 0;
       for (int s = 0; s < 4; ++s)
       {
@@ -107,17 +108,17 @@ namespace ojph
           continue;
 
         ui32 num_levels = 1 +
-                          ojph_max(log2ceil(cb_idxs[s].siz.w), log2ceil(cb_idxs[s].siz.h));
+          ojph_max(log2ceil(cb_idxs[s].siz.w), log2ceil(cb_idxs[s].siz.h));
 
-        // create quad trees for inclusion and missing msbs
+        //create quad trees for inclusion and missing msbs
         tag_tree inc_tag, inc_tag_flags, mmsb_tag, mmsb_tag_flags;
         inc_tag.init(scratch, lev_idx, num_levels, cb_idxs[s].siz, 255);
         inc_tag_flags.init(scratch + tag_tree_size,
-                           lev_idx, num_levels, cb_idxs[s].siz, 0);
-        mmsb_tag.init(scratch + (tag_tree_size << 1),
-                      lev_idx, num_levels, cb_idxs[s].siz, 255);
-        mmsb_tag_flags.init(scratch + (tag_tree_size << 1) + tag_tree_size,
-                            lev_idx, num_levels, cb_idxs[s].siz, 0);
+          lev_idx, num_levels, cb_idxs[s].siz, 0);
+        mmsb_tag.init(scratch + (tag_tree_size<<1),
+          lev_idx, num_levels, cb_idxs[s].siz, 255);
+        mmsb_tag_flags.init(scratch + (tag_tree_size<<1) + tag_tree_size,
+          lev_idx, num_levels, cb_idxs[s].siz, 0);
         ui32 band_width = bands[s].num_blocks.w;
         coded_cb_header *cp = bands[s].coded_cbs;
         cp += cb_idxs[s].org.x + cb_idxs[s].org.y * band_width;
@@ -126,60 +127,60 @@ namespace ojph
           for (ui32 x = 0; x < cb_idxs[s].siz.w; ++x)
           {
             coded_cb_header *p = cp + x;
-            *inc_tag.get(x, y, 0) = (p->next_coded == NULL); // 1 if true
+            *inc_tag.get(x, y, 0) = (p->next_coded == NULL); //1 if true
             *mmsb_tag.get(x, y, 0) = (ui8)p->missing_msbs;
           }
           cp += band_width;
         }
         for (ui32 lev = 1; lev < num_levels; ++lev)
         {
-          ui32 height = (cb_idxs[s].siz.h + (1 << lev) - 1) >> lev;
-          ui32 width = (cb_idxs[s].siz.w + (1 << lev) - 1) >> lev;
+          ui32 height = (cb_idxs[s].siz.h + (1<<lev) - 1) >> lev;
+          ui32 width = (cb_idxs[s].siz.w + (1<<lev) - 1) >> lev;
           for (ui32 y = 0; y < height; ++y)
           {
             for (ui32 x = 0; x < width; ++x)
             {
               ui8 t1, t2;
-              t1 = ojph_min(*inc_tag.get(x << 1, y << 1, lev - 1),
-                            *inc_tag.get((x << 1) + 1, y << 1, lev - 1));
-              t2 = ojph_min(*inc_tag.get(x << 1, (y << 1) + 1, lev - 1),
-                            *inc_tag.get((x << 1) + 1, (y << 1) + 1, lev - 1));
+              t1 = ojph_min(*inc_tag.get(x<<1, y<<1, lev-1),
+                            *inc_tag.get((x<<1) + 1, y<<1, lev-1));
+              t2 = ojph_min(*inc_tag.get(x<<1, (y<<1) + 1, lev-1),
+                            *inc_tag.get((x<<1) + 1, (y<<1) + 1, lev-1));
               *inc_tag.get(x, y, lev) = ojph_min(t1, t2);
               *inc_tag_flags.get(x, y, lev) = 0;
-              t1 = ojph_min(*mmsb_tag.get(x << 1, y << 1, lev - 1),
-                            *mmsb_tag.get((x << 1) + 1, y << 1, lev - 1));
-              t2 = ojph_min(*mmsb_tag.get(x << 1, (y << 1) + 1, lev - 1),
-                            *mmsb_tag.get((x << 1) + 1, (y << 1) + 1, lev - 1));
+              t1 = ojph_min(*mmsb_tag.get(x<<1, y<<1, lev-1),
+                            *mmsb_tag.get((x<<1) + 1, y<<1, lev-1));
+              t2 = ojph_min(*mmsb_tag.get(x<<1, (y<<1) + 1, lev-1),
+                            *mmsb_tag.get((x<<1) + 1, (y<<1) + 1, lev-1));
               *mmsb_tag.get(x, y, lev) = ojph_min(t1, t2);
               *mmsb_tag_flags.get(x, y, lev) = 0;
             }
           }
         }
-        *inc_tag.get(0, 0, num_levels) = 0;
-        *inc_tag_flags.get(0, 0, num_levels) = 0;
-        *mmsb_tag.get(0, 0, num_levels) = 0;
-        *mmsb_tag_flags.get(0, 0, num_levels) = 0;
-        if (*inc_tag.get(0, 0, num_levels - 1) != 0) // empty subband
+        *inc_tag.get(0,0,num_levels) = 0;
+        *inc_tag_flags.get(0,0,num_levels) = 0;
+        *mmsb_tag.get(0,0,num_levels) = 0;
+        *mmsb_tag_flags.get(0,0,num_levels) = 0;
+        if (*inc_tag.get(0, 0, num_levels-1) != 0) //empty subband
         {
-          if (coded) // non empty precinct, tag tree top is 0
+          if (coded) //non empty precinct, tag tree top is 0
             bb_put_bits(&bb, 0, 1, elastic, cur_coded_list, ph_bytes);
           else
             ++num_skipped_subbands;
           continue;
         }
-        // now we are in a position to code
+        //now we are in a position to code
         if (coded == NULL)
         {
           bb_init(&bb, elastic, cur_coded_list);
           coded = cur_coded_list;
-          // store non empty packet
+          //store non empty packet
           bb_put_bit(&bb, 1, elastic, cur_coded_list, ph_bytes);
 
           // if the first one or two subbands are empty (has codeblocks but
           // no data in them), we need to code them here.
           bb_put_bits(&bb, 0, num_skipped_subbands, elastic, cur_coded_list,
                       ph_bytes);
-          num_skipped_subbands = 0; // this line is not needed
+          num_skipped_subbands = 0; //this line is not needed
         }
 
         ui32 width = cb_idxs[s].siz.w;
@@ -190,77 +191,77 @@ namespace ojph
           cp += cb_idxs[s].org.x + (y + cb_idxs[s].org.y) * band_width;
           for (ui32 x = 0; x < width; ++x, ++cp)
           {
-            // inclusion bits
+            //inclusion bits
             for (ui32 cur_lev = num_levels; cur_lev > 0; --cur_lev)
             {
               ui32 levm1 = cur_lev - 1;
-              // check sent
-              if (*inc_tag_flags.get(x >> levm1, y >> levm1, levm1) == 0)
+              //check sent
+              if (*inc_tag_flags.get(x>>levm1, y>>levm1, levm1) == 0)
               {
-                ui32 skipped = *inc_tag.get(x >> levm1, y >> levm1, levm1);
-                skipped -= *inc_tag.get(x >> cur_lev, y >> cur_lev, cur_lev);
+                ui32 skipped = *inc_tag.get(x>>levm1, y>>levm1, levm1);
+                skipped -= *inc_tag.get(x>>cur_lev, y>>cur_lev, cur_lev);
                 assert(skipped <= 1); // for HTJ2K, this should 0 or 1
                 bb_put_bits(&bb, 1 - skipped, 1,
-                            elastic, cur_coded_list, ph_bytes);
-                *inc_tag_flags.get(x >> levm1, y >> levm1, levm1) = 1;
+                  elastic, cur_coded_list, ph_bytes);
+                *inc_tag_flags.get(x>>levm1, y>>levm1, levm1) = 1;
               }
-              if (*inc_tag.get(x >> levm1, y >> levm1, levm1) > 0)
+              if (*inc_tag.get(x>>levm1, y>>levm1, levm1) > 0)
                 break;
             }
 
-            if (cp->num_passes == 0) // empty codeblock
+            if (cp->num_passes == 0) //empty codeblock
               continue;
 
-            // missing msbs
+            //missing msbs
             for (ui32 cur_lev = num_levels; cur_lev > 0; --cur_lev)
             {
               ui32 levm1 = cur_lev - 1;
-              // check sent
-              if (*mmsb_tag_flags.get(x >> levm1, y >> levm1, levm1) == 0)
+              //check sent
+              if (*mmsb_tag_flags.get(x>>levm1, y>>levm1, levm1) == 0)
               {
-                int num_zeros = *mmsb_tag.get(x >> levm1, y >> levm1, levm1);
-                num_zeros -= *mmsb_tag.get(x >> cur_lev, y >> cur_lev, cur_lev);
+                int num_zeros = *mmsb_tag.get(x>>levm1, y>>levm1, levm1);
+                num_zeros -= *mmsb_tag.get(x>>cur_lev, y>>cur_lev, cur_lev);
                 bb_put_zeros(&bb, num_zeros,
-                             elastic, cur_coded_list, ph_bytes);
+                  elastic, cur_coded_list, ph_bytes);
                 bb_put_bits(&bb, 1, 1,
-                            elastic, cur_coded_list, ph_bytes);
-                *mmsb_tag_flags.get(x >> levm1, y >> levm1, levm1) = 1;
+                  elastic, cur_coded_list, ph_bytes);
+                *mmsb_tag_flags.get(x>>levm1, y>>levm1, levm1) = 1;
               }
             }
 
-            // number of coding passes
+            //number of coding passes
             switch (cp->num_passes)
             {
-            case 3:
-              bb_put_bits(&bb, 12, 4, elastic, cur_coded_list, ph_bytes);
-              break;
-            case 2:
-              bb_put_bits(&bb, 2, 2, elastic, cur_coded_list, ph_bytes);
-              break;
-            case 1:
-              bb_put_bits(&bb, 0, 1, elastic, cur_coded_list, ph_bytes);
-              break;
-            default:
-              assert(0);
+              case 3:
+                bb_put_bits(&bb, 12, 4, elastic, cur_coded_list, ph_bytes);
+                break;
+              case 2:
+                bb_put_bits(&bb, 2, 2, elastic, cur_coded_list, ph_bytes);
+                break;
+              case 1:
+                bb_put_bits(&bb, 0, 1, elastic, cur_coded_list, ph_bytes);
+                break;
+              default:
+                assert(0);
             }
 
-            // pass lengths
-            // either one, two, or three passes, but only one or two lengths
+            //pass lengths
+            //either one, two, or three passes, but only one or two lengths
             int bits1 = 32 - (int)count_leading_zeros(cp->pass_length[0]);
-            int extra_bit = cp->num_passes > 2 ? 1 : 0; // for 2nd length
+            int extra_bit = cp->num_passes > 2 ? 1 : 0; //for 2nd length
             int bits2 = 0;
             if (cp->num_passes > 1)
               bits2 = 32 - (int)count_leading_zeros(cp->pass_length[1]);
             int bits = ojph_max(bits1, bits2 - extra_bit) - 3;
             bits = ojph_max(bits, 0);
-            bb_put_bits(&bb, 0xFFFFFFFEu, bits + 1,
-                        elastic, cur_coded_list, ph_bytes);
+            bb_put_bits(&bb, 0xFFFFFFFEu, bits+1,
+              elastic, cur_coded_list, ph_bytes);
 
-            bb_put_bits(&bb, cp->pass_length[0], bits + 3,
-                        elastic, cur_coded_list, ph_bytes);
+            bb_put_bits(&bb, cp->pass_length[0], bits+3,
+              elastic, cur_coded_list, ph_bytes);
             if (cp->num_passes > 1)
-              bb_put_bits(&bb, cp->pass_length[1], bits + 3 + extra_bit,
-                          elastic, cur_coded_list, ph_bytes);
+              bb_put_bits(&bb, cp->pass_length[1], bits+3+extra_bit,
+                elastic, cur_coded_list, ph_bytes);
 
             cb_bytes += cp->pass_length[0] + cp->pass_length[1];
           }
@@ -281,7 +282,7 @@ namespace ojph
     {
       if (coded)
       {
-        // write packet header
+        //write packet header
         coded_lists *ccl = coded;
         while (ccl)
         {
@@ -289,7 +290,7 @@ namespace ojph
           ccl = ccl->next_list;
         }
 
-        // write codeblocks
+        //write codeblocks
         for (int s = 0; s < 4; ++s)
         {
           if (bands[s].empty)
@@ -316,14 +317,15 @@ namespace ojph
       }
       else
       {
-        // empty packet
+        //empty packet
         char buf = 0x00;
         file->write(&buf, 1);
       }
     }
 
+
     //////////////////////////////////////////////////////////////////////////
-    void precinct::parse(int tag_tree_size, ui32 *lev_idx,
+    void precinct::parse(int tag_tree_size, ui32* lev_idx,
                          mem_elastic_allocator *elastic,
                          ui32 &data_left, infile_base *file,
                          bool skipped)
@@ -343,34 +345,30 @@ namespace ojph
         if (cb_idxs[s].siz.w == 0 || cb_idxs[s].siz.h == 0)
           continue;
 
-        if (empty_packet) // one bit to check if the packet is empty
+        if (empty_packet) //one bit to check if the packet is empty
         {
           ui32 bit;
           bb_read_bit(&bb, bit);
-          if (bit == 0) // empty packet
-          {
-            bb_terminate(&bb, uses_eph);
-            data_left = bb.bytes_left;
-            return;
-          }
+          if (bit == 0) //empty packet
+          { bb_terminate(&bb, uses_eph); data_left = bb.bytes_left; return; }
           empty_packet = false;
         }
 
         ui32 num_levels = 1 +
-                          ojph_max(log2ceil(cb_idxs[s].siz.w), log2ceil(cb_idxs[s].siz.h));
+          ojph_max(log2ceil(cb_idxs[s].siz.w), log2ceil(cb_idxs[s].siz.h));
 
-        // create quad trees for inclusion and missing msbs
+        //create quad trees for inclusion and missing msbs
         tag_tree inc_tag, inc_tag_flags, mmsb_tag, mmsb_tag_flags;
         inc_tag.init(scratch, lev_idx, num_levels, cb_idxs[s].siz, 0);
         *inc_tag.get(0, 0, num_levels) = 0;
         inc_tag_flags.init(scratch + tag_tree_size, lev_idx, num_levels,
-                           cb_idxs[s].siz, 0);
+          cb_idxs[s].siz, 0);
         *inc_tag_flags.get(0, 0, num_levels) = 0;
-        mmsb_tag.init(scratch + (tag_tree_size << 1), lev_idx, num_levels,
-                      cb_idxs[s].siz, 0);
+        mmsb_tag.init(scratch + (tag_tree_size<<1), lev_idx, num_levels,
+          cb_idxs[s].siz, 0);
         *mmsb_tag.get(0, 0, num_levels) = 0;
-        mmsb_tag_flags.init(scratch + (tag_tree_size << 1) + tag_tree_size,
-                            lev_idx, num_levels, cb_idxs[s].siz, 0);
+        mmsb_tag_flags.init(scratch + (tag_tree_size<<1) + tag_tree_size,
+          lev_idx, num_levels, cb_idxs[s].siz, 0);
         *mmsb_tag_flags.get(0, 0, num_levels) = 0;
 
         //
@@ -383,26 +381,23 @@ namespace ojph
           cp += cb_idxs[s].org.x + (y + cb_idxs[s].org.y) * band_width;
           for (ui32 x = 0; x < width; ++x, ++cp)
           {
-            // process inclusion
+            //process inclusion
             bool empty_cb = false;
             for (ui32 cl = num_levels; cl > 0; --cl)
             {
               ui32 cur_lev = cl - 1;
-              empty_cb = *inc_tag.get(x >> cur_lev, y >> cur_lev, cur_lev) == 1;
+              empty_cb = *inc_tag.get(x>>cur_lev, y>>cur_lev, cur_lev) == 1;
               if (empty_cb)
                 break;
-              // check received
-              if (*inc_tag_flags.get(x >> cur_lev, y >> cur_lev, cur_lev) == 0)
+              //check received
+              if (*inc_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) == 0)
               {
                 ui32 bit;
                 if (bb_read_bit(&bb, bit) == false)
-                {
-                  data_left = 0;
-                  throw "error reading from file p1";
-                }
+                { data_left = 0; throw "error reading from file p1"; }
                 empty_cb = (bit == 0);
-                *inc_tag.get(x >> cur_lev, y >> cur_lev, cur_lev) = (ui8)(1 - bit);
-                *inc_tag_flags.get(x >> cur_lev, y >> cur_lev, cur_lev) = 1;
+                *inc_tag.get(x>>cur_lev, y>>cur_lev, cur_lev) = (ui8)(1 - bit);
+                *inc_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) = 1;
               }
               if (empty_cb)
                 break;
@@ -411,74 +406,56 @@ namespace ojph
             if (empty_cb)
               continue;
 
-            // process missing msbs
+            //process missing msbs
             ui32 mmsbs = 0;
             for (ui32 levp1 = num_levels; levp1 > 0; --levp1)
             {
               ui32 cur_lev = levp1 - 1;
-              mmsbs = *mmsb_tag.get(x >> levp1, y >> levp1, levp1);
-              // check received
-              if (*mmsb_tag_flags.get(x >> cur_lev, y >> cur_lev, cur_lev) == 0)
+              mmsbs = *mmsb_tag.get(x>>levp1, y>>levp1, levp1);
+              //check received
+              if (*mmsb_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) == 0)
               {
                 ui32 bit = 0;
                 while (bit == 0)
                 {
                   if (bb_read_bit(&bb, bit) == false)
-                  {
-                    data_left = 0;
-                    throw "error reading from file p2";
-                  }
+                  { data_left = 0; throw "error reading from file p2"; }
                   mmsbs += 1 - bit;
                 }
-                *mmsb_tag.get(x >> cur_lev, y >> cur_lev, cur_lev) = (ui8)mmsbs;
-                *mmsb_tag_flags.get(x >> cur_lev, y >> cur_lev, cur_lev) = 1;
+                *mmsb_tag.get(x>>cur_lev, y>>cur_lev, cur_lev) = (ui8)mmsbs;
+                *mmsb_tag_flags.get(x>>cur_lev, y>>cur_lev, cur_lev) = 1;
               }
             }
 
             if (mmsbs > cp->Kmax)
               throw "error in parsing a tile header; "
-                    "missing msbs are larger or equal to Kmax. The most likely "
-                    "cause is a corruption in the bitstream.";
+              "missing msbs are larger or equal to Kmax. The most likely "
+              "cause is a corruption in the bitstream.";
             cp->missing_msbs = mmsbs;
 
-            // get number of passes
+            //get number of passes
             ui32 bit, num_passes = 1;
             if (bb_read_bit(&bb, bit) == false)
-            {
-              data_left = 0;
-              throw "error reading from file p3";
-            }
+            { data_left = 0; throw "error reading from file p3"; }
             if (bit)
             {
               num_passes = 2;
               if (bb_read_bit(&bb, bit) == false)
-              {
-                data_left = 0;
-                throw "error reading from file p4";
-              }
+              { data_left = 0; throw "error reading from file p4"; }
               if (bit)
               {
                 if (bb_read_bits(&bb, 2, bit) == false)
-                {
-                  data_left = 0;
-                  throw "error reading from file p5";
-                }
+                { data_left = 0; throw "error reading from file p5";  }
                 num_passes = 3 + bit;
                 if (bit == 3)
                 {
                   if (bb_read_bits(&bb, 5, bit) == false)
-                  {
-                    data_left = 0;
-                    throw "error reading from file p6";
-                  }
+                  { data_left = 0; throw "error reading from file p6"; }
                   num_passes = 6 + bit;
                   if (bit == 31)
                   {
                     if (bb_read_bits(&bb, 7, bit) == false)
-                    {
-                      data_left = 0;
-                      throw "error reading from file p7";
-                    }
+                    { data_left = 0; throw "error reading from file p7"; }
                     num_passes = 37 + bit;
                   }
                 }
@@ -486,49 +463,54 @@ namespace ojph
             }
             cp->num_passes = num_passes;
 
-            // parse pass lengths
-            // for one pass, one length, but for 2 or 3 passes, two lengths
-            int extra_bit = cp->num_passes > 2 ? 1 : 0;
-            int bits1 = 3;
+            // Parse pass lengths
+            // When number of passes is one, one length.
+            // When number of passes is two or three, two lengths.
+            // When number of passes > 3, we have place holder passes;
+            // In this case, subtract multiples of 3 from the number of
+            // passes; for example, if we have 10 passes, we subtract 9,
+            // producing 1 pass.
+
+            // 1 => 1, 2 => 2, 3 => 3, 4 => 1, 5 => 2, 6 => 3
+            ui32 num_phld_passes = (num_passes - 1) / 3;
+            cp->missing_msbs += num_phld_passes;
+
+            num_phld_passes *= 3;
+            cp->num_passes = num_passes - num_phld_passes;
+            cp->pass_length[0] = cp->pass_length[1] = 0;
+
+            int Lblock = 3;
             bit = 1;
             while (bit)
             {
+              // add any extra bits here
               if (bb_read_bit(&bb, bit) == false)
-              {
-                data_left = 0;
-                throw "error reading from file p8";
-              }
-              bits1 += bit;
+              { data_left = 0; throw "error reading from file p8"; }
+              Lblock += bit;
             }
 
-            if (bb_read_bits(&bb, bits1, bit) == false)
-            {
-              data_left = 0;
-              throw "error reading from file p9";
-            }
+            int bits = Lblock + 31 -
+              (int)count_leading_zeros(num_phld_passes + 1);
+            if (bb_read_bits(&bb, bits, bit) == false)
+            { data_left = 0; throw "error reading from file p9"; }
             if (bit < 2)
-            {
               throw "The cleanup segment of an HT codeblock cannot contain "
-                    "less than 2 bytes";
-            }
+                "less than 2 bytes";
             if (bit >= 65535)
-            {
               throw "The cleanup segment of an HT codeblock must contain "
-                    "less than 65535 bytes";
-            }
+                "less than 65535 bytes";
             cp->pass_length[0] = bit;
-            if (num_passes > 1)
+
+            if (cp->num_passes > 1)
             {
-              if (bb_read_bits(&bb, bits1 + extra_bit, bit) == false)
-              {
-                data_left = 0;
-                throw "error reading from file p10";
-              }
+              //bits = Lblock + 31 - count_leading_zeros(cp->num_passes - 1);
+              // The following is simpler than the above, I think?
+              bits = Lblock + (cp->num_passes > 2 ? 1 : 0);
+              if (bb_read_bits(&bb, bits, bit) == false)
+              { data_left = 0; throw "error reading from file p10"; }
               if (bit >= 2047)
-              {
                 throw "The refinement segment (SigProp and MagRep passes) of "
-                      "an HT codeblock must contain less than 2047 bytes";
-              }
+                  "an HT codeblock must contain less than 2047 bytes";
               cp->pass_length[1] = bit;
             }
           }
@@ -538,10 +520,10 @@ namespace ojph
       { // all subbands are empty
         ui32 bit = 0;
         bb_read_bit(&bb, bit);
-        // assert(bit == 0);
+        //assert(bit == 0);
       }
       bb_terminate(&bb, uses_eph);
-      // read codeblock data
+      //read codeblock data
       for (int s = 0; s < 4; ++s)
       {
         if (bands[s].empty)
@@ -562,7 +544,7 @@ namespace ojph
               if (num_bytes)
               {
                 if (skipped)
-                { // no need to read
+                { //no need to read
                   si64 cur_loc = file->tell();
                   ui32 t = ojph_min(num_bytes, bb.bytes_left);
                   file->seek(t, infile_base::OJPH_SEEK_CUR);
@@ -575,7 +557,7 @@ namespace ojph
                 {
                   if (!bb_read_chunk(&bb, num_bytes, cp->next_coded, elastic))
                   {
-                    // no need to decode a broken codeblock
+                    //no need to decode a broken codeblock
                     cp->pass_length[0] = cp->pass_length[1] = 0;
                     data_left = 0;
                   }
@@ -589,5 +571,6 @@ namespace ojph
       }
       data_left = bb.bytes_left;
     }
+
   }
 }

--- a/Native/Common/OpenJPH/codestream/ojph_precinct.h
+++ b/Native/Common/OpenJPH/codestream/ojph_precinct.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,48 +35,44 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_PRECINCT_H
 #define OJPH_PRECINCT_H
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class mem_elastic_allocator;
   struct coded_lists;
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    // defined here
+    //defined here
     class subband;
-
+    
     //////////////////////////////////////////////////////////////////////////
     struct precinct
     {
-      precinct()
-      {
-        scratch = NULL;
-        bands = NULL;
-        coded = NULL;
+      precinct() {
+        scratch = NULL; bands = NULL; coded = NULL;
         may_use_sop = uses_eph = false;
       }
-      ui32 prepare_precinct(int tag_tree_size, ui32 *lev_idx,
+      ui32 prepare_precinct(int tag_tree_size, ui32* lev_idx,
                             mem_elastic_allocator *elastic);
       void write(outfile_base *file);
-      void parse(int tag_tree_size, ui32 *lev_idx,
+      void parse(int tag_tree_size, ui32* lev_idx,
                  mem_elastic_allocator *elastic,
-                 ui32 &data_left, infile_base *file, bool skipped);
+                 ui32& data_left, infile_base *file, bool skipped);
 
       ui8 *scratch;
-      point img_point; // the precinct projected to full resolution
-      rect cb_idxs[4]; // indices of codeblocks
-      subband *bands;  // the subbands
-      coded_lists *coded;
+      point img_point; //the precinct projected to full resolution
+      rect cb_idxs[4]; //indices of codeblocks
+      subband *bands;  //the subbands
+      coded_lists* coded;
       bool may_use_sop, uses_eph;
     };
 

--- a/Native/Common/OpenJPH/codestream/ojph_resolution.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_resolution.cpp
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 #include <new>
@@ -50,45 +51,39 @@
 
 #include "../transform/ojph_transform.h"
 
-namespace ojph
-{
+namespace ojph {
 
   namespace local
   {
     //////////////////////////////////////////////////////////////////////////
-    void resolution::pre_alloc(codestream *codestream, const rect &res_rect,
-                               const rect &recon_res_rect,
+    void resolution::pre_alloc(codestream* codestream, const rect& res_rect,
+                               const rect& recon_res_rect,
                                ui32 comp_num, ui32 res_num)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
-      const param_cod *cdp = codestream->get_coc(comp_num);
+      mem_fixed_allocator* allocator = codestream->get_allocator();
+      const param_cod* cdp = codestream->get_coc(comp_num);
       ui32 num_decomps = cdp->get_num_decompositions();
       ui32 t = num_decomps - codestream->get_skipped_res_for_recon();
       bool skipped_res_for_recon = res_num > t;
 
-      const param_atk *atk = cdp->access_atk();
+      const param_atk* atk = cdp->access_atk();
       param_dfs::dfs_dwt_type ds = param_dfs::BIDIR_DWT;
-      if (cdp->is_dfs_defined())
-      {
-        const param_dfs *dfs = codestream->access_dfs();
-        if (dfs == NULL)
-        {
+      if (cdp->is_dfs_defined()) {
+        const param_dfs* dfs = codestream->access_dfs();
+        if (dfs == NULL) {
           OJPH_ERROR(0x00070001, "There is a problem with codestream "
-                                 "marker segments. COD/COC specifies the use of a DFS marker "
-                                 "but there are no DFS markers within the main codestream "
-                                 "headers");
+            "marker segments. COD/COC specifies the use of a DFS marker "
+            "but there are no DFS markers within the main codestream "
+            "headers");
         }
-        else
-        {
+        else {
           ui16 dfs_idx = cdp->get_dfs_index();
           dfs = dfs->get_dfs(dfs_idx);
-          if (dfs == NULL)
-          {
+          if (dfs == NULL) {
             OJPH_ERROR(0x00070002, "There is a problem with codestream "
-                                   "marker segments. COD/COC specifies the use of a DFS marker "
-                                   "with index %d, but there are no such marker within the "
-                                   "main codestream headers",
-                       dfs_idx);
+              "marker segments. COD/COC specifies the use of a DFS marker "
+              "with index %d, but there are no such marker within the "
+              "main codestream headers", dfs_idx);
           }
           ds = dfs->get_dwt_type(num_decomps - res_num + 1);
         }
@@ -105,7 +100,7 @@ namespace ojph
           transform_flags = VERT_TRX;
       }
 
-      // allocate resolution/subbands
+      //allocate resolution/subbands
       ui32 trx0 = res_rect.org.x;
       ui32 try0 = res_rect.org.y;
       ui32 trx1 = res_rect.org.x + res_rect.siz.w;
@@ -127,12 +122,11 @@ namespace ojph
             re.org.y = tby0;
             re.siz.w = tbx1 - tbx0;
             re.siz.h = tby1 - tby0;
-            if (i == 0)
-            {
+            if (i == 0) {
               allocator->pre_alloc_obj<resolution>(1);
               resolution::pre_alloc(codestream, re,
-                                    skipped_res_for_recon ? recon_res_rect : re,
-                                    comp_num, res_num - 1);
+                skipped_res_for_recon ? recon_res_rect : re,
+                comp_num, res_num - 1);
             }
             else
               subband::pre_alloc(codestream, re, comp_num, res_num,
@@ -149,8 +143,8 @@ namespace ojph
           re.siz.h = tby1 - tby0;
           allocator->pre_alloc_obj<resolution>(1);
           resolution::pre_alloc(codestream, re,
-                                skipped_res_for_recon ? recon_res_rect : re,
-                                comp_num, res_num - 1);
+            skipped_res_for_recon ? recon_res_rect : re,
+            comp_num, res_num - 1);
 
           tby0 = try0 >> 1;
           tby1 = try1 >> 1;
@@ -169,8 +163,8 @@ namespace ojph
           re.siz.w = tbx1 - tbx0;
           allocator->pre_alloc_obj<resolution>(1);
           resolution::pre_alloc(codestream, re,
-                                skipped_res_for_recon ? recon_res_rect : re,
-                                comp_num, res_num - 1);
+            skipped_res_for_recon ? recon_res_rect : re,
+            comp_num, res_num - 1);
 
           tbx0 = trx0 >> 1;
           tbx1 = trx1 >> 1;
@@ -184,15 +178,15 @@ namespace ojph
           assert(ds == param_dfs::NO_DWT);
           allocator->pre_alloc_obj<resolution>(1);
           resolution::pre_alloc(codestream, res_rect,
-                                skipped_res_for_recon ? recon_res_rect : res_rect,
-                                comp_num, res_num - 1);
+            skipped_res_for_recon ? recon_res_rect : res_rect,
+            comp_num, res_num - 1);
         }
       }
       else
         subband::pre_alloc(codestream, res_rect, comp_num, res_num,
                            transform_flags);
 
-      // prealloc precincts
+      //prealloc precincts
       size log_PP = cdp->get_log_precinct_size(res_num);
       size num_precincts;
       if (trx0 != trx1 && try0 != try1)
@@ -204,23 +198,22 @@ namespace ojph
         allocator->pre_alloc_obj<precinct>((size_t)num_precincts.area());
       }
 
-      // allocate lines
+      //allocate lines
       if (skipped_res_for_recon == false)
       {
         ui32 num_steps = atk->get_num_steps();
         allocator->pre_alloc_obj<line_buf>(num_steps + 2);
         allocator->pre_alloc_obj<lifting_buf>(num_steps + 2);
 
-        const param_qcd *qp = codestream->access_qcd()->get_qcc(comp_num);
+        const param_qcd* qp = codestream->access_qcd()->get_qcc(comp_num);
         ui32 precision = qp->propose_precision(cdp);
-        const param_atk *atk = cdp->access_atk();
+        const param_atk* atk = cdp->access_atk();
         bool reversible = atk->is_reversible();
 
         ui32 width = res_rect.siz.w + 1;
         if (reversible)
         {
-          if (precision <= 32)
-          {
+          if (precision <= 32) {
             for (ui32 i = 0; i < num_steps; ++i)
               allocator->pre_alloc_data<si32>(width, 1);
             allocator->pre_alloc_data<si32>(width, 1);
@@ -234,8 +227,7 @@ namespace ojph
             allocator->pre_alloc_data<si64>(width, 1);
           }
         }
-        else
-        {
+        else {
           for (ui32 i = 0; i < num_steps; ++i)
             allocator->pre_alloc_data<float>(width, 1);
           allocator->pre_alloc_data<float>(width, 1);
@@ -245,17 +237,17 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void resolution::finalize_alloc(codestream *codestream,
-                                    const rect &res_rect,
-                                    const rect &recon_res_rect,
+    void resolution::finalize_alloc(codestream* codestream,
+                                    const rect& res_rect,
+                                    const rect& recon_res_rect,
                                     ui32 comp_num, ui32 res_num,
                                     point comp_downsamp, point res_downsamp,
-                                    tile_comp *parent_tile_comp,
-                                    resolution *parent_res)
+                                    tile_comp* parent_tile_comp,
+                                    resolution* parent_res)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      mem_fixed_allocator* allocator = codestream->get_allocator();
       elastic = codestream->get_elastic_alloc();
-      const param_cod *cdp = codestream->get_coc(comp_num);
+      const param_cod* cdp = codestream->get_coc(comp_num);
       ui32 t, num_decomps = cdp->get_num_decompositions();
       t = num_decomps - codestream->get_skipped_res_for_recon();
       skipped_res_for_recon = res_num > t;
@@ -271,27 +263,22 @@ namespace ojph
       this->num_bytes = 0;
       this->atk = cdp->access_atk();
       param_dfs::dfs_dwt_type ds = param_dfs::BIDIR_DWT;
-      if (cdp->is_dfs_defined())
-      {
-        const param_dfs *dfs = codestream->access_dfs();
-        if (dfs == NULL)
-        {
+      if (cdp->is_dfs_defined()) {
+        const param_dfs* dfs = codestream->access_dfs();
+        if (dfs == NULL) {
           OJPH_ERROR(0x00070011, "There is a problem with codestream "
-                                 "marker segments. COD/COC specifies the use of a DFS marker "
-                                 "but there are no DFS markers within the main codestream "
-                                 "headers");
+            "marker segments. COD/COC specifies the use of a DFS marker "
+            "but there are no DFS markers within the main codestream "
+            "headers");
         }
-        else
-        {
+        else {
           ui16 dfs_idx = cdp->get_dfs_index();
           dfs = dfs->get_dfs(dfs_idx);
-          if (dfs == NULL)
-          {
+          if (dfs == NULL) {
             OJPH_ERROR(0x00070012, "There is a problem with codestream "
-                                   "marker segments. COD/COC specifies the use of a DFS marker "
-                                   "with index %d, but there are no such marker within the "
-                                   "main codestream headers",
-                       dfs_idx);
+              "marker segments. COD/COC specifies the use of a DFS marker "
+              "with index %d, but there are no such marker within the "
+              "main codestream headers", dfs_idx);
           }
           ui32 num_decomps = cdp->get_num_decompositions();
           ds = dfs->get_dwt_type(num_decomps - res_num + 1);
@@ -309,7 +296,7 @@ namespace ojph
           transform_flags = VERT_TRX;
       }
 
-      // allocate resolution/subbands
+      //allocate resolution/subbands
       ui32 trx0 = res_rect.org.x;
       ui32 try0 = res_rect.org.y;
       ui32 trx1 = res_rect.org.x + res_rect.siz.w;
@@ -333,17 +320,16 @@ namespace ojph
             re.org.y = tby0;
             re.siz.w = tbx1 - tbx0;
             re.siz.h = tby1 - tby0;
-            if (i == 0)
-            {
+            if (i == 0) {
               point next_res_downsamp;
               next_res_downsamp.x = res_downsamp.x * 2;
               next_res_downsamp.y = res_downsamp.y * 2;
 
               child_res = allocator->post_alloc_obj<resolution>(1);
               child_res->finalize_alloc(codestream, re,
-                                        skipped_res_for_recon ? recon_res_rect : re, comp_num,
-                                        res_num - 1, comp_downsamp, next_res_downsamp,
-                                        parent_tile_comp, this);
+                skipped_res_for_recon ? recon_res_rect : re, comp_num,
+                res_num - 1, comp_downsamp, next_res_downsamp,
+                parent_tile_comp, this);
             }
             else
               bands[i].finalize_alloc(codestream, re, this, res_num, i);
@@ -363,9 +349,9 @@ namespace ojph
           next_res_downsamp.y = res_downsamp.y * 2;
           child_res = allocator->post_alloc_obj<resolution>(1);
           child_res->finalize_alloc(codestream, re,
-                                    skipped_res_for_recon ? recon_res_rect : re, comp_num,
-                                    res_num - 1, comp_downsamp, next_res_downsamp,
-                                    parent_tile_comp, this);
+            skipped_res_for_recon ? recon_res_rect : re, comp_num,
+            res_num - 1, comp_downsamp, next_res_downsamp,
+            parent_tile_comp, this);
 
           tby0 = try0 >> 1;
           tby1 = try1 >> 1;
@@ -387,9 +373,9 @@ namespace ojph
           next_res_downsamp.y = res_downsamp.y;
           child_res = allocator->post_alloc_obj<resolution>(1);
           child_res->finalize_alloc(codestream, re,
-                                    skipped_res_for_recon ? recon_res_rect : re, comp_num,
-                                    res_num - 1, comp_downsamp, next_res_downsamp,
-                                    parent_tile_comp, this);
+            skipped_res_for_recon ? recon_res_rect : re, comp_num,
+            res_num - 1, comp_downsamp, next_res_downsamp,
+            parent_tile_comp, this);
 
           tbx0 = trx0 >> 1;
           tbx1 = trx1 >> 1;
@@ -402,17 +388,16 @@ namespace ojph
           assert(ds == param_dfs::NO_DWT);
           child_res = allocator->post_alloc_obj<resolution>(1);
           child_res->finalize_alloc(codestream, res_rect,
-                                    skipped_res_for_recon ? recon_res_rect : res_rect, comp_num,
-                                    res_num - 1, comp_downsamp, res_downsamp, parent_tile_comp, this);
+            skipped_res_for_recon ? recon_res_rect : res_rect, comp_num,
+            res_num - 1, comp_downsamp, res_downsamp, parent_tile_comp, this);
         }
       }
-      else
-      {
+      else {
         child_res = NULL;
         bands[0].finalize_alloc(codestream, res_rect, this, res_num, 0);
       }
 
-      // finalize precincts
+      //finalize precincts
       log_PP = cdp->get_log_precinct_size(res_num);
       num_precincts = size();
       precincts = NULL;
@@ -423,7 +408,7 @@ namespace ojph
         num_precincts.h = (try1 + (1 << log_PP.h) - 1) >> log_PP.h;
         num_precincts.h -= try0 >> log_PP.h;
         precincts =
-            allocator->post_alloc_obj<precinct>((size_t)num_precincts.area());
+          allocator->post_alloc_obj<precinct>((size_t)num_precincts.area());
         ui64 num = num_precincts.area();
         for (ui64 i = 0; i < num; ++i)
           precincts[i] = precinct();
@@ -433,7 +418,7 @@ namespace ojph
       ui32 x_lower_bound = (trx0 >> log_PP.w) << log_PP.w;
       ui32 y_lower_bound = (try0 >> log_PP.h) << log_PP.h;
 
-      precinct *pp = precincts;
+      precinct* pp = precincts;
       point tile_top_left = parent_tile_comp->get_tile()->get_tile_rect().org;
       for (ui32 y = 0; y < num_precincts.h; ++y)
       {
@@ -473,7 +458,7 @@ namespace ojph
         level_index[i] = level_index[i - 1] + val;
       cur_precinct_loc = point(0, 0);
 
-      // allocate lines
+      //allocate lines
       if (skipped_res_for_recon == false)
       {
         this->atk = cdp->access_atk();
@@ -486,8 +471,7 @@ namespace ojph
         aug = ssp + num_steps + 1;
 
         // initiate lifting_bufs
-        for (ui32 i = 0; i < num_steps; ++i)
-        {
+        for (ui32 i = 0; i < num_steps; ++i) {
           new (ssp + i) lifting_buf;
           ssp[i].line = lines + i;
         };
@@ -496,7 +480,7 @@ namespace ojph
         new (aug) lifting_buf;
         aug->line = lines + num_steps + 1;
 
-        const param_qcd *qp = codestream->access_qcd()->get_qcc(comp_num);
+        const param_qcd* qp = codestream->access_qcd()->get_qcc(comp_num);
         ui32 precision = qp->propose_precision(cdp);
 
         // initiate storage of line_buf
@@ -507,31 +491,31 @@ namespace ojph
           {
             for (ui32 i = 0; i < num_steps; ++i)
               ssp[i].line->wrap(
-                  allocator->post_alloc_data<si32>(width, 1), width, 1);
+                allocator->post_alloc_data<si32>(width, 1), width, 1);
             sig->line->wrap(
-                allocator->post_alloc_data<si32>(width, 1), width, 1);
+              allocator->post_alloc_data<si32>(width, 1), width, 1);
             aug->line->wrap(
-                allocator->post_alloc_data<si32>(width, 1), width, 1);
+              allocator->post_alloc_data<si32>(width, 1), width, 1);
           }
           else
           {
             for (ui32 i = 0; i < num_steps; ++i)
               ssp[i].line->wrap(
-                  allocator->post_alloc_data<si64>(width, 1), width, 1);
+                allocator->post_alloc_data<si64>(width, 1), width, 1);
             sig->line->wrap(
-                allocator->post_alloc_data<si64>(width, 1), width, 1);
+              allocator->post_alloc_data<si64>(width, 1), width, 1);
             aug->line->wrap(
-                allocator->post_alloc_data<si64>(width, 1), width, 1);
+              allocator->post_alloc_data<si64>(width, 1), width, 1);
           }
         }
         else
         {
-          for (ui32 i = 0; i < num_steps; ++i)
-            ssp[i].line->wrap(
+            for (ui32 i = 0; i < num_steps; ++i)
+              ssp[i].line->wrap(
                 allocator->post_alloc_data<float>(width, 1), width, 1);
-          sig->line->wrap(
+            sig->line->wrap(
               allocator->post_alloc_data<float>(width, 1), width, 1);
-          aug->line->wrap(
+            aug->line->wrap(
               allocator->post_alloc_data<float>(width, 1), width, 1);
         }
 
@@ -543,7 +527,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    line_buf *resolution::get_line()
+    line_buf* resolution::get_line()
     {
       if (vert_even)
       {
@@ -577,44 +561,38 @@ namespace ojph
       {
         if (res_rect.siz.h > 1)
         {
-          if (!vert_even && cur_line < res_rect.siz.h)
-          {
+          if (!vert_even && cur_line < res_rect.siz.h) {
             vert_even = !vert_even;
             return;
           }
 
           do
           {
-            // vertical transform
+            //vertical transform
             for (ui32 i = 0; i < num_steps; ++i)
             {
               if (aug->active && (sig->active || ssp[i].active))
               {
-                line_buf *dp = aug->line;
-                line_buf *sp1 = sig->active ? sig->line : ssp[i].line;
-                line_buf *sp2 = ssp[i].active ? ssp[i].line : sig->line;
-                const lifting_step *s = atk->get_step(num_steps - i - 1);
+                line_buf* dp = aug->line;
+                line_buf* sp1 = sig->active ? sig->line : ssp[i].line;
+                line_buf* sp2 = ssp[i].active ? ssp[i].line : sig->line;
+                const lifting_step* s = atk->get_step(num_steps - i - 1);
                 rev_vert_step(s, sp1, sp2, dp, width, false);
               }
-              lifting_buf t = *aug;
-              *aug = ssp[i];
-              ssp[i] = *sig;
-              *sig = t;
+              lifting_buf t = *aug; *aug = ssp[i]; ssp[i] = *sig; *sig = t;
             }
 
-            if (aug->active)
-            {
+            if (aug->active) {
               rev_horz_ana(atk, bands[2].get_line(),
-                           bands[3].get_line(), aug->line, width, horz_even);
+                bands[3].get_line(), aug->line, width, horz_even);
               bands[2].push_line();
               bands[3].push_line();
               aug->active = false;
               --rows_to_produce;
             }
-            if (sig->active)
-            {
+            if (sig->active) {
               rev_horz_ana(atk, child_res->get_line(),
-                           bands[1].get_line(), sig->line, width, horz_even);
+                bands[1].get_line(), sig->line, width, horz_even);
               bands[1].push_line();
               child_res->push_line();
               sig->active = false;
@@ -625,11 +603,10 @@ namespace ojph
         }
         else
         {
-          if (vert_even)
-          {
+          if (vert_even) {
             // horizontal transform
             rev_horz_ana(atk, child_res->get_line(),
-                         bands[1].get_line(), sig->line, width, horz_even);
+              bands[1].get_line(), sig->line, width, horz_even);
             bands[1].push_line();
             child_res->push_line();
           }
@@ -638,20 +615,20 @@ namespace ojph
             // vertical transform
             if (aug->line->flags & line_buf::LFT_32BIT)
             {
-              si32 *sp = aug->line->i32;
+              si32* sp = aug->line->i32;
               for (ui32 i = width; i > 0; --i)
                 *sp++ <<= 1;
             }
             else
             {
               assert(aug->line->flags & line_buf::LFT_64BIT);
-              si64 *sp = aug->line->i64;
+              si64* sp = aug->line->i64;
               for (ui32 i = width; i > 0; --i)
                 *sp++ <<= 1;
             }
             // horizontal transform
             rev_horz_ana(atk, bands[2].get_line(),
-                         bands[3].get_line(), aug->line, width, horz_even);
+              bands[3].get_line(), aug->line, width, horz_even);
             bands[2].push_line();
             bands[3].push_line();
           }
@@ -661,50 +638,44 @@ namespace ojph
       {
         if (res_rect.siz.h > 1)
         {
-          if (!vert_even && cur_line < res_rect.siz.h)
-          {
+          if (!vert_even && cur_line < res_rect.siz.h) {
             vert_even = !vert_even;
             return;
           }
 
           do
           {
-            // vertical transform
+            //vertical transform
             for (ui32 i = 0; i < num_steps; ++i)
             {
               if (aug->active && (sig->active || ssp[i].active))
               {
-                line_buf *dp = aug->line;
-                line_buf *sp1 = sig->active ? sig->line : ssp[i].line;
-                line_buf *sp2 = ssp[i].active ? ssp[i].line : sig->line;
-                const lifting_step *s = atk->get_step(num_steps - i - 1);
+                line_buf* dp = aug->line;
+                line_buf* sp1 = sig->active ? sig->line : ssp[i].line;
+                line_buf* sp2 = ssp[i].active ? ssp[i].line : sig->line;
+                const lifting_step* s = atk->get_step(num_steps - i - 1);
                 irv_vert_step(s, sp1, sp2, dp, width, false);
               }
-              lifting_buf t = *aug;
-              *aug = ssp[i];
-              ssp[i] = *sig;
-              *sig = t;
+              lifting_buf t = *aug; *aug = ssp[i]; ssp[i] = *sig; *sig = t;
             }
 
-            if (aug->active)
-            {
+            if (aug->active) {
               const float K = atk->get_K();
               irv_vert_times_K(K, aug->line, width);
 
               irv_horz_ana(atk, bands[2].get_line(),
-                           bands[3].get_line(), aug->line, width, horz_even);
+                bands[3].get_line(), aug->line, width, horz_even);
               bands[2].push_line();
               bands[3].push_line();
               aug->active = false;
               --rows_to_produce;
             }
-            if (sig->active)
-            {
+            if (sig->active) {
               const float K_inv = 1.0f / atk->get_K();
               irv_vert_times_K(K_inv, sig->line, width);
 
               irv_horz_ana(atk, child_res->get_line(),
-                           bands[1].get_line(), sig->line, width, horz_even);
+                bands[1].get_line(), sig->line, width, horz_even);
               bands[1].push_line();
               child_res->push_line();
               sig->active = false;
@@ -715,23 +686,22 @@ namespace ojph
         }
         else
         {
-          if (vert_even)
-          {
+          if (vert_even) {
             // horizontal transform
             irv_horz_ana(atk, child_res->get_line(),
-                         bands[1].get_line(), sig->line, width, horz_even);
+              bands[1].get_line(), sig->line, width, horz_even);
             bands[1].push_line();
             child_res->push_line();
           }
           else
           {
             // vertical transform
-            float *sp = aug->line->f32;
+            float* sp = aug->line->f32;
             for (ui32 i = width; i > 0; --i)
               *sp++ *= 2.0f;
             // horizontal transform
             irv_horz_ana(atk, bands[2].get_line(),
-                         bands[3].get_line(), aug->line, width, horz_even);
+              bands[3].get_line(), aug->line, width, horz_even);
             bands[2].push_line();
             bands[3].push_line();
           }
@@ -740,7 +710,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    line_buf *resolution::pull_line()
+    line_buf* resolution::pull_line()
     {
       if (res_num == 0)
       {
@@ -761,67 +731,61 @@ namespace ojph
         {
           if (res_rect.siz.h > 1)
           {
-            if (sig->active)
-            {
+            if (sig->active) {
               sig->active = false;
               return sig->line;
             };
             for (;;)
             {
-              // horizontal transform
+              //horizontal transform
               if (cur_line < res_rect.siz.h)
               {
-                if (vert_even)
-                { // even
+                if (vert_even) { // even
                   if (transform_flags & HORZ_TRX)
                     rev_horz_syn(atk, aug->line, child_res->pull_line(),
-                                 bands[1].pull_line(), width, horz_even);
+                      bands[1].pull_line(), width, horz_even);
                   else
                     memcpy(aug->line->p, child_res->pull_line()->p,
-                           (size_t)width * (aug->line->flags & line_buf::LFT_SIZE_MASK));
+                      (size_t)width
+                      * (aug->line->flags & line_buf::LFT_SIZE_MASK));
                   aug->active = true;
                   vert_even = !vert_even;
                   ++cur_line;
                   continue;
                 }
-                else
-                {
+                else {
                   if (transform_flags & HORZ_TRX)
                     rev_horz_syn(atk, sig->line, bands[2].pull_line(),
-                                 bands[3].pull_line(), width, horz_even);
+                      bands[3].pull_line(), width, horz_even);
                   else
                     memcpy(sig->line->p, bands[2].pull_line()->p,
-                           (size_t)width * (sig->line->flags & line_buf::LFT_SIZE_MASK));
+                      (size_t)width
+                      * (sig->line->flags & line_buf::LFT_SIZE_MASK));
                   sig->active = true;
                   vert_even = !vert_even;
                   ++cur_line;
                 }
               }
 
-              // vertical transform
+              //vertical transform
               for (ui32 i = 0; i < num_steps; ++i)
               {
                 if (aug->active && (sig->active || ssp[i].active))
                 {
-                  line_buf *dp = aug->line;
-                  line_buf *sp1 = sig->active ? sig->line : ssp[i].line;
-                  line_buf *sp2 = ssp[i].active ? ssp[i].line : sig->line;
-                  const lifting_step *s = atk->get_step(i);
+                  line_buf* dp = aug->line;
+                  line_buf* sp1 = sig->active ? sig->line : ssp[i].line;
+                  line_buf* sp2 = ssp[i].active ? ssp[i].line : sig->line;
+                  const lifting_step* s = atk->get_step(i);
                   rev_vert_step(s, sp1, sp2, dp, width, true);
                 }
-                lifting_buf t = *aug;
-                *aug = ssp[i];
-                ssp[i] = *sig;
-                *sig = t;
+                lifting_buf t = *aug; *aug = ssp[i]; ssp[i] = *sig; *sig = t;
               }
 
-              if (aug->active)
-              {
+              if (aug->active) {
                 aug->active = false;
                 return aug->line;
               }
-              if (sig->active)
-              {
+              if (sig->active) {
                 sig->active = false;
                 return sig->line;
               };
@@ -829,33 +793,34 @@ namespace ojph
           }
           else
           {
-            if (vert_even)
-            {
+            if (vert_even) {
               if (transform_flags & HORZ_TRX)
                 rev_horz_syn(atk, aug->line, child_res->pull_line(),
-                             bands[1].pull_line(), width, horz_even);
+                  bands[1].pull_line(), width, horz_even);
               else
                 memcpy(aug->line->p, child_res->pull_line()->p,
-                       (size_t)width * (aug->line->flags & line_buf::LFT_SIZE_MASK));
+                  (size_t)width
+                  * (aug->line->flags & line_buf::LFT_SIZE_MASK));
             }
             else
             {
               if (transform_flags & HORZ_TRX)
                 rev_horz_syn(atk, aug->line, bands[2].pull_line(),
-                             bands[3].pull_line(), width, horz_even);
+                  bands[3].pull_line(), width, horz_even);
               else
                 memcpy(aug->line->p, bands[2].pull_line()->p,
-                       (size_t)width * (aug->line->flags & line_buf::LFT_SIZE_MASK));
+                  (size_t)width
+                  * (aug->line->flags & line_buf::LFT_SIZE_MASK));
               if (aug->line->flags & line_buf::LFT_32BIT)
               {
-                si32 *sp = aug->line->i32;
+                si32* sp = aug->line->i32;
                 for (ui32 i = width; i > 0; --i)
                   *sp++ >>= 1;
               }
               else
               {
                 assert(aug->line->flags & line_buf::LFT_64BIT);
-                si64 *sp = aug->line->i64;
+                si64* sp = aug->line->i64;
                 for (ui32 i = width; i > 0; --i)
                   *sp++ >>= 1;
               }
@@ -867,24 +832,22 @@ namespace ojph
         {
           if (res_rect.siz.h > 1)
           {
-            if (sig->active)
-            {
+            if (sig->active) {
               sig->active = false;
               return sig->line;
             };
             for (;;)
             {
-              // horizontal transform
+              //horizontal transform
               if (cur_line < res_rect.siz.h)
               {
-                if (vert_even)
-                { // even
+                if (vert_even) { // even
                   if (transform_flags & HORZ_TRX)
                     irv_horz_syn(atk, aug->line, child_res->pull_line(),
-                                 bands[1].pull_line(), width, horz_even);
+                      bands[1].pull_line(), width, horz_even);
                   else
                     memcpy(aug->line->f32, child_res->pull_line()->f32,
-                           width * sizeof(float));
+                      width * sizeof(float));
                   aug->active = true;
                   vert_even = !vert_even;
                   ++cur_line;
@@ -894,14 +857,13 @@ namespace ojph
 
                   continue;
                 }
-                else
-                {
+                else {
                   if (transform_flags & HORZ_TRX)
                     irv_horz_syn(atk, sig->line, bands[2].pull_line(),
-                                 bands[3].pull_line(), width, horz_even);
+                      bands[3].pull_line(), width, horz_even);
                   else
                     memcpy(sig->line->f32, bands[2].pull_line()->f32,
-                           width * sizeof(float));
+                      width * sizeof(float));
                   sig->active = true;
                   vert_even = !vert_even;
                   ++cur_line;
@@ -911,30 +873,25 @@ namespace ojph
                 }
               }
 
-              // vertical transform
+              //vertical transform
               for (ui32 i = 0; i < num_steps; ++i)
               {
                 if (aug->active && (sig->active || ssp[i].active))
                 {
-                  line_buf *dp = aug->line;
-                  line_buf *sp1 = sig->active ? sig->line : ssp[i].line;
-                  line_buf *sp2 = ssp[i].active ? ssp[i].line : sig->line;
-                  const lifting_step *s = atk->get_step(i);
+                  line_buf* dp = aug->line;
+                  line_buf* sp1 = sig->active ? sig->line : ssp[i].line;
+                  line_buf* sp2 = ssp[i].active ? ssp[i].line : sig->line;
+                  const lifting_step* s = atk->get_step(i);
                   irv_vert_step(s, sp1, sp2, dp, width, true);
                 }
-                lifting_buf t = *aug;
-                *aug = ssp[i];
-                ssp[i] = *sig;
-                *sig = t;
+                lifting_buf t = *aug; *aug = ssp[i]; ssp[i] = *sig; *sig = t;
               }
 
-              if (aug->active)
-              {
+              if (aug->active) {
                 aug->active = false;
                 return aug->line;
               }
-              if (sig->active)
-              {
+              if (sig->active) {
                 sig->active = false;
                 return sig->line;
               };
@@ -942,24 +899,23 @@ namespace ojph
           }
           else
           {
-            if (vert_even)
-            {
+            if (vert_even) {
               if (transform_flags & HORZ_TRX)
                 irv_horz_syn(atk, aug->line, child_res->pull_line(),
-                             bands[1].pull_line(), width, horz_even);
+                  bands[1].pull_line(), width, horz_even);
               else
                 memcpy(aug->line->f32, child_res->pull_line()->f32,
-                       width * sizeof(float));
+                  width * sizeof(float));
             }
             else
             {
               if (transform_flags & HORZ_TRX)
                 irv_horz_syn(atk, aug->line, bands[2].pull_line(),
-                             bands[3].pull_line(), width, horz_even);
-              else
+                  bands[3].pull_line(), width, horz_even);
+             else
                 memcpy(aug->line->f32, bands[2].pull_line()->f32,
-                       width * sizeof(float));
-              float *sp = aug->line->f32;
+                  width * sizeof(float));
+              float* sp = aug->line->f32;
               for (ui32 i = width; i > 0; --i)
                 *sp++ *= 0.5f;
             }
@@ -973,20 +929,20 @@ namespace ojph
         {
           if (transform_flags & HORZ_TRX)
             rev_horz_syn(atk, aug->line, child_res->pull_line(),
-                         bands[1].pull_line(), width, horz_even);
+              bands[1].pull_line(), width, horz_even);
           else
             memcpy(aug->line->p, child_res->pull_line()->p,
-                   (size_t)width * (aug->line->flags & line_buf::LFT_SIZE_MASK));
+              (size_t)width * (aug->line->flags & line_buf::LFT_SIZE_MASK));
           return aug->line;
         }
         else
         {
           if (transform_flags & HORZ_TRX)
             irv_horz_syn(atk, aug->line, child_res->pull_line(),
-                         bands[1].pull_line(), width, horz_even);
+              bands[1].pull_line(), width, horz_even);
           else
             memcpy(aug->line->f32, child_res->pull_line()->f32,
-                   width * sizeof(float));
+              width * sizeof(float));
           return aug->line;
         }
       }
@@ -1003,20 +959,20 @@ namespace ojph
       si32 repeat = (si32)num_precincts.area();
       for (si32 i = 0; i < repeat; ++i)
         this->num_bytes += precincts[i].prepare_precinct(tag_tree_size,
-                                                         level_index, elastic);
+          level_index, elastic);
       return this->num_bytes + lower_resolutions_bytes;
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void resolution::write_precincts(outfile_base *file)
+    void resolution::write_precincts(outfile_base* file)
     {
-      precinct *p = precincts;
+      precinct* p = precincts;
       for (si32 i = 0; i < (si32)num_precincts.area(); ++i)
         p[i].write(file);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    bool resolution::get_top_left_precinct(point &top_left)
+    bool resolution::get_top_left_precinct(point& top_left)
     {
       ui32 idx = cur_precinct_loc.x + cur_precinct_loc.y * num_precincts.w;
       if (idx < num_precincts.area())
@@ -1028,7 +984,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void resolution::write_one_precinct(outfile_base *file)
+    void resolution::write_one_precinct(outfile_base* file)
     {
       ui32 idx = cur_precinct_loc.x + cur_precinct_loc.y * num_precincts.w;
       assert(idx < num_precincts.area());
@@ -1042,16 +998,16 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void resolution::parse_all_precincts(ui32 &data_left, infile_base *file)
+    void resolution::parse_all_precincts(ui32& data_left, infile_base* file)
     {
-      precinct *p = precincts;
+      precinct* p = precincts;
       ui32 idx = cur_precinct_loc.x + cur_precinct_loc.y * num_precincts.w;
       for (ui32 i = idx; i < num_precincts.area(); ++i)
       {
         if (data_left == 0)
           break;
         p[i].parse(tag_tree_size, level_index, elastic, data_left, file,
-                   skipped_res_for_read);
+          skipped_res_for_read);
         if (++cur_precinct_loc.x >= num_precincts.w)
         {
           cur_precinct_loc.x = 0;
@@ -1061,16 +1017,16 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void resolution::parse_one_precinct(ui32 &data_left, infile_base *file)
+    void resolution::parse_one_precinct(ui32& data_left, infile_base* file)
     {
       ui32 idx = cur_precinct_loc.x + cur_precinct_loc.y * num_precincts.w;
       assert(idx < num_precincts.area());
 
       if (data_left == 0)
         return;
-      precinct *p = precincts + idx;
+      precinct* p = precincts + idx;
       p->parse(tag_tree_size, level_index, elastic, data_left, file,
-               skipped_res_for_read);
+        skipped_res_for_read);
       if (++cur_precinct_loc.x >= num_precincts.w)
       {
         cur_precinct_loc.x = 0;
@@ -1083,8 +1039,7 @@ namespace ojph
     {
       if (this->res_num == resolution_num)
         return get_num_bytes();
-      if (resolution_num < this->res_num)
-      {
+      if (resolution_num < this->res_num) {
         assert(child_res);
         return child_res->get_num_bytes(resolution_num);
       }

--- a/Native/Common/OpenJPH/codestream/ojph_resolution.h
+++ b/Native/Common/OpenJPH/codestream/ojph_resolution.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,25 +35,24 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_RESOLUTION_H
 #define OJPH_RESOLUTION_H
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class line_buf;
   class mem_elastic_allocator;
   class codestream;
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    // defined here
+    //defined here
     class tile_comp;
     struct precinct;
     class subband;
@@ -62,25 +61,24 @@ namespace ojph
     class resolution
     {
     public:
-      enum : ui32
-      {
-        HORZ_TRX = 0x01, // horizontal transform
-        VERT_TRX = 0x02, // vertical transform
+      enum : ui32 {
+        HORZ_TRX = 0x01,   // horizontal transform
+        VERT_TRX = 0x02,   // vertical transform
       };
 
     public:
-      static void pre_alloc(codestream *codestream, const rect &res_rect,
-                            const rect &recon_res_rect,
+      static void pre_alloc(codestream *codestream, const rect& res_rect,
+                            const rect& recon_res_rect, 
                             ui32 comp_num, ui32 res_num);
-      void finalize_alloc(codestream *codestream, const rect &res_rect,
-                          const rect &recon_res_rect, ui32 comp_num,
-                          ui32 res_num, point comp_downsamp,
+      void finalize_alloc(codestream *codestream, const rect& res_rect,
+                          const rect& recon_res_rect, ui32 comp_num,
+                          ui32 res_num, point comp_downsamp, 
                           point res_downsamp, tile_comp *parent_tile_comp,
                           resolution *parent_res);
 
-      line_buf *get_line();
+      line_buf* get_line();
       void push_line();
-      line_buf *pull_line();
+      line_buf* pull_line();
       rect get_rect() { return res_rect; }
       ui32 get_comp_num() { return comp_num; }
       bool has_horz_transform() { return (transform_flags & HORZ_TRX) != 0; }
@@ -91,8 +89,8 @@ namespace ojph
       bool get_top_left_precinct(point &top_left);
       void write_one_precinct(outfile_base *file);
       resolution *next_resolution() { return child_res; }
-      void parse_all_precincts(ui32 &data_left, infile_base *file);
-      void parse_one_precinct(ui32 &data_left, infile_base *file);
+      void parse_all_precincts(ui32& data_left, infile_base *file);
+      void parse_one_precinct(ui32& data_left, infile_base *file);
 
       ui32 get_num_bytes() const { return num_bytes; }
       ui32 get_num_bytes(ui32 resolution_num) const;
@@ -102,27 +100,27 @@ namespace ojph
       ui32 num_steps;
       ui32 res_num;
       ui32 comp_num;
-      ui32 num_bytes; // number of bytes in this resolution
+      ui32 num_bytes; // number of bytes in this resolution 
                       // used for tilepart length
       point comp_downsamp;
-      rect res_rect;    // resolution rectangle
-      line_buf *lines;  // used to store lines
-      lifting_buf *ssp; // step state pointer
+      rect res_rect;                             // resolution rectangle
+      line_buf* lines;                           // used to store lines
+      lifting_buf *ssp;                          // step state pointer
       lifting_buf *aug, *sig;
       subband *bands;
       tile_comp *parent_comp;
       resolution *parent_res, *child_res;
-      // precincts stuff
+      //precincts stuff
       precinct *precincts;
       size num_precincts;
       size log_PP;
       ui32 max_num_levels;
       int tag_tree_size;
-      ui32 level_index[20];   // more than enough
-      point cur_precinct_loc; // used for progressing spatial modes (2, 3, 4)
-      const param_atk *atk;
+      ui32 level_index[20]; //more than enough
+      point cur_precinct_loc; //used for progressing spatial modes (2, 3, 4)
+      const param_atk* atk;
       ui32 transform_flags;
-      // wavelet machinery
+      //wavelet machinery
       ui32 cur_line;
       ui32 rows_to_produce;
       bool vert_even, horz_even;

--- a/Native/Common/OpenJPH/codestream/ojph_subband.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_subband.cpp
@@ -36,6 +36,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 
@@ -47,8 +48,7 @@
 #include "ojph_codeblock.h"
 #include "ojph_precinct.h"
 
-namespace ojph
-{
+namespace ojph {
 
   namespace local
   {
@@ -57,13 +57,13 @@ namespace ojph
     void subband::pre_alloc(codestream *codestream, const rect &band_rect,
                             ui32 comp_num, ui32 res_num, ui32 transform_flags)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      mem_fixed_allocator* allocator = codestream->get_allocator();
 
       bool empty = ((band_rect.siz.w == 0) || (band_rect.siz.h == 0));
       if (empty)
         return;
 
-      const param_cod *cdp = codestream->get_coc(comp_num);
+      const param_cod* cdp = codestream->get_coc(comp_num);
       size log_cb = cdp->get_log_block_dims();
       size log_PP = cdp->get_log_precinct_size(res_num);
 
@@ -87,20 +87,20 @@ namespace ojph
       num_blocks.h -= tby0 >> ycb_prime;
 
       allocator->pre_alloc_obj<codeblock>(num_blocks.w);
-      // allocate codeblock headers
+      //allocate codeblock headers
       allocator->pre_alloc_obj<coded_cb_header>((size_t)num_blocks.area());
 
-      const param_qcd *qp = codestream->access_qcd()->get_qcc(comp_num);
+      const param_qcd* qp = codestream->access_qcd()->get_qcc(comp_num);
       ui32 precision = qp->propose_precision(cdp);
-      const param_atk *atk = cdp->access_atk();
+      const param_atk* atk = cdp->access_atk();
       bool reversible = atk->is_reversible();
 
       for (ui32 i = 0; i < num_blocks.w; ++i)
         codeblock::pre_alloc(codestream, nominal, precision);
 
-      // allocate lines
+      //allocate lines
       allocator->pre_alloc_obj<line_buf>(1);
-      // allocate line_buf
+      //allocate line_buf
       ui32 width = band_rect.siz.w + 1;
       if (reversible)
       {
@@ -116,10 +116,10 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     void subband::finalize_alloc(codestream *codestream,
                                  const rect &band_rect,
-                                 resolution *res, ui32 res_num,
+                                 resolution* res, ui32 res_num,
                                  ui32 subband_num)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      mem_fixed_allocator* allocator = codestream->get_allocator();
       elastic = codestream->get_elastic_alloc();
 
       this->res_num = res_num;
@@ -127,7 +127,8 @@ namespace ojph
       this->band_rect = band_rect;
       this->parent = res;
 
-      const param_cod *cdp = codestream->get_coc(parent->get_comp_num());
+      ui32 comp_num = parent->get_comp_num();
+      const param_cod* cdp = codestream->get_coc(comp_num);
       this->reversible = cdp->access_atk()->is_reversible();
       size log_cb = cdp->get_log_block_dims();
       log_PP = cdp->get_log_precinct_size(res_num);
@@ -143,24 +144,23 @@ namespace ojph
       cur_cb_row = 0;
       cur_line = 0;
       cur_cb_height = 0;
-      const param_dfs *dfs = NULL;
-      if (cdp->is_dfs_defined())
-      {
+      const param_dfs* dfs = NULL;
+      if (cdp->is_dfs_defined()) {
         dfs = codestream->access_dfs();
         if (dfs != NULL)
           dfs = dfs->get_dfs(cdp->get_dfs_index());
       }
-      ui32 comp_num = parent->get_comp_num();
-      const param_qcd *qcd = codestream->access_qcd()->get_qcc(comp_num);
+      const param_qcd* qcd = codestream->access_qcd()->get_qcc(comp_num);
       ui32 num_decomps = cdp->get_num_decompositions();
       this->K_max = qcd->get_Kmax(dfs, num_decomps, this->res_num, band_num);
       if (!reversible)
       {
         float d =
-            qcd->get_irrev_delta(dfs, num_decomps, res_num, subband_num);
+          qcd->get_irrev_delta(dfs, num_decomps,
+            comp_num, res_num, subband_num);
         d /= (float)(1u << (31 - this->K_max));
         delta = d;
-        delta_inv = (1.0f / d);
+        delta_inv = (1.0f/d);
       }
       ui32 precision = qcd->propose_precision(cdp);
 
@@ -180,9 +180,9 @@ namespace ojph
       num_blocks.h -= tby0 >> ycb_prime;
 
       blocks = allocator->post_alloc_obj<codeblock>(num_blocks.w);
-      // allocate codeblock headers
+      //allocate codeblock headers
       coded_cb_header *cp = coded_cbs =
-          allocator->post_alloc_obj<coded_cb_header>((size_t)num_blocks.area());
+        allocator->post_alloc_obj<coded_cb_header>((size_t)num_blocks.area());
       memset(coded_cbs, 0, sizeof(coded_cb_header) * (size_t)num_blocks.area());
       for (int i = (int)num_blocks.area(); i > 0; --i, ++cp)
         cp->Kmax = K_max;
@@ -205,9 +205,9 @@ namespace ojph
         line_offset += cb_size.w;
       }
 
-      // allocate lines
+      //allocate lines
       lines = allocator->post_alloc_obj<line_buf>(1);
-      // allocate line_buf
+      //allocate line_buf
       ui32 width = band_rect.siz.w + 1;
       if (reversible)
       {
@@ -221,7 +221,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void subband::get_cb_indices(const size &num_precincts,
+    void subband::get_cb_indices(const size& num_precincts,
                                  precinct *precincts)
     {
       if (empty)
@@ -248,7 +248,7 @@ namespace ojph
         pcy1 = (pcy1 - (band_num >> 1) + (1 << y_shift) - 1) >> y_shift;
 
         precinct *p = precincts + y * num_precincts.w;
-        yb = ((pcy1 + (1 << ycb_prime) - 1) >> ycb_prime);
+        yb = ((pcy1 + (1<<ycb_prime) - 1) >> ycb_prime);
         yb -= (pcy0 >> ycb_prime);
         colx = 0;
 
@@ -260,7 +260,7 @@ namespace ojph
           pcx1 = (pcx1 - (band_num & 1) + (1 << x_shift) - 1) >> x_shift;
 
           rect *bp = p->cb_idxs + band_num;
-          xb = ((pcx1 + (1 << xcb_prime) - 1) >> xcb_prime);
+          xb = ((pcx1 + (1<<xcb_prime) - 1) >> xcb_prime);
           xb -= (pcx0 >> xcb_prime);
 
           bp->org.x = colx;
@@ -283,7 +283,7 @@ namespace ojph
 
       assert(l->pre_size == lines[0].pre_size && l->size == lines[0].size &&
              l->flags == lines[0].flags);
-      void *p = lines[0].p;
+      void* p = lines[0].p;
       lines[0].p = l->p;
       l->p = p;
     }
@@ -294,7 +294,7 @@ namespace ojph
       if (empty)
         return;
 
-      // push to codeblocks
+      //push to codeblocks
       for (ui32 i = 0; i < num_blocks.w; ++i)
         blocks[i].push(lines + 0);
       if (++cur_line >= cur_cb_height)
@@ -338,7 +338,7 @@ namespace ojph
       if (empty)
         return lines;
 
-      // pull from codeblocks
+      //pull from codeblocks
       if (--cur_line <= 0)
       {
         if (cur_cb_row < num_blocks.h)
@@ -352,7 +352,7 @@ namespace ojph
           ui32 x_lower_bound = (tbx0 >> xcb_prime) << xcb_prime;
           ui32 y_lower_bound = (tby0 >> ycb_prime) << ycb_prime;
           ui32 cby0 = ojph_max(tby0, y_lower_bound + cur_cb_row * nominal.h);
-          ui32 cby1 = ojph_min(tby1, y_lower_bound + (cur_cb_row + 1) * nominal.h);
+          ui32 cby1 = ojph_min(tby1, y_lower_bound+(cur_cb_row+1)*nominal.h);
 
           size cb_size;
           cb_size.h = cby1 - cby0;
@@ -372,11 +372,12 @@ namespace ojph
 
       assert(cur_line >= 0);
 
-      // pull from codeblocks
+      //pull from codeblocks
       for (ui32 i = 0; i < num_blocks.w; ++i)
         blocks[i].pull_line(lines + 0);
 
       return lines;
     }
+
   }
 }

--- a/Native/Common/OpenJPH/codestream/ojph_subband.h
+++ b/Native/Common/OpenJPH/codestream/ojph_subband.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,41 +35,38 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_SUBBAND_H
 #define OJPH_SUBBAND_H
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class line_buf;
   class mem_elastic_allocator;
   class codestream;
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    // defined here
+    //defined here
     class resolution;
     struct precinct;
     class codeblock;
     struct coded_cb_header;
-
-    //////////////////////////////////////////////////////////////////////////
+  
+  //////////////////////////////////////////////////////////////////////////
     class subband
     {
       friend struct precinct;
-
     public:
-      subband()
-      {
+      subband() { 
         res_num = band_num = 0;
         reversible = false;
-        empty = true; // <---- true
+        empty = true;             // <---- true
         lines = NULL;
         parent = NULL;
         blocks = NULL;
@@ -83,32 +80,32 @@ namespace ojph
         elastic = NULL;
       }
 
-      static void pre_alloc(codestream *codestream, const rect &band_rect,
+      static void pre_alloc(codestream *codestream, const rect& band_rect,
                             ui32 comp_num, ui32 res_num, ui32 transform_flags);
-      void finalize_alloc(codestream *codestream, const rect &band_rect,
-                          resolution *res, ui32 res_num, ui32 subband_num);
+      void finalize_alloc(codestream *codestream, const rect& band_rect,
+                          resolution* res, ui32 res_num, ui32 subband_num);
 
-      void exchange_buf(line_buf *l);
-      line_buf *get_line() { return lines; }
+      void exchange_buf(line_buf* l);
+      line_buf* get_line() { return lines; }
       void push_line();
 
-      void get_cb_indices(const size &num_precincts, precinct *precincts);
+      void get_cb_indices(const size& num_precincts, precinct *precincts);
       float get_delta() { return delta; }
       bool exists() { return !empty; }
 
-      line_buf *pull_line();
-      resolution *get_parent() { return parent; }
-      const resolution *get_parent() const { return parent; }
+      line_buf* pull_line();
+      resolution* get_parent() { return parent; }
+      const resolution* get_parent() const { return parent; }
 
     private:
-      bool empty; // true if the subband has no pixels or
-                  // the subband is NOT USED
+      bool empty;                  // true if the subband has no pixels or
+                                   // the subband is NOT USED
       ui32 res_num, band_num;
       bool reversible;
       rect band_rect;
       line_buf *lines;
-      resolution *parent;
-      codeblock *blocks;
+      resolution* parent;
+      codeblock* blocks;
       size num_blocks;
       size log_PP;
       ui32 xcb_prime, ycb_prime;

--- a/Native/Common/OpenJPH/codestream/ojph_tile.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_tile.cpp
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 
@@ -46,43 +47,41 @@
 
 #include "../transform/ojph_colour.h"
 
-namespace ojph
-{
+namespace ojph {
 
   namespace local
   {
 
     //////////////////////////////////////////////////////////////////////////
-    void tile::pre_alloc(codestream *codestream, const rect &tile_rect,
-                         const rect &recon_tile_rect, ui32 &num_tileparts)
+    void tile::pre_alloc(codestream *codestream, const rect& tile_rect,
+                         const rect& recon_tile_rect, ui32& num_tileparts)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      mem_fixed_allocator* allocator = codestream->get_allocator();
 
-      // allocate tiles_comp
+      //allocate tiles_comp
       const param_siz *szp = codestream->get_siz();
       ui32 num_comps = szp->get_num_components();
       allocator->pre_alloc_obj<tile_comp>(num_comps);
-      allocator->pre_alloc_obj<rect>(num_comps); // for comp_rects
-      allocator->pre_alloc_obj<rect>(num_comps); // for recon_comp_rects
-      allocator->pre_alloc_obj<ui32>(num_comps); // for line_offsets
-      allocator->pre_alloc_obj<ui32>(num_comps); // for num_bits
-      allocator->pre_alloc_obj<bool>(num_comps); // for is_signed
-      allocator->pre_alloc_obj<bool>(num_comps); // for reversible
-      allocator->pre_alloc_obj<ui8>(num_comps);  // for nlt_type3
-      allocator->pre_alloc_obj<ui32>(num_comps); // for cur_line
+      allocator->pre_alloc_obj<rect>(num_comps); //for comp_rects
+      allocator->pre_alloc_obj<rect>(num_comps); //for recon_comp_rects
+      allocator->pre_alloc_obj<ui32>(num_comps); //for line_offsets
+      allocator->pre_alloc_obj<ui32>(num_comps); //for num_bits
+      allocator->pre_alloc_obj<bool>(num_comps); //for is_signed
+      allocator->pre_alloc_obj<bool>(num_comps); //for reversible
+      allocator->pre_alloc_obj<ui8>(num_comps);  //for nlt_type3
+      allocator->pre_alloc_obj<ui32>(num_comps); //for cur_line
 
       {
         ui32 tilepart_div = codestream->get_tilepart_div();
         ui32 t = tilepart_div & OJPH_TILEPART_MASK;
         if (t == OJPH_TILEPART_NO_DIVISIONS)
-          num_tileparts = 1; // for num_rc_bytes
+          num_tileparts = 1; //for num_rc_bytes
         else if (t == OJPH_TILEPART_COMPONENTS)
           num_tileparts = num_comps;
         else if (t == OJPH_TILEPART_RESOLUTIONS)
         {
           ui32 max_decs = 0;
-          for (ui32 c = 0; c < num_comps; ++c)
-          {
+          for (ui32 c = 0; c < num_comps; ++c) {
             ui32 s = codestream->get_coc(c)->get_num_decompositions();
             max_decs = ojph_max(max_decs, s);
           }
@@ -91,16 +90,14 @@ namespace ojph
         else if (t == (OJPH_TILEPART_COMPONENTS | OJPH_TILEPART_RESOLUTIONS))
         {
           num_tileparts = 0;
-          for (ui32 c = 0; c < num_comps; ++c)
-          {
+          for (ui32 c = 0; c < num_comps; ++c) {
             ui32 s = codestream->get_coc(c)->get_num_decompositions();
             num_tileparts += s + 1;
           }
         }
         if (num_tileparts > 255)
           OJPH_ERROR(0x000300D1, "Trying to create %d tileparts; a tile "
-                                 "cannot have more than 255 tile parts.",
-                     num_tileparts);
+            "cannot have more than 255 tile parts.", num_tileparts);
       }
 
       ui32 tx0 = tile_rect.org.x;
@@ -113,6 +110,7 @@ namespace ojph
       ui32 recon_ty1 = recon_tile_rect.org.y + recon_tile_rect.siz.h;
 
       ui32 width = 0;
+      rect colour_comp_rect[3];
       for (ui32 i = 0; i < num_comps; ++i)
       {
         point downsamp = szp->get_downsampling(i);
@@ -132,6 +130,9 @@ namespace ojph
         comp_rect.siz.w = tcx1 - tcx0;
         comp_rect.siz.h = tcy1 - tcy0;
 
+        if (i < 3)
+          colour_comp_rect[i] = comp_rect;
+
         rect recon_comp_rect;
         recon_comp_rect.org.x = recon_tcx0;
         recon_comp_rect.org.y = recon_tcy0;
@@ -142,23 +143,38 @@ namespace ojph
         width = ojph_max(width, recon_comp_rect.siz.w);
       }
 
-      // allocate lines
-      const param_cod *cdp = codestream->get_cod();
+      //allocate lines
+      const param_cod* cdp = codestream->get_cod();
       if (cdp->is_employing_color_transform())
       {
         bool reversible[3];
         for (ui32 i = 0; i < 3; ++i)
           reversible[i] = codestream->get_coc(i)->is_reversible();
         if (reversible[0] != reversible[1] || reversible[1] != reversible[2])
-          OJPH_ERROR(0x000300A2, "When the colour transform is employed. "
-                                 "all colour components must undergo either reversible or "
-                                 "irreversible wavelet transform; if not, then it is not clear "
-                                 "what colour transform should be used (reversible or "
-                                 "irreversible).  Here we found that the first three colour "
-                                 "components uses %s, %s, and %s transforms, respectively.",
-                     reversible[0] ? "reversible" : "irreversible",
-                     reversible[1] ? "reversible" : "irreversible",
-                     reversible[2] ? "reversible" : "irreversible");
+          OJPH_ERROR(0x000300A2, "When the colour transform is employed, "
+            "all colour components must undergo either reversible or "
+            "irreversible wavelet transform; if not, then it is not clear "
+            "what colour transform should be used (reversible or "
+            "irreversible).  Here we found that the first three colour "
+            "components uses %s, %s, and %s transforms, respectively.",
+            reversible[0] ? "reversible" : "irreversible",
+            reversible[1] ? "reversible" : "irreversible",
+            reversible[2] ? "reversible" : "irreversible");
+
+        if (colour_comp_rect[0] != colour_comp_rect[1] ||
+          colour_comp_rect[1] != colour_comp_rect[2])
+          OJPH_ERROR(0x000300A3, "When the colour transform is employed, "
+            "the first three colour components must have the same rectangle; "
+            "i.e., the same origin on the canvas and the same width and "
+            "height. The first three components have the following "
+            "origin-size (x,y)-(w,h) values. Component 0 (%d,%d)-(%d,%d), "
+            "Component 1 (%d,%d)-(%d,%d), Component 2 (%d,%d)-(%d,%d)",
+            colour_comp_rect[0].org.x, colour_comp_rect[0].org.y,
+            colour_comp_rect[0].siz.w, colour_comp_rect[0].siz.h,
+            colour_comp_rect[1].org.x, colour_comp_rect[1].org.y,
+            colour_comp_rect[1].siz.w, colour_comp_rect[1].siz.h,
+            colour_comp_rect[2].org.x, colour_comp_rect[2].org.y,
+            colour_comp_rect[2].siz.w, colour_comp_rect[2].siz.h);
 
         allocator->pre_alloc_obj<line_buf>(3);
         if (reversible[0])
@@ -171,17 +187,17 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void tile::finalize_alloc(codestream *codestream, const rect &tile_rect,
-                              ui32 tile_idx, ui32 &offset,
+    void tile::finalize_alloc(codestream *codestream, const rect& tile_rect,
+                              ui32 tile_idx, ui32& offset,
                               ui32 &num_tileparts)
     {
-      // this->parent = codestream;
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      //this->parent = codestream;
+      mem_fixed_allocator* allocator = codestream->get_allocator();
 
       sot.init(0, (ui16)tile_idx, 0, 1);
       prog_order = codestream->access_cod().get_progression_order();
 
-      // allocate tiles_comp
+      //allocate tiles_comp
       const param_siz *szp = codestream->get_siz();
       const param_nlt *nlp = codestream->get_nlt();
 
@@ -205,14 +221,13 @@ namespace ojph
         ui32 tilepart_div = codestream->get_tilepart_div();
         ui32 t = tilepart_div & OJPH_TILEPART_MASK;
         if (t == OJPH_TILEPART_NO_DIVISIONS)
-          num_tileparts = 1; // for num_rc_bytes
+          num_tileparts = 1; //for num_rc_bytes
         else if (t == OJPH_TILEPART_COMPONENTS)
           num_tileparts = num_comps;
         else if (t == OJPH_TILEPART_RESOLUTIONS)
         {
           ui32 max_decs = 0;
-          for (ui32 c = 0; c < num_comps; ++c)
-          {
+          for (ui32 c = 0; c < num_comps; ++c) {
             ui32 s = codestream->get_coc(c)->get_num_decompositions();
             max_decs = ojph_max(max_decs, s);
           }
@@ -221,16 +236,14 @@ namespace ojph
         else if (t == (OJPH_TILEPART_COMPONENTS | OJPH_TILEPART_RESOLUTIONS))
         {
           num_tileparts = 0;
-          for (ui32 c = 0; c < num_comps; ++c)
-          {
+          for (ui32 c = 0; c < num_comps; ++c) {
             ui32 s = codestream->get_coc(c)->get_num_decompositions();
             num_tileparts += s + 1;
           }
         }
         if (num_tileparts > 255)
           OJPH_ERROR(0x000300D1, "Trying to create %d tileparts; a tile "
-                                 "cannot have more than 255 tile parts.",
-                     num_tileparts);
+          "cannot have more than 255 tile parts.", num_tileparts);
       }
 
       this->resilient = codestream->is_resilient();
@@ -244,8 +257,7 @@ namespace ojph
       ui32 width = 0;
       for (ui32 i = 0; i < num_comps; ++i)
       {
-        ui8 bd;
-        bool is; // used for nlt_type3
+        ui8 bd; bool is; // used for nlt_type3
 
         point downsamp = szp->get_downsampling(i);
         point recon_downsamp = szp->get_recon_downsampling(i);
@@ -260,7 +272,7 @@ namespace ojph
         ui32 recon_tcy1 = ojph_div_ceil(ty1, recon_downsamp.y);
 
         line_offsets[i] =
-            recon_tcx0 - ojph_div_ceil(tx0 - offset, recon_downsamp.x);
+          recon_tcx0 - ojph_div_ceil(tx0 - offset, recon_downsamp.x);
         comp_rects[i].org.x = tcx0;
         comp_rects[i].org.y = tcy0;
         comp_rects[i].siz.w = tcx1 - tcx0;
@@ -271,7 +283,7 @@ namespace ojph
         recon_comp_rects[i].siz.h = recon_tcy1 - recon_tcy0;
 
         comps[i].finalize_alloc(codestream, this, i, comp_rects[i],
-                                recon_comp_rects[i]);
+          recon_comp_rects[i]);
         width = ojph_max(width, recon_comp_rects[i].siz.w);
 
         num_bits[i] = szp->get_bit_depth(i);
@@ -279,19 +291,20 @@ namespace ojph
         bool result = nlp->get_nonlinear_transform(i, bd, is, nlt_type3[i]);
         if (result == true && (bd != num_bits[i] || is != is_signed[i]))
           OJPH_ERROR(0x000300A1, "Mismatch between Ssiz (bit_depth = %d, "
-                                 "is_signed = %s) from SIZ marker segment, and BDnlt "
-                                 "(bit_depth = %d, is_signed = %s) from NLT marker segment, "
-                                 "for component %d",
-                     i, num_bits[i],
-                     is_signed[i] ? "True" : "False", bd, is ? "True" : "False");
+            "is_signed = %s) from SIZ marker segment, and BDnlt "
+            "(bit_depth = %d, is_signed = %s) from NLT marker segment, "
+            "for component %d", num_bits[i],
+            is_signed[i] ? "True" : "False", bd, is ? "True" : "False", i);
+        if (result == false)
+          nlt_type3[i] = param_nlt::nonlinearity::OJPH_NLT_NO_NLT;
         cur_line[i] = 0;
         reversible[i] = codestream->get_coc(i)->is_reversible();
       }
 
       offset += tile_rect.siz.w;
 
-      // allocate lines
-      const param_cod *cdp = codestream->get_cod();
+      //allocate lines
+      const param_cod* cdp = codestream->get_cod();
       this->employ_color_transform = cdp->is_employing_color_transform();
       if (this->employ_color_transform)
       {
@@ -300,11 +313,11 @@ namespace ojph
         if (reversible[0])
           for (int i = 0; i < 3; ++i)
             lines[i].wrap(
-                allocator->post_alloc_data<si32>(width, 0), width, 0);
+              allocator->post_alloc_data<si32>(width, 0), width, 0);
         else
           for (int i = 0; i < 3; ++i)
             lines[i].wrap(
-                allocator->post_alloc_data<float>(width, 0), width, 0);
+              allocator->post_alloc_data<float>(width, 0), width, 0);
       }
       else
       {
@@ -318,15 +331,15 @@ namespace ojph
     bool tile::push(line_buf *line, ui32 comp_num)
     {
       constexpr ui8 type3 =
-          param_nlt::nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
+        param_nlt::nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
 
       assert(comp_num < num_comps);
       if (cur_line[comp_num] >= comp_rects[comp_num].siz.h)
         return false;
       cur_line[comp_num]++;
 
-      // converts to signed representation
-      // employs color transform if there is a need
+      //converts to signed representation
+      //employs color transform if there is a need
       if (!employ_color_transform || comp_num >= 3)
       {
         assert(comp_num < num_comps);
@@ -337,22 +350,21 @@ namespace ojph
           si64 shift = (si64)1 << (num_bits[comp_num] - 1);
           if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
             rev_convert_nlt_type3(line, line_offsets[comp_num],
-                                  tc, 0, shift + 1, comp_width);
-          else
-          {
+              tc, 0, shift + 1, comp_width);
+          else {
             shift = is_signed[comp_num] ? 0 : -shift;
             rev_convert(line, line_offsets[comp_num], tc, 0,
-                        shift, comp_width);
+              shift, comp_width);
           }
         }
         else
         {
           if (nlt_type3[comp_num] == type3)
             irv_convert_to_float_nlt_type3(line, line_offsets[comp_num],
-                                           tc, num_bits[comp_num], is_signed[comp_num], comp_width);
+              tc, num_bits[comp_num], is_signed[comp_num], comp_width);
           else
             irv_convert_to_float(line, line_offsets[comp_num],
-                                 tc, num_bits[comp_num], is_signed[comp_num], comp_width);
+              tc, num_bits[comp_num], is_signed[comp_num], comp_width);
         }
         comps[comp_num].push_line();
       }
@@ -364,12 +376,11 @@ namespace ojph
         {
           if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
             rev_convert_nlt_type3(line, line_offsets[comp_num],
-                                  lines + comp_num, 0, shift + 1, comp_width);
-          else
-          {
+              lines + comp_num, 0, shift + 1, comp_width);
+          else {
             shift = is_signed[comp_num] ? 0 : -shift;
             rev_convert(line, line_offsets[comp_num], lines + comp_num, 0,
-                        shift, comp_width);
+              shift, comp_width);
           }
 
           if (comp_num == 2)
@@ -378,30 +389,30 @@ namespace ojph
                         comps[0].get_line(),
                         comps[1].get_line(),
                         comps[2].get_line(), comp_width);
-            comps[0].push_line();
-            comps[1].push_line();
-            comps[2].push_line();
+                        comps[0].push_line();
+                        comps[1].push_line();
+                        comps[2].push_line();
           }
         }
         else
         {
           if (nlt_type3[comp_num] == type3)
             irv_convert_to_float_nlt_type3(line, line_offsets[comp_num],
-                                           lines + comp_num, num_bits[comp_num], is_signed[comp_num],
-                                           comp_width);
+              lines + comp_num, num_bits[comp_num], is_signed[comp_num],
+              comp_width);
           else
             irv_convert_to_float(line, line_offsets[comp_num],
-                                 lines + comp_num, num_bits[comp_num], is_signed[comp_num],
-                                 comp_width);
+              lines + comp_num, num_bits[comp_num], is_signed[comp_num],
+              comp_width);
           if (comp_num == 2)
           { // irreversible color transform
             ict_forward(lines[0].f32, lines[1].f32, lines[2].f32,
                         comps[0].get_line()->f32,
                         comps[1].get_line()->f32,
                         comps[2].get_line()->f32, comp_width);
-            comps[0].push_line();
-            comps[1].push_line();
-            comps[2].push_line();
+                        comps[0].push_line();
+                        comps[1].push_line();
+                        comps[2].push_line();
           }
         }
       }
@@ -410,10 +421,10 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    bool tile::pull(line_buf *tgt_line, ui32 comp_num)
+    bool tile::pull(line_buf* tgt_line, ui32 comp_num)
     {
       constexpr ui8 type3 =
-          param_nlt::nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
+        param_nlt::nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
 
       assert(comp_num < num_comps);
       if (cur_line[comp_num] >= recon_comp_rects[comp_num].siz.h)
@@ -421,94 +432,95 @@ namespace ojph
 
       cur_line[comp_num]++;
 
+      ui32 comp_width = recon_comp_rects[comp_num].siz.w;
+      if (comp_width == 0)
+        return true; // nothing to pull, but not an error
+
       if (!employ_color_transform || num_comps == 1)
       {
         line_buf *src_line = comps[comp_num].pull_line();
-        ui32 comp_width = recon_comp_rects[comp_num].siz.w;
         if (reversible[comp_num])
         {
           si64 shift = (si64)1 << (num_bits[comp_num] - 1);
           if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
             rev_convert_nlt_type3(src_line, 0, tgt_line,
-                                  line_offsets[comp_num], shift + 1, comp_width);
-          else
-          {
+              line_offsets[comp_num], shift + 1, comp_width);
+          else {
             shift = is_signed[comp_num] ? 0 : shift;
             rev_convert(src_line, 0, tgt_line,
-                        line_offsets[comp_num], shift, comp_width);
+              line_offsets[comp_num], shift, comp_width);
           }
         }
         else
         {
           if (nlt_type3[comp_num] == type3)
             irv_convert_to_integer_nlt_type3(src_line, tgt_line,
-                                             line_offsets[comp_num], num_bits[comp_num],
-                                             is_signed[comp_num], comp_width);
+              line_offsets[comp_num], num_bits[comp_num],
+              is_signed[comp_num], comp_width);
           else
             irv_convert_to_integer(src_line, tgt_line,
-                                   line_offsets[comp_num], num_bits[comp_num],
-                                   is_signed[comp_num], comp_width);
+              line_offsets[comp_num], num_bits[comp_num],
+              is_signed[comp_num], comp_width);
         }
       }
       else
       {
         assert(num_comps >= 3);
-        ui32 comp_width = recon_comp_rects[comp_num].siz.w;
         if (comp_num == 0)
         {
           if (reversible[comp_num])
             rct_backward(comps[0].pull_line(), comps[1].pull_line(),
-                         comps[2].pull_line(), lines + 0, lines + 1,
-                         lines + 2, comp_width);
+              comps[2].pull_line(), lines + 0, lines + 1,
+              lines + 2, comp_width);
           else
             ict_backward(comps[0].pull_line()->f32, comps[1].pull_line()->f32,
-                         comps[2].pull_line()->f32, lines[0].f32, lines[1].f32,
-                         lines[2].f32, comp_width);
+              comps[2].pull_line()->f32, lines[0].f32, lines[1].f32,
+              lines[2].f32, comp_width);
         }
         if (reversible[comp_num])
         {
           si64 shift = (si64)1 << (num_bits[comp_num] - 1);
-          line_buf *src_line;
+          line_buf* src_line;
           if (comp_num < 3)
             src_line = lines + comp_num;
           else
             src_line = comps[comp_num].pull_line();
           if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
             rev_convert_nlt_type3(src_line, 0, tgt_line,
-                                  line_offsets[comp_num], shift + 1, comp_width);
-          else
-          {
+              line_offsets[comp_num], shift + 1, comp_width);
+          else {
             shift = is_signed[comp_num] ? 0 : shift;
             rev_convert(src_line, 0, tgt_line,
-                        line_offsets[comp_num], shift, comp_width);
+              line_offsets[comp_num], shift, comp_width);
           }
         }
         else
         {
-          line_buf *lbp;
+          line_buf* lbp;
           if (comp_num < 3)
             lbp = lines + comp_num;
           else
             lbp = comps[comp_num].pull_line();
           if (nlt_type3[comp_num] == type3)
             irv_convert_to_integer_nlt_type3(lbp, tgt_line,
-                                             line_offsets[comp_num], num_bits[comp_num],
-                                             is_signed[comp_num], comp_width);
+              line_offsets[comp_num], num_bits[comp_num],
+              is_signed[comp_num], comp_width);
           else
             irv_convert_to_integer(lbp, tgt_line,
-                                   line_offsets[comp_num], num_bits[comp_num],
-                                   is_signed[comp_num], comp_width);
+              line_offsets[comp_num], num_bits[comp_num],
+              is_signed[comp_num], comp_width);
         }
       }
 
       return true;
     }
 
+
     //////////////////////////////////////////////////////////////////////////
     void tile::prepare_for_flush()
     {
       this->num_bytes = 0;
-      // prepare precinct headers
+      //prepare precinct headers
       for (ui32 c = 0; c < num_comps; ++c)
         num_bytes += comps[c].prepare_precincts();
     }
@@ -516,8 +528,7 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
     void tile::fill_tlm(param_tlm *tlm)
     {
-      if (tilepart_div == OJPH_TILEPART_NO_DIVISIONS)
-      {
+      if (tilepart_div == OJPH_TILEPART_NO_DIVISIONS) {
         tlm->set_next_pair(sot.get_tile_index(), this->num_bytes);
       }
       else if (tilepart_div == OJPH_TILEPART_RESOLUTIONS)
@@ -567,27 +578,29 @@ namespace ojph
       }
     }
 
+
     //////////////////////////////////////////////////////////////////////////
     void tile::flush(outfile_base *file)
     {
       ui32 max_decompositions = 0;
       for (ui32 c = 0; c < num_comps; ++c)
         max_decompositions = ojph_max(max_decompositions,
-                                      comps[c].get_num_decompositions());
+          comps[c].get_num_decompositions());
 
       if (tilepart_div == OJPH_TILEPART_NO_DIVISIONS)
       {
-        // write tile header
+        //write tile header
         if (!sot.write(file, this->num_bytes))
           OJPH_ERROR(0x00030081, "Error writing to file");
 
-        // write start of data
-        ui16 t = swap_byte(JP2K_MARKER::SOD);
+        //write start of data
+        ui16 t = swap_bytes_if_le(JP2K_MARKER::SOD);
         if (!file->write(&t, 2))
           OJPH_ERROR(0x00030082, "Error writing to file");
       }
 
-      // sequence the writing of precincts according to progression order
+
+      //sequence the writing of precincts according to progression order
       if (prog_order == OJPH_PO_LRCP || prog_order == OJPH_PO_RLCP)
       {
         if (tilepart_div == OJPH_TILEPART_NO_DIVISIONS)
@@ -604,16 +617,16 @@ namespace ojph
             for (ui32 c = 0; c < num_comps; ++c)
               bytes += comps[c].get_num_bytes(r);
 
-            // write tile header
+            //write tile header
             if (!sot.write(file, bytes, (ui8)r, (ui8)(max_decompositions + 1)))
               OJPH_ERROR(0x00030083, "Error writing to file");
 
-            // write start of data
-            ui16 t = swap_byte(JP2K_MARKER::SOD);
+            //write start of data
+            ui16 t = swap_bytes_if_le(JP2K_MARKER::SOD);
             if (!file->write(&t, 2))
               OJPH_ERROR(0x00030084, "Error writing to file");
 
-            // write precincts
+            //write precincts
             for (ui32 c = 0; c < num_comps; ++c)
               comps[c].write_precincts(r, file);
           }
@@ -623,14 +636,13 @@ namespace ojph
           ui32 num_tileparts = num_comps * (max_decompositions + 1);
           for (ui32 r = 0; r <= max_decompositions; ++r)
             for (ui32 c = 0; c < num_comps; ++c)
-              if (r <= comps[c].get_num_decompositions())
-              {
-                // write tile header
+              if (r <= comps[c].get_num_decompositions()) {
+                //write tile header
                 if (!sot.write(file, comps[c].get_num_bytes(r),
                                (ui8)(c + r * num_comps), (ui8)num_tileparts))
                   OJPH_ERROR(0x00030085, "Error writing to file");
-                // write start of data
-                ui16 t = swap_byte(JP2K_MARKER::SOD);
+                //write start of data
+                ui16 t = swap_bytes_if_le(JP2K_MARKER::SOD);
                 if (!file->write(&t, 2))
                   OJPH_ERROR(0x00030086, "Error writing to file");
                 comps[c].write_precincts(r, file);
@@ -646,12 +658,12 @@ namespace ojph
             ui32 bytes = 0;
             for (ui32 c = 0; c < num_comps; ++c)
               bytes += comps[c].get_num_bytes(r);
-            // write tile header
+            //write tile header
             if (!sot.write(file, bytes, (ui8)r, (ui8)(max_decompositions + 1)))
               OJPH_ERROR(0x00030087, "Error writing to file");
 
-            // write start of data
-            ui16 t = swap_byte(JP2K_MARKER::SOD);
+            //write start of data
+            ui16 t = swap_bytes_if_le(JP2K_MARKER::SOD);
             if (!file->write(&t, 2))
               OJPH_ERROR(0x00030088, "Error writing to file");
           }
@@ -668,15 +680,9 @@ namespace ojph
                 found = true;
 
               if (cur.y < smallest.y)
-              {
-                smallest = cur;
-                comp_num = c;
-              }
+              { smallest = cur; comp_num = c; }
               else if (cur.y == smallest.y && cur.x < smallest.x)
-              {
-                smallest = cur;
-                comp_num = c;
-              }
+              { smallest = cur; comp_num = c; }
             }
             if (found == true)
               comps[comp_num].write_one_precinct(r, file);
@@ -703,31 +709,15 @@ namespace ojph
                 found = true;
 
               if (cur.y < smallest.y)
-              {
-                smallest = cur;
-                comp_num = c;
-                res_num = r;
-              }
+              { smallest = cur; comp_num = c; res_num = r; }
               else if (cur.y == smallest.y && cur.x < smallest.x)
-              {
-                smallest = cur;
-                comp_num = c;
-                res_num = r;
-              }
+              { smallest = cur; comp_num = c; res_num = r; }
               else if (cur.y == smallest.y && cur.x == smallest.x &&
                        c < comp_num)
-              {
-                smallest = cur;
-                comp_num = c;
-                res_num = r;
-              }
+              { smallest = cur; comp_num = c; res_num = r; }
               else if (cur.y == smallest.y && cur.x == smallest.x &&
                        c == comp_num && r < res_num)
-              {
-                smallest = cur;
-                comp_num = c;
-                res_num = r;
-              }
+              { smallest = cur; comp_num = c; res_num = r; }
             }
           }
           if (found == true)
@@ -743,12 +733,12 @@ namespace ojph
           if (tilepart_div == OJPH_TILEPART_COMPONENTS)
           {
             ui32 bytes = comps[c].get_num_bytes();
-            // write tile header
+            //write tile header
             if (!sot.write(file, bytes, (ui8)c, (ui8)num_comps))
               OJPH_ERROR(0x0003008A, "Error writing to file");
 
-            // write start of data
-            ui16 t = swap_byte(JP2K_MARKER::SOD);
+            //write start of data
+            ui16 t = swap_bytes_if_le(JP2K_MARKER::SOD);
             if (!file->write(&t, 2))
               OJPH_ERROR(0x0003008B, "Error writing to file");
           }
@@ -760,21 +750,15 @@ namespace ojph
             point smallest(INT_MAX, INT_MAX), cur;
             for (ui32 r = 0; r <= max_decompositions; ++r)
             {
-              if (!comps[c].get_top_left_precinct(r, cur)) // res exist?
+              if (!comps[c].get_top_left_precinct(r, cur)) //res exist?
                 continue;
               else
                 found = true;
 
               if (cur.y < smallest.y)
-              {
-                smallest = cur;
-                res_num = r;
-              }
+              { smallest = cur; res_num = r; }
               else if (cur.y == smallest.y && cur.x < smallest.x)
-              {
-                smallest = cur;
-                res_num = r;
-              }
+              { smallest = cur; res_num = r; }
             }
             if (found == true)
               comps[c].write_one_precinct(res_num, file);
@@ -785,11 +769,12 @@ namespace ojph
       }
       else
         assert(0);
+
     }
 
     //////////////////////////////////////////////////////////////////////////
     void tile::parse_tile_header(const param_sot &sot, infile_base *file,
-                                 const ui64 &tile_start_location)
+                                 const ui64& tile_start_location)
     {
       if (sot.get_tile_part_index() != next_tile_part)
       {
@@ -800,10 +785,10 @@ namespace ojph
       }
       ++next_tile_part;
 
-      // tile_end_location used on failure
+      //tile_end_location used on failure
       ui64 tile_end_location = tile_start_location + sot.get_payload_length();
 
-      ui32 data_left = sot.get_payload_length(); // bytes left to parse
+      ui32 data_left = sot.get_payload_length(); //bytes left to parse
       data_left -= (ui32)((ui64)file->tell() - tile_start_location);
 
       if (data_left == 0)
@@ -812,11 +797,11 @@ namespace ojph
       ui32 max_decompositions = 0;
       for (ui32 c = 0; c < num_comps; ++c)
         max_decompositions = ojph_max(max_decompositions,
-                                      comps[c].get_num_decompositions());
+          comps[c].get_num_decompositions());
 
       try
       {
-        // sequence the reading of precincts according to progression order
+        //sequence the reading of precincts according to progression order
         if (prog_order == OJPH_PO_LRCP || prog_order == OJPH_PO_RLCP)
         {
           max_decompositions -= skipped_res_for_read;
@@ -843,15 +828,9 @@ namespace ojph
                   found = true;
 
                 if (cur.y < smallest.y)
-                {
-                  smallest = cur;
-                  comp_num = c;
-                }
+                { smallest = cur; comp_num = c; }
                 else if (cur.y == smallest.y && cur.x < smallest.x)
-                {
-                  smallest = cur;
-                  comp_num = c;
-                }
+                { smallest = cur; comp_num = c; }
               }
               if (found == true && data_left > 0)
                 comps[comp_num].parse_one_precinct(r, data_left, file);
@@ -878,31 +857,15 @@ namespace ojph
                   found = true;
 
                 if (cur.y < smallest.y)
-                {
-                  smallest = cur;
-                  comp_num = c;
-                  res_num = r;
-                }
+                { smallest = cur; comp_num = c; res_num = r; }
                 else if (cur.y == smallest.y && cur.x < smallest.x)
-                {
-                  smallest = cur;
-                  comp_num = c;
-                  res_num = r;
-                }
+                { smallest = cur; comp_num = c; res_num = r; }
                 else if (cur.y == smallest.y && cur.x == smallest.x &&
                          c < comp_num)
-                {
-                  smallest = cur;
-                  comp_num = c;
-                  res_num = r;
-                }
+                { smallest = cur; comp_num = c; res_num = r; }
                 else if (cur.y == smallest.y && cur.x == smallest.x &&
                          c == comp_num && r < res_num)
-                {
-                  smallest = cur;
-                  comp_num = c;
-                  res_num = r;
-                }
+                { smallest = cur; comp_num = c; res_num = r; }
               }
             }
             if (found == true && data_left > 0)
@@ -922,21 +885,15 @@ namespace ojph
               point smallest(INT_MAX, INT_MAX), cur;
               for (ui32 r = 0; r <= max_decompositions; ++r)
               {
-                if (!comps[c].get_top_left_precinct(r, cur)) // res exist?
+                if (!comps[c].get_top_left_precinct(r, cur)) //res exist?
                   continue;
                 else
                   found = true;
 
                 if (cur.y < smallest.y)
-                {
-                  smallest = cur;
-                  res_num = r;
-                }
+                { smallest = cur; res_num = r; }
                 else if (cur.y == smallest.y && cur.x < smallest.x)
-                {
-                  smallest = cur;
-                  res_num = r;
-                }
+                { smallest = cur; res_num = r; }
               }
               if (found == true && data_left > 0)
                 comps[c].parse_one_precinct(res_num, data_left, file);
@@ -947,6 +904,7 @@ namespace ojph
         }
         else
           assert(0);
+
       }
       catch (const char *error)
       {

--- a/Native/Common/OpenJPH/codestream/ojph_tile.h
+++ b/Native/Common/OpenJPH/codestream/ojph_tile.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_TILE_H
 #define OJPH_TILE_H
 
@@ -42,46 +43,44 @@
 #include "ojph_file.h"
 #include "ojph_params_local.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class line_buf;
   class codestream;
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    // defined here
+    //defined here
     class tile_comp;
 
     //////////////////////////////////////////////////////////////////////////
     class tile
     {
     public:
-      static void pre_alloc(codestream *codestream, const rect &tile_rect,
-                            const rect &recon_tile_rect, ui32 &num_tileparts);
-      void finalize_alloc(codestream *codestream, const rect &tile_rect,
-                          ui32 tile_idx, ui32 &offset, ui32 &num_tileparts);
+      static void pre_alloc(codestream *codestream, const rect& tile_rect,
+                            const rect& recon_tile_rect, ui32 &num_tileparts);
+      void finalize_alloc(codestream *codestream, const rect& tile_rect,
+                          ui32 tile_idx, ui32& offset, ui32 &num_tileparts);
 
       bool push(line_buf *line, ui32 comp_num);
       void prepare_for_flush();
-      void fill_tlm(param_tlm *tlm);
+      void fill_tlm(param_tlm* tlm);
       void flush(outfile_base *file);
-      void parse_tile_header(const param_sot &sot, infile_base *file,
-                             const ui64 &tile_start_location);
+      void parse_tile_header(const param_sot& sot, infile_base *file,
+                             const ui64& tile_start_location);
       bool pull(line_buf *, ui32 comp_num);
       rect get_tile_rect() { return tile_rect; }
 
     private:
-      // codestream *parent;
+      //codestream *parent;
       rect tile_rect;
       ui32 num_comps;
       tile_comp *comps;
       ui32 num_lines;
-      line_buf *lines;
+      line_buf* lines;
       bool employ_color_transform, resilient;
       bool *reversible;
       rect *comp_rects, *recon_comp_rects;
@@ -100,13 +99,13 @@ namespace ojph
 
     private:
       int profile;
-      ui32 tilepart_div; // tilepart division value
-      bool need_tlm;     // true if tlm markers are needed
+      ui32 tilepart_div;    // tilepart division value
+      bool need_tlm;        // true if tlm markers are needed
 
       ui32 num_bytes; // number of bytes in this tile
                       // used for tile length
     };
-
+    
   }
 }
 

--- a/Native/Common/OpenJPH/codestream/ojph_tile_comp.cpp
+++ b/Native/Common/OpenJPH/codestream/ojph_tile_comp.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <climits>
 #include <cmath>
 
@@ -44,36 +45,35 @@
 #include "ojph_tile_comp.h"
 #include "ojph_resolution.h"
 
-namespace ojph
-{
+namespace ojph {
 
   namespace local
   {
 
     //////////////////////////////////////////////////////////////////////////
-    void tile_comp::pre_alloc(codestream *codestream, ui32 comp_num,
-                              const rect &comp_rect,
-                              const rect &recon_comp_rect)
+    void tile_comp::pre_alloc(codestream *codestream, ui32 comp_num, 
+                              const rect& comp_rect,
+                              const rect& recon_comp_rect)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      mem_fixed_allocator* allocator = codestream->get_allocator();
 
-      // allocate a resolution
+      //allocate a resolution
       ui32 num_decomps;
       num_decomps = codestream->get_coc(comp_num)->get_num_decompositions();
       allocator->pre_alloc_obj<resolution>(1);
 
-      resolution::pre_alloc(codestream, comp_rect, recon_comp_rect, comp_num,
+      resolution::pre_alloc(codestream, comp_rect, recon_comp_rect, comp_num, 
                             num_decomps);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void tile_comp::finalize_alloc(codestream *codestream, tile *parent,
-                                   ui32 comp_num, const rect &comp_rect,
-                                   const rect &recon_comp_rect)
+                                  ui32 comp_num, const rect& comp_rect,
+                                  const rect& recon_comp_rect)
     {
-      mem_fixed_allocator *allocator = codestream->get_allocator();
+      mem_fixed_allocator* allocator = codestream->get_allocator();
 
-      // allocate a resolution
+      //allocate a resolution
       num_decomps = codestream->get_coc(comp_num)->get_num_decompositions();
 
       comp_downsamp = codestream->get_siz()->get_downsampling(comp_num);
@@ -84,12 +84,12 @@ namespace ojph
       this->num_bytes = 0;
       res = allocator->post_alloc_obj<resolution>(1);
       res->finalize_alloc(codestream, comp_rect, recon_comp_rect, comp_num,
-                          num_decomps, comp_downsamp, comp_downsamp, this,
+                          num_decomps, comp_downsamp, comp_downsamp, this, 
                           NULL);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    line_buf *tile_comp::get_line()
+    line_buf* tile_comp::get_line()
     {
       return res->get_line();
     }
@@ -101,7 +101,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    line_buf *tile_comp::pull_line()
+    line_buf* tile_comp::pull_line()
     {
       return res->pull_line();
     }
@@ -117,14 +117,14 @@ namespace ojph
     void tile_comp::write_precincts(ui32 res_num, outfile_base *file)
     {
       assert(res_num <= num_decomps);
-      res_num = num_decomps - res_num; // how many levels to go down
+      res_num = num_decomps - res_num; //how many levels to go down
       resolution *r = res;
       while (res_num > 0 && r != NULL)
       {
         r = r->next_resolution();
         --res_num;
       }
-      if (r) // resolution does not exist if r is NULL
+      if (r) //resolution does not exist if r is NULL
         r->write_precincts(file);
     }
 
@@ -133,12 +133,12 @@ namespace ojph
     {
       int resolution_num = (int)num_decomps - (int)res_num;
       resolution *r = res;
-      while (resolution_num > 0 && r != NULL)
+       while (resolution_num > 0 && r != NULL)
       {
         r = r->next_resolution();
         --resolution_num;
       }
-      if (r) // resolution does not exist if r is NULL
+      if (r) //resolution does not exist if r is NULL
         return r->get_top_left_precinct(top_left);
       else
         return false;
@@ -154,28 +154,29 @@ namespace ojph
         r = r->next_resolution();
         --resolution_num;
       }
-      if (r) // resolution does not exist if r is NULL
+      if (r) //resolution does not exist if r is NULL
         r->write_one_precinct(file);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void tile_comp::parse_precincts(ui32 res_num, ui32 &data_left,
+    void tile_comp::parse_precincts(ui32 res_num, ui32& data_left,
                                     infile_base *file)
     {
       assert(res_num <= num_decomps);
-      res_num = num_decomps - res_num; // how many levels to go down
+      res_num = num_decomps - res_num; //how many levels to go down
       resolution *r = res;
       while (res_num > 0 && r != NULL)
       {
         r = r->next_resolution();
         --res_num;
       }
-      if (r) // resolution does not exist if r is NULL
+      if (r) //resolution does not exist if r is NULL
         r->parse_all_precincts(data_left, file);
     }
 
+
     //////////////////////////////////////////////////////////////////////////
-    void tile_comp::parse_one_precinct(ui32 res_num, ui32 &data_left,
+    void tile_comp::parse_one_precinct(ui32 res_num, ui32& data_left,
                                        infile_base *file)
     {
       assert(res_num <= num_decomps);
@@ -186,7 +187,7 @@ namespace ojph
         r = r->next_resolution();
         --res_num;
       }
-      if (r) // resolution does not exist if r is NULL
+      if (r) //resolution does not exist if r is NULL
         r->parse_one_precinct(data_left, file);
     }
 

--- a/Native/Common/OpenJPH/codestream/ojph_tile_comp.h
+++ b/Native/Common/OpenJPH/codestream/ojph_tile_comp.h
@@ -3,21 +3,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -36,6 +36,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_TILE_COMP_H
 #define OJPH_TILE_COMP_H
 
@@ -43,19 +44,17 @@
 #include "ojph_base.h"
 #include "ojph_file.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class line_buf;
   class codestream;
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    // defined here
+    //defined here
     class tile;
     class resolution;
 
@@ -63,26 +62,26 @@ namespace ojph
     class tile_comp
     {
     public:
-      static void pre_alloc(codestream *codestream, ui32 comp_num,
-                            const rect &comp_rect,
-                            const rect &recon_comp_rect);
+      static void pre_alloc(codestream *codestream, ui32 comp_num, 
+                            const rect& comp_rect,
+                            const rect& recon_comp_rect);
       void finalize_alloc(codestream *codestream, tile *parent,
-                          ui32 comp_num, const rect &comp_rect,
-                          const rect &recon_comp_rect);
+                          ui32 comp_num, const rect& comp_rect,
+                          const rect& recon_comp_rect);
 
       ui32 get_num_resolutions() { return num_decomps + 1; }
       ui32 get_num_decompositions() { return num_decomps; }
-      tile *get_tile() { return parent_tile; }
-      line_buf *get_line();
+      tile* get_tile() { return parent_tile; }
+      line_buf* get_line();
       void push_line();
-      line_buf *pull_line();
+      line_buf* pull_line();
 
       ui32 prepare_precincts();
       void write_precincts(ui32 res_num, outfile_base *file);
       bool get_top_left_precinct(ui32 res_num, point &top_left);
       void write_one_precinct(ui32 res_num, outfile_base *file);
-      void parse_precincts(ui32 res_num, ui32 &data_left, infile_base *file);
-      void parse_one_precinct(ui32 res_num, ui32 &data_left,
+      void parse_precincts(ui32 res_num, ui32& data_left, infile_base *file);
+      void parse_one_precinct(ui32 res_num, ui32& data_left, 
                               infile_base *file);
 
       ui32 get_num_bytes() const { return num_bytes; }

--- a/Native/Common/OpenJPH/coding/ojph_block_common.cpp
+++ b/Native/Common/OpenJPH/coding/ojph_block_common.cpp
@@ -2,21 +2,22 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -32,6 +33,7 @@
 // This file is part of the OpenJPH software implementation.
 // File: ojph_block_common.cpp
 // Author: Aous Naman
+// Author: Osamu Watanabe
 // Date: 13 May 2022
 //***************************************************************************/
 
@@ -45,16 +47,14 @@
  *  @brief defines tables used for decoding HTJ2K blocks
  */
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //************************************************************************/
     /** @defgroup vlc_decoding_tables_grp VLC decoding tables
      *  @{
      *  VLC decoding tables used in decoding VLC codewords to these fields:  \n
-     *  \li \c cwd_len : 3bits -> the codeword length of the VLC codeword;
+     *  \li \c cwd_len : 3bits -> the codeword length of the VLC codeword;    
      *                   the VLC cwd is in the LSB of bitstream              \n
      *  \li \c u_off   : 1bit  -> u_offset, which is 1 if u value is not 0   \n
      *  \li \c rho     : 4bits -> significant samples within a quad           \n
@@ -62,25 +62,25 @@ namespace ojph
      *  \li \c e_k     : 4bits -> EMB e_k                                    \n
      *                                                                       \n
      *  The table index is 10 bits and composed of two parts:                \n
-     *  The 7 LSBs contain a codeword which might be shorter than 7 bits;
+     *  The 7 LSBs contain a codeword which might be shorter than 7 bits;    
      *  this word is the next decodable bits in the bitstream.                \n
      *  The 3 MSB is the context of for the codeword.                        \n
      */
 
     /// @brief vlc_tbl0 contains decoding information for initial row of quads
-    ui16 vlc_tbl0[1024] = {0};
-    /// @brief vlc_tbl1 contains decoding information for non-initial row of
+    ui16 vlc_tbl0[1024] = { 0 };
+    /// @brief vlc_tbl1 contains decoding information for non-initial row of 
     ///        quads
-    ui16 vlc_tbl1[1024] = {0};
+    ui16 vlc_tbl1[1024] = { 0 };
     /// @}
 
     //************************************************************************/
     /** @defgroup uvlc_decoding_tables_grp VLC decoding tables
      *  @{
-     *  UVLC decoding tables used to partially decode u values from UVLC
+     *  UVLC decoding tables used to partially decode u values from UVLC     
      *  codewords.                                                           \n
      *  The table index is 8 (or 9)  bits and composed of two parts:         \n
-     *  The 6 LSBs carries the head of the VLC to be decoded. Up to 6 bits to
+     *  The 6 LSBs carries the head of the VLC to be decoded. Up to 6 bits to 
      *  be used; these are uvlc prefix code for quad 0 and 1                 \n
      *  The 2 (or 3) MSBs contain u_off of quad 0 + 2 * o_off quad 1
      *  + 4 * mel event for initial row of quads when needed                 \n
@@ -92,9 +92,9 @@ namespace ojph
      *  \li \c prefix for quad 0 (3 bits)                                    \n
      *  \li \c prefix for quad 1 (3 bits)                                    \n
      *                                                                       \n
-     *  Another table is uvlc_bias, which is needed to correctly decode the
+     *  Another table is uvlc_bias, which is needed to correctly decode the 
      *  extension u_ext for initial row of quads. Under certain condition,
-     *  we deduct 1 or 2 from u_q0 and u_q1 before encoding them; so for us
+     *  we deduct 1 or 2 from u_q0 and u_q1 before encoding them; so for us 
      *  to know that decoding u_ext is needed, we recreate the u_q0 and u_q1
      *  that we actually encoded.                                            \n
      *  For simplicity, we use the same index as before                      \n
@@ -103,12 +103,17 @@ namespace ojph
      */
 
     /// @brief uvlc_tbl0 contains decoding information for initial row of quads
-    ui16 uvlc_tbl0[256 + 64] = {0};
+    ui16 uvlc_tbl0[256+64] = { 0 };
     /// @brief uvlc_tbl1 contains decoding information for non-initial row of
     ///        quads
-    ui16 uvlc_tbl1[256] = {0};
+    ui16 uvlc_tbl1[256] = { 0 };
+    /// @brief uvlc_tbl1_wide: wider UVLC table for non-initial rows.
+    ///        Index = mode(2 bits) * 1024 + vlc_data(10 bits) = 12 bits.
+    ///        Entry bits: [4:0]=total_bits, [12:5]=u_q0, [20:13]=u_q1.
+    ///        total_bits == 0x1F means fallback to original decode path.
+    ui32 uvlc_tbl1_wide[4096] = { 0 };
     /// @brief uvlc_bias contains decoding info. for initial row of quads
-    ui8 uvlc_bias[256 + 64] = {0};
+    ui8 uvlc_bias[256+64] = { 0 };
     /// @}
 
     //************************************************************************/
@@ -118,71 +123,66 @@ namespace ojph
      */
     static bool vlc_init_tables()
     {
-      const bool debug = false; // useful for checking
+      const bool debug = false; //useful for checking 
 
-      // Data in the table is arranged in this format (taken from the standard)
-      //  c_q is the context for a quad
-      //  rho is the significance pattern for a quad
-      //  u_off indicate if u value is 0 (u_off is 0), or communicated
-      //  e_k, e_1 EMB patterns
-      //  cwd VLC codeword
-      //  cwd VLC codeword length
-      struct vlc_src_table
-      {
-        int c_q, rho, u_off, e_k, e_1, cwd, cwd_len;
-      };
+      //Data in the table is arranged in this format (taken from the standard)
+      // c_q is the context for a quad
+      // rho is the significance pattern for a quad
+      // u_off indicate if u value is 0 (u_off is 0), or communicated
+      // e_k, e_1 EMB patterns
+      // cwd VLC codeword
+      // cwd VLC codeword length
+      struct vlc_src_table { int c_q, rho, u_off, e_k, e_1, cwd, cwd_len; };
       // initial quad rows
       vlc_src_table tbl0[] = {
-#include "table0.h"
+    #include "table0.h"
       };
       // number of entries in the table
-      size_t tbl0_size = sizeof(tbl0) / sizeof(vlc_src_table);
+      size_t tbl0_size = sizeof(tbl0) / sizeof(vlc_src_table); 
 
       // nono-initial quad rows
       vlc_src_table tbl1[] = {
-#include "table1.h"
+    #include "table1.h"
       };
       // number of entries in the table
       size_t tbl1_size = sizeof(tbl1) / sizeof(vlc_src_table);
 
-      if (debug)
-        memset(vlc_tbl0, 0, sizeof(vlc_tbl0)); // unnecessary
+      if (debug) memset(vlc_tbl0, 0, sizeof(vlc_tbl0)); //unnecessary
 
       // this is to convert table entries into values for decoder look up
       // There can be at most 1024 possibilities, not all of them are valid.
-      //
+      // 
       for (int i = 0; i < 1024; ++i)
       {
         int cwd = i & 0x7F; // from i extract codeword
         int c_q = i >> 7;   // from i extract context
         // See if this case exist in the table, if so then set the entry in
         // vlc_tbl0
-        for (size_t j = 0; j < tbl0_size; ++j)
+        for (size_t j = 0; j < tbl0_size; ++j) 
           if (tbl0[j].c_q == c_q) // this is an and operation
             if (tbl0[j].cwd == (cwd & ((1 << tbl0[j].cwd_len) - 1)))
             {
-              if (debug)
-                assert(vlc_tbl0[i] == 0);
+              if (debug) assert(vlc_tbl0[i] == 0);
               // Put this entry into the table
-              vlc_tbl0[i] = (ui16)((tbl0[j].rho << 4) | (tbl0[j].u_off << 3) | (tbl0[j].e_k << 12) | (tbl0[j].e_1 << 8) | tbl0[j].cwd_len);
+              vlc_tbl0[i] = (ui16)((tbl0[j].rho << 4) | (tbl0[j].u_off << 3)
+                | (tbl0[j].e_k << 12) | (tbl0[j].e_1 << 8) | tbl0[j].cwd_len);
             }
       }
 
-      if (debug)
-        memset(vlc_tbl1, 0, sizeof(vlc_tbl1)); // unnecessary
+      if (debug) memset(vlc_tbl1, 0, sizeof(vlc_tbl1)); //unnecessary
 
       // this the same as above but for non-initial rows
       for (int i = 0; i < 1024; ++i)
       {
-        int cwd = i & 0x7F; // 7 bits
+        int cwd = i & 0x7F; //7 bits
         int c_q = i >> 7;
         for (size_t j = 0; j < tbl1_size; ++j)
           if (tbl1[j].c_q == c_q) // this is an and operation
             if (tbl1[j].cwd == (cwd & ((1 << tbl1[j].cwd_len) - 1)))
             {
-              if (debug)
-                assert(vlc_tbl1[i] == 0);
-              vlc_tbl1[i] = (ui16)((tbl1[j].rho << 4) | (tbl1[j].u_off << 3) | (tbl1[j].e_k << 12) | (tbl1[j].e_1 << 8) | tbl1[j].cwd_len);
+              if (debug) assert(vlc_tbl1[i] == 0);
+              vlc_tbl1[i] = (ui16)((tbl1[j].rho << 4) | (tbl1[j].u_off << 3)
+                | (tbl1[j].e_k << 12) | (tbl1[j].e_1 << 8) | tbl1[j].cwd_len);
             }
       }
 
@@ -198,34 +198,32 @@ namespace ojph
       // table stores possible decoding three bits from vlc
       // there are 8 entries for xx1, x10, 100, 000, where x means do not
       // care table value is made up of
-      // 2 bits in the LSB for prefix length
+      // 2 bits in the LSB for prefix length 
       // 3 bits for suffix length
       // 3 bits in the MSB for prefix value (u_pfx in Table 3 of ITU T.814)
-      static const ui8 dec[8] = {
-          // the index is the prefix codeword
-          3 | (5 << 2) | (5 << 5), // 000 == 000, prefix codeword "000"
-          1 | (0 << 2) | (1 << 5), // 001 == xx1, prefix codeword "1"
-          2 | (0 << 2) | (2 << 5), // 010 == x10, prefix codeword "01"
-          1 | (0 << 2) | (1 << 5), // 011 == xx1, prefix codeword "1"
-          3 | (1 << 2) | (3 << 5), // 100 == 100, prefix codeword "001"
-          1 | (0 << 2) | (1 << 5), // 101 == xx1, prefix codeword "1"
-          2 | (0 << 2) | (2 << 5), // 110 == x10, prefix codeword "01"
-          1 | (0 << 2) | (1 << 5)  // 111 == xx1, prefix codeword "1"
+      static const ui8 dec[8] = { // the index is the prefix codeword
+        3 | (5 << 2) | (5 << 5), //000 == 000, prefix codeword "000"
+        1 | (0 << 2) | (1 << 5), //001 == xx1, prefix codeword "1"
+        2 | (0 << 2) | (2 << 5), //010 == x10, prefix codeword "01"
+        1 | (0 << 2) | (1 << 5), //011 == xx1, prefix codeword "1"
+        3 | (1 << 2) | (3 << 5), //100 == 100, prefix codeword "001"
+        1 | (0 << 2) | (1 << 5), //101 == xx1, prefix codeword "1"
+        2 | (0 << 2) | (2 << 5), //110 == x10, prefix codeword "01"
+        1 | (0 << 2) | (1 << 5)  //111 == xx1, prefix codeword "1"
       };
 
       for (ui32 i = 0; i < 256 + 64; ++i)
-      {
+      { 
         ui32 mode = i >> 6;
         ui32 vlc = i & 0x3F;
 
-        if (mode == 0)
-        { // both u_off are 0
+        if (mode == 0) {      // both u_off are 0
           uvlc_tbl0[i] = 0;
           uvlc_bias[i] = 0;
         }
         else if (mode <= 2) // u_off are either 01 or 10
         {
-          ui32 d = dec[vlc & 0x7]; // look at the least significant 3 bits
+          ui32 d = dec[vlc & 0x7];   //look at the least significant 3 bits
 
           ui32 total_prefix = d & 0x3;
           ui32 total_suffix = (d >> 2) & 0x7;
@@ -233,17 +231,18 @@ namespace ojph
           ui32 u0 = (mode == 1) ? (d >> 5) : 0;
           ui32 u1 = (mode == 1) ? 0 : (d >> 5);
 
-          uvlc_tbl0[i] = (ui16)(total_prefix |
-                                (total_suffix << 3) |
-                                (u0_suffix_len << 7) |
-                                (u0 << 10) |
-                                (u1 << 13));
+          uvlc_tbl0[i] = (ui16)(total_prefix | 
+                               (total_suffix << 3) |
+                               (u0_suffix_len << 7) |
+                               (u0 << 10) |
+                               (u1 << 13));
+          
         }
         else if (mode == 3) // both u_off are 1, and MEL event is 0
         {
-          ui32 d0 = dec[vlc & 0x7]; // LSBs of VLC are prefix codeword
-          vlc >>= d0 & 0x3;         // Consume bits
-          ui32 d1 = dec[vlc & 0x7]; // LSBs of VLC are prefix codeword
+          ui32 d0 = dec[vlc & 0x7];  // LSBs of VLC are prefix codeword
+          vlc >>= d0 & 0x3;          // Consume bits
+          ui32 d1 = dec[vlc & 0x7];  // LSBs of VLC are prefix codeword
 
           ui32 total_prefix, u0_suffix_len, total_suffix, u0, u1;
           if ((d0 & 0x3) == 3)
@@ -265,17 +264,17 @@ namespace ojph
             uvlc_bias[i] = 0;
           }
 
-          uvlc_tbl0[i] = (ui16)(total_prefix |
-                                (total_suffix << 3) |
-                                (u0_suffix_len << 7) |
-                                (u0 << 10) |
-                                (u1 << 13));
+          uvlc_tbl0[i] = (ui16)(total_prefix | 
+                               (total_suffix << 3) |
+                               (u0_suffix_len << 7) |
+                               (u0 << 10) |
+                               (u1 << 13));
         }
         else if (mode == 4) // both u_off are 1, and MEL event is 1
         {
-          ui32 d0 = dec[vlc & 0x7]; // LSBs of VLC are prefix codeword
-          vlc >>= d0 & 0x3;         // Consume bits
-          ui32 d1 = dec[vlc & 0x7]; // LSBs of VLC are prefix codeword
+          ui32 d0 = dec[vlc & 0x7];  // LSBs of VLC are prefix codeword
+          vlc >>= d0 & 0x3;          // Consume bits
+          ui32 d1 = dec[vlc & 0x7];  // LSBs of VLC are prefix codeword
 
           ui32 total_prefix = (d0 & 0x3) + (d1 & 0x3);
           ui32 u0_suffix_len = (d0 >> 2) & 0x7;
@@ -283,11 +282,11 @@ namespace ojph
           ui32 u0 = (d0 >> 5) + 2;
           ui32 u1 = (d1 >> 5) + 2;
 
-          uvlc_tbl0[i] = (ui16)(total_prefix |
-                                (total_suffix << 3) |
-                                (u0_suffix_len << 7) |
-                                (u0 << 10) |
-                                (u1 << 13));
+          uvlc_tbl0[i] = (ui16)(total_prefix | 
+                               (total_suffix << 3) |
+                               (u0_suffix_len << 7) |
+                               (u0 << 10) |
+                               (u1 << 13));
           uvlc_bias[i] = 10; // 0b10 for u0 and 0b10 for u1
         }
       }
@@ -297,11 +296,11 @@ namespace ojph
         ui32 mode = i >> 6;
         ui32 vlc = i & 0x3F;
 
-        if (mode == 0) // both u_off are 0
+        if (mode == 0)       // both u_off are 0
           uvlc_tbl1[i] = 0;
-        else if (mode <= 2) // u_off are either 01 or 10
+        else if (mode <= 2)  // u_off are either 01 or 10
         {
-          ui32 d = dec[vlc & 0x7]; // look at the 3 LSB bits
+          ui32 d = dec[vlc & 0x7];   // look at the 3 LSB bits
 
           ui32 total_prefix = d & 0x3;
           ui32 total_suffix = (d >> 2) & 0x7;
@@ -309,17 +308,17 @@ namespace ojph
           ui32 u0 = (mode == 1) ? (d >> 5) : 0;
           ui32 u1 = (mode == 1) ? 0 : (d >> 5);
 
-          uvlc_tbl1[i] = (ui16)(total_prefix |
-                                (total_suffix << 3) |
-                                (u0_suffix_len << 7) |
-                                (u0 << 10) |
-                                (u1 << 13));
+          uvlc_tbl1[i] = (ui16)(total_prefix | 
+                               (total_suffix << 3) |
+                               (u0_suffix_len << 7) |
+                               (u0 << 10) |
+                               (u1 << 13));
         }
         else if (mode == 3) // both u_off are 1
         {
-          ui32 d0 = dec[vlc & 0x7]; // LSBs of VLC are prefix codeword
-          vlc >>= d0 & 0x3;         // Consume bits
-          ui32 d1 = dec[vlc & 0x7]; // LSBs of VLC are prefix codeword
+          ui32 d0 = dec[vlc & 0x7];  // LSBs of VLC are prefix codeword
+          vlc >>= d0 & 0x3;          // Consume bits
+          ui32 d1 = dec[vlc & 0x7];  // LSBs of VLC are prefix codeword
 
           ui32 total_prefix = (d0 & 0x3) + (d1 & 0x3);
           ui32 u0_suffix_len = (d0 >> 2) & 0x7;
@@ -327,12 +326,91 @@ namespace ojph
           ui32 u0 = d0 >> 5;
           ui32 u1 = d1 >> 5;
 
-          uvlc_tbl1[i] = (ui16)(total_prefix |
-                                (total_suffix << 3) |
-                                (u0_suffix_len << 7) |
-                                (u0 << 10) |
-                                (u1 << 13));
+          uvlc_tbl1[i] = (ui16)(total_prefix | 
+                               (total_suffix << 3) |
+                               (u0_suffix_len << 7) |
+                               (u0 << 10) |
+                               (u1 << 13));
         }
+      }
+      return true;
+    }
+
+    //************************************************************************/
+    /** @ingroup uvlc_decoding_tables_grp
+     *  @brief Initializes uvlc_tbl1_wide: wider UVLC table for non-initial
+     *         rows. Index = mode(2b) * 1024 + vlc(10b). Entry packs
+     *         total_bits[4:0], u_q0[12:5], u_q1[20:13].
+     *         total_bits == 0x1F signals fallback to original decode.
+     */
+    static bool uvlc_init_wide_table()
+    {
+      static const ui8 dec[8] = {
+        3 | (5 << 2) | (5 << 5), //000
+        1 | (0 << 2) | (1 << 5), //xx1
+        2 | (0 << 2) | (2 << 5), //x10
+        1 | (0 << 2) | (1 << 5), //xx1
+        3 | (1 << 2) | (3 << 5), //100
+        1 | (0 << 2) | (1 << 5), //xx1
+        2 | (0 << 2) | (2 << 5), //x10
+        1 | (0 << 2) | (1 << 5)  //xx1
+      };
+
+      for (ui32 idx = 0; idx < 4096; ++idx)
+      {
+        ui32 mode = idx >> 10;       // 2 bits
+        ui32 vlc = idx & 0x3FF;      // 10 bits
+
+        if (mode == 0) {
+          uvlc_tbl1_wide[idx] = 0;
+          continue;
+        }
+
+        if (mode <= 2) // single UVLC (one u_off set)
+        {
+          ui32 d = dec[vlc & 0x7];
+          ui32 prefix_len = d & 0x3;
+          ui32 suffix_len = (d >> 2) & 0x7;
+          ui32 u_pfx = d >> 5;
+          ui32 suffix_val = (vlc >> prefix_len) & ((1u << suffix_len) - 1);
+          ui32 u_val = u_pfx + suffix_val;
+          ui32 total = prefix_len + suffix_len;
+          ui32 u_q0 = (mode == 1) ? u_val : 0;
+          ui32 u_q1 = (mode == 2) ? u_val : 0;
+          uvlc_tbl1_wide[idx] = total | (u_q0 << 5) | (u_q1 << 13);
+          continue;
+        }
+
+        // mode == 3: both u_off set
+        // Bitstream layout: [prefix0][prefix1][suffix0][suffix1]
+        ui32 d0 = dec[vlc & 0x7];
+        ui32 p0_len = d0 & 0x3;
+        ui32 s0_len = (d0 >> 2) & 0x7;
+        ui32 u0_pfx = d0 >> 5;
+
+        ui32 vlc1 = vlc >> p0_len;  // consume prefix0
+        ui32 d1 = dec[vlc1 & 0x7];
+        ui32 p1_len = d1 & 0x3;
+        ui32 s1_len = (d1 >> 2) & 0x7;
+        ui32 u1_pfx = d1 >> 5;
+
+        ui32 total_prefix = p0_len + p1_len;
+        ui32 total_suffix = s0_len + s1_len;
+        ui32 total = total_prefix + total_suffix;
+
+        if (total > 10) {
+          uvlc_tbl1_wide[idx] = 0x1F; // fallback sentinel
+          continue;
+        }
+
+        // suffixes follow both prefixes in the bitstream
+        ui32 suffix_bits = vlc >> total_prefix;
+        ui32 s0_val = suffix_bits & ((1u << s0_len) - 1);
+        ui32 s1_val = (suffix_bits >> s0_len) & ((1u << s1_len) - 1);
+
+        ui32 u_q0 = u0_pfx + s0_val;
+        ui32 u_q1 = u1_pfx + s1_val;
+        uvlc_tbl1_wide[idx] = total | (u_q0 << 5) | (u_q1 << 13);
       }
       return true;
     }
@@ -348,6 +426,12 @@ namespace ojph
      *  @brief Initializes UVLC tables uvlc_tbl0 and uvlc_tbl1
      */
     static bool uvlc_tables_initialized = uvlc_init_tables();
+
+    //************************************************************************/
+    /** @ingroup uvlc_decoding_tables_grp
+     *  @brief Initializes wide UVLC table uvlc_tbl1_wide
+     */
+    static bool uvlc_wide_initialized = uvlc_init_wide_table();
 
   } // !namespace local
 } // !namespace ojph

--- a/Native/Common/OpenJPH/coding/ojph_block_common.h
+++ b/Native/Common/OpenJPH/coding/ojph_block_common.h
@@ -2,21 +2,22 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -32,20 +33,20 @@
 // This file is part of the OpenJPH software implementation.
 // File: ojph_block_common.h
 // Author: Aous Naman
+// Author: Osamu Watanabe
 // Date: 13 May 2022
 //***************************************************************************/
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
-  namespace local
-  {
-
+namespace ojph{
+  namespace local {
+    
     extern ui16 vlc_tbl0[1024];
     extern ui16 vlc_tbl1[1024];
-    extern ui16 uvlc_tbl0[256 + 64];
+    extern ui16 uvlc_tbl0[256+64];
     extern ui16 uvlc_tbl1[256];
-    extern ui8 uvlc_bias[256 + 64];
+    extern ui32 uvlc_tbl1_wide[4096];
+    extern ui8 uvlc_bias[256+64];
   } // !namespace local
 } // !namespace ojph

--- a/Native/Common/OpenJPH/coding/ojph_block_decoder.h
+++ b/Native/Common/OpenJPH/coding/ojph_block_decoder.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
-// Copyright (c) 2019, The University of New South Wales, Australia
+// Copyright (c) 2019, The University of New South Wales, Australia 
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,48 +35,47 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_BLOCK_DECODER_H
 #define OJPH_BLOCK_DECODER_H
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    // decodes the cleanup pass, significance propagation pass,
-    //  and magnitude refinement pass
+    //decodes the cleanup pass, significance propagation pass,
+    // and magnitude refinement pass
 
     // generic decoder
     bool
-    ojph_decode_codeblock32(ui8 *coded_data, ui32 *decoded_data,
-                            ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
-                            ui32 width, ui32 height, ui32 stride, bool stripe_causal);
+      ojph_decode_codeblock32(ui8* coded_data, ui32* decoded_data,
+        ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
+        ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
     bool
-    ojph_decode_codeblock64(ui8 *coded_data, ui64 *decoded_data,
-                            ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
-                            ui32 width, ui32 height, ui32 stride, bool stripe_causal);
+      ojph_decode_codeblock64(ui8* coded_data, ui64* decoded_data,
+        ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
+        ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
     // SSSE3-accelerated decoder
     bool
-    ojph_decode_codeblock_ssse3(ui8 *coded_data, ui32 *decoded_data,
-                                ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
-                                ui32 width, ui32 height, ui32 stride, bool stripe_causal);
+      ojph_decode_codeblock_ssse3(ui8* coded_data, ui32* decoded_data,
+        ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
+        ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
     // AVX2-accelerated decoder
     bool
-    ojph_decode_codeblock_avx2(ui8 *coded_data, ui32 *decoded_data,
-                               ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
-                               ui32 width, ui32 height, ui32 stride, bool stripe_causal);
+      ojph_decode_codeblock_avx2(ui8* coded_data, ui32* decoded_data,
+        ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
+        ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
     // WASM SIMD-accelerated decoder
     bool
-    ojph_decode_codeblock_wasm(ui8 *coded_data, ui32 *decoded_data,
-                               ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
-                               ui32 width, ui32 height, ui32 stride, bool stripe_causal);
+      ojph_decode_codeblock_wasm(ui8* coded_data, ui32* decoded_data,
+        ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
+        ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
   }
 }

--- a/Native/Common/OpenJPH/coding/ojph_block_decoder32.cpp
+++ b/Native/Common/OpenJPH/coding/ojph_block_decoder32.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -50,1589 +50,1567 @@
 #include "ojph_arch.h"
 #include "ojph_message.h"
 
-namespace ojph
-{
-    namespace local
+namespace ojph {
+  namespace local {
+
+    //************************************************************************/
+    /** @brief MEL state structure for reading and decoding the MEL bitstream
+     *
+     *  A number of events is decoded from the MEL bitstream ahead of time
+     *  and stored in run/num_runs.
+     *  Each run represents the number of zero events before a one event.
+     */ 
+    struct dec_mel_st {
+      dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
+        k(0), num_runs(0), runs(0)
+      {}
+      // data decoding machinery
+      ui8* data;    //!<the address of data (or bitstream)
+      ui64 tmp;     //!<temporary buffer for read data
+      int bits;     //!<number of bits stored in tmp
+      int size;     //!<number of bytes in MEL code
+      bool unstuff; //!<true if the next bit needs to be unstuffed
+      int k;        //!<state of MEL decoder
+
+      // queue of decoded runs
+      int num_runs; //!<number of decoded runs left in runs (maximum 8)
+      ui64 runs;    //!<runs of decoded MEL codewords (7 bits/run)
+    };
+
+    //************************************************************************/
+    /** @brief Reads and unstuffs the MEL bitstream
+     * 
+     *  This design needs more bytes in the codeblock buffer than the length
+     *  of the cleanup pass by up to 2 bytes.
+     *
+     *  Unstuffing removes the MSB of the byte following a byte whose
+     *  value is 0xFF; this prevents sequences larger than 0xFF7F in value
+     *  from appearing the bitstream.
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     */
+    static inline
+    void mel_read(dec_mel_st *melp)
     {
+      if (melp->bits > 32)  //there are enough bits in the tmp variable
+        return;             // return without reading new data
 
-        //************************************************************************/
-        /** @brief MEL state structure for reading and decoding the MEL bitstream
-         *
-         *  A number of events is decoded from the MEL bitstream ahead of time
-         *  and stored in run/num_runs.
-         *  Each run represents the number of zero events before a one event.
-         */
-        struct dec_mel_st
-        {
-            dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
-                           k(0), num_runs(0), runs(0)
-            {
-            }
-            // data decoding machinery
-            ui8 *data;    //!< the address of data (or bitstream)
-            ui64 tmp;     //!< temporary buffer for read data
-            int bits;     //!< number of bits stored in tmp
-            int size;     //!< number of bytes in MEL code
-            bool unstuff; //!< true if the next bit needs to be unstuffed
-            int k;        //!< state of MEL decoder
-
-            // queue of decoded runs
-            int num_runs; //!< number of decoded runs left in runs (maximum 8)
-            ui64 runs;    //!< runs of decoded MEL codewords (7 bits/run)
-        };
-
-        //************************************************************************/
-        /** @brief Reads and unstuffs the MEL bitstream
-         *
-         *  This design needs more bytes in the codeblock buffer than the length
-         *  of the cleanup pass by up to 2 bytes.
-         *
-         *  Unstuffing removes the MSB of the byte following a byte whose
-         *  value is 0xFF; this prevents sequences larger than 0xFF7F in value
-         *  from appearing the bitstream.
-         *
-         *  @param [in]  melp is a pointer to dec_mel_st structure
-         */
-        static inline void mel_read(dec_mel_st *melp)
-        {
-            if (melp->bits > 32) // there are enough bits in the tmp variable
-                return;          // return without reading new data
-
-            ui32 val = 0xFFFFFFFF; // feed in 0xFF if buffer is exhausted
-            if (melp->size > 4)
-            {                              // if there is data in the MEL segment
-                val = *(ui32 *)melp->data; // read 32 bits from MEL data
-                melp->data += 4;           // advance pointer
-                melp->size -= 4;           // reduce counter
-            }
-            else if (melp->size > 0)
-            { // 4 or less
-                int i = 0;
-                while (melp->size > 1)
-                {
-                    ui32 v = *melp->data++;     // read one byte at a time
-                    ui32 m = ~(0xFFu << i);     // mask of location
-                    val = (val & m) | (v << i); // put one byte in its correct location
-                    --melp->size;
-                    i += 8;
-                }
-                // size equal to 1
-                ui32 v = *melp->data++; // the one before the last is different
-                v |= 0xF;               // MEL and VLC segments can overlap
-                ui32 m = ~(0xFFu << i);
-                val = (val & m) | (v << i);
-                --melp->size;
-            }
-
-            // next we unstuff them before adding them to the buffer
-            int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
-                                           // the previously read byte requires
-                                           // unstuffing
-
-            // data is unstuffed and accumulated in t
-            // bits has the number of bits in t
-            ui32 t = val & 0xFF;
-            bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
-            bits -= unstuff;                       // there is one less bit in t if unstuffing is needed
-            t = t << (8 - unstuff);                // move up to make room for the next byte
-
-            // this is a repeat of the above
-            t |= (val >> 8) & 0xFF;
-            unstuff = (((val >> 8) & 0xFF) == 0xFF);
-            bits -= unstuff;
-            t = t << (8 - unstuff);
-
-            t |= (val >> 16) & 0xFF;
-            unstuff = (((val >> 16) & 0xFF) == 0xFF);
-            bits -= unstuff;
-            t = t << (8 - unstuff);
-
-            t |= (val >> 24) & 0xFF;
-            melp->unstuff = (((val >> 24) & 0xFF) == 0xFF);
-
-            // move t to tmp, and push the result all the way up, so we read from
-            // the MSB
-            melp->tmp |= ((ui64)t) << (64 - bits - melp->bits);
-            melp->bits += bits; // increment the number of bits in tmp
+      ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
+      if (melp->size > 4) {        // if there is data in the MEL segment
+        val = load_le_ui32(melp->data); // read 32 bits from MEL data
+        melp->data += 4;           // advance pointer
+        melp->size -= 4;           // reduce counter
+      }
+      else if (melp->size > 0)
+      { // 4 or less
+        int i = 0;
+        while (melp->size > 1) {   
+          ui32 v = *melp->data++;    // read one byte at a time
+          ui32 m = ~(0xFFu << i);    // mask of location
+          val = (val & m) | (v << i);// put one byte in its correct location
+          --melp->size;
+          i += 8;
         }
-
-        //************************************************************************/
-        /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
-         *
-         *  Runs are stored in "runs" and the number of runs in "num_runs".
-         *  Each run represents a number of zero events that may or may not
-         *  terminate in a 1 event.
-         *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
-         *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating
-         *  with 1, contain the number of consecutive 0 zero events * 2; for the
-         *  case terminating with 0, they store (number of consecutive 0 zero
-         *  events - 1) * 2.
-         *  A total of 6 bits (made up of 1 + 5) should have been enough.
-         *
-         *  @param [in]  melp is a pointer to dec_mel_st structure
-         */
-        static inline void mel_decode(dec_mel_st *melp)
-        {
-            static const int mel_exp[13] = {// MEL exponents
-                                            0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5};
-
-            if (melp->bits < 6) // if there are less than 6 bits in tmp
-                mel_read(melp); // then read from the MEL bitstream
-                                // 6 bits is the largest decodable MEL cwd
-
-            // repeat so long that there is enough decodable bits in tmp,
-            //  and the runs store is not full (num_runs < 8)
-            while (melp->bits >= 6 && melp->num_runs < 8)
-            {
-                int eval = mel_exp[melp->k]; // number of bits associated with state
-                int run = 0;
-                if (melp->tmp & (1ull << 63)) // The next bit to decode (stored in MSB)
-                {                             // one is found
-                    run = 1 << eval;
-                    run--;                                         // consecutive runs of 0 events - 1
-                    melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12; // increment, max is 12
-                    melp->tmp <<= 1;                               // consume one bit from tmp
-                    melp->bits -= 1;
-                    run = run << 1; // a stretch of zeros not terminating in one
-                }
-                else
-                { // 0 is found
-                    run = (int)(melp->tmp >> (63 - eval)) & ((1 << eval) - 1);
-                    melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; // decrement, min is 0
-                    melp->tmp <<= eval + 1;                      // consume eval + 1 bits (max is 6)
-                    melp->bits -= eval + 1;
-                    run = (run << 1) + 1; // a stretch of zeros terminating with one
-                }
-                eval = melp->num_runs * 7;           // 7 bits per run
-                melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
-                melp->runs |= ((ui64)run) << eval;   // store the value in runs
-                melp->num_runs++;                    // increment count
-            }
-        }
-
-        //************************************************************************/
-        /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
-         *         some bytes in order to get the read address to a multiple
-         *         of 4
-         *
-         *  @param [in]  melp is a pointer to dec_mel_st structure
-         *  @param [in]  bbuf is a pointer to byte buffer
-         *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-         *  @param [in]  scup is the length of MEL+VLC segments
-         */
-        static inline void mel_init(dec_mel_st *melp, ui8 *bbuf, int lcup, int scup)
-        {
-            melp->data = bbuf + lcup - scup; // move the pointer to the start of MEL
-            melp->bits = 0;                  // 0 bits in tmp
-            melp->tmp = 0;                   //
-            melp->unstuff = false;           // no unstuffing
-            melp->size = scup - 1;           // size is the length of MEL+VLC-1
-            melp->k = 0;                     // 0 for state
-            melp->num_runs = 0;              // num_runs is 0
-            melp->runs = 0;                  //
-
-            // This code is borrowed; original is for a different architecture
-            // These few lines take care of the case where data is not at a multiple
-            //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
-            int num = 4 - (int)(intptr_t(melp->data) & 0x3);
-            for (int i = 0; i < num; ++i)
-            { // this code is similar to mel_read
-                assert(melp->unstuff == false || melp->data[0] <= 0x8F);
-                ui64 d = (melp->size > 0) ? *melp->data : 0xFF; // if buffer is consumed
-                                                                // set data to 0xFF
-                if (melp->size == 1)
-                    d |= 0xF; // if this is MEL+VLC-1, set LSBs to 0xF
-                              //  see the standard
-                melp->data += melp->size-- > 0;        // increment if the end is not reached
-                int d_bits = 8 - melp->unstuff;        // if unstuffing is needed, reduce by 1
-                melp->tmp = (melp->tmp << d_bits) | d; // store bits in tmp
-                melp->bits += d_bits;                  // increment tmp by number of bits
-                melp->unstuff = ((d & 0xFF) == 0xFF);  // true of next byte needs
-                                                      // unstuffing
-            }
-            melp->tmp <<= (64 - melp->bits); // push all the way up so the first bit
-                                             //  is the MSB
-        }
-
-        //************************************************************************/
-        /** @brief Retrieves one run from dec_mel_st; if there are no runs stored
-         *         MEL segment is decoded
-         *
-         * @param [in]  melp is a pointer to dec_mel_st structure
-         */
-        static inline int mel_get_run(dec_mel_st *melp)
-        {
-            if (melp->num_runs == 0) // if no runs, decode more bit from MEL segment
-                mel_decode(melp);
-
-            int t = melp->runs & 0x7F; // retrieve one run
-            melp->runs >>= 7;          // remove the retrieved run
-            melp->num_runs--;
-            return t; // return run
-        }
-
-        //************************************************************************/
-        /** @brief A structure for reading and unstuffing a segment that grows
-         *         backward, such as VLC and MRP
-         */
-        struct rev_struct
-        {
-            rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
-            {
-            }
-            // storage
-            ui8 *data;    //!< pointer to where to read data
-            ui64 tmp;     //!< temporary buffer of read data
-            ui32 bits;    //!< number of bits stored in tmp
-            int size;     //!< number of bytes left
-            bool unstuff; //!< true if the last byte is more than 0x8F
-                          //!< then the current byte is unstuffed if it is 0x7F
-        };
-
-        //************************************************************************/
-        /** @brief Read and unstuff data from a backwardly-growing segment
-         *
-         *  This reader can read up to 8 bytes from before the VLC segment.
-         *  Care must be taken not read from unreadable memory, causing a
-         *  segmentation fault.
-         *
-         *  Note that there is another subroutine rev_read_mrp that is slightly
-         *  different.  The other one fills zeros when the buffer is exhausted.
-         *  This one basically does not care if the bytes are consumed, because
-         *  any extra data should not be used in the actual decoding.
-         *
-         *  Unstuffing is needed to prevent sequences more than 0xFF8F from
-         *  appearing in the bits stream; since we are reading backward, we keep
-         *  watch when a value larger than 0x8F appears in the bitstream.
-         *  If the byte following this is 0x7F, we unstuff this byte (ignore the
-         *  MSB of that byte, which should be 0).
-         *
-         *  @param [in]  vlcp is a pointer to rev_struct structure
-         */
-        static inline void rev_read(rev_struct *vlcp)
-        {
-            // process 4 bytes at a time
-            if (vlcp->bits > 32) // if there are more than 32 bits in tmp, then
-                return;          // reading 32 bits can overflow vlcp->tmp
-            ui32 val = 0;
-            // the next line (the if statement) needs to be tested first
-            if (vlcp->size > 3) // if there are more than 3 bytes left in VLC
-            {
-                // (vlcp->data - 3) move pointer back to read 32 bits at once
-                val = *(ui32 *)(vlcp->data - 3); // then read 32 bits
-                vlcp->data -= 4;                 // move data pointer back by 4
-                vlcp->size -= 4;                 // reduce available byte by 4
-            }
-            else if (vlcp->size > 0)
-            { // 4 or less
-                int i = 24;
-                while (vlcp->size > 0)
-                {
-                    ui32 v = *vlcp->data--; // read one byte at a time
-                    val |= (v << i);        // put byte in its correct location
-                    --vlcp->size;
-                    i -= 8;
-                }
-            }
-
-            // accumulate in tmp, number of bits in tmp are stored in bits
-            ui32 tmp = val >> 24; // start with the MSB byte
-            ui32 bits;
-
-            // test unstuff (previous byte is >0x8F), and this byte is 0x7F
-            bits = 8 - ((vlcp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
-            bool unstuff = (val >> 24) > 0x8F; // this is for the next byte
-
-            tmp |= ((val >> 16) & 0xFF) << bits; // process the next byte
-            bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = ((val >> 16) & 0xFF) > 0x8F;
-
-            tmp |= ((val >> 8) & 0xFF) << bits;
-            bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = ((val >> 8) & 0xFF) > 0x8F;
-
-            tmp |= (val & 0xFF) << bits;
-            bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = (val & 0xFF) > 0x8F;
-
-            // now move the read and unstuffed bits into vlcp->tmp
-            vlcp->tmp |= (ui64)tmp << vlcp->bits;
-            vlcp->bits += bits;
-            vlcp->unstuff = unstuff; // this for the next read
-        }
-
-        //************************************************************************/
-        /** @brief Initiates the rev_struct structure and reads a few bytes to
-         *         move the read address to multiple of 4
-         *
-         *  There is another similar rev_init_mrp subroutine.  The difference is
-         *  that this one, rev_init, discards the first 12 bits (they have the
-         *  sum of the lengths of VLC and MEL segments), and first unstuff depends
-         *  on first 4 bits.
-         *
-         *  @param [in]  vlcp is a pointer to rev_struct structure
-         *  @param [in]  data is a pointer to byte at the start of the cleanup pass
-         *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-         *  @param [in]  scup is the length of MEL+VLC segments
-         */
-        static inline void rev_init(rev_struct *vlcp, ui8 *data, int lcup, int scup)
-        {
-            // first byte has only the upper 4 bits
-            vlcp->data = data + lcup - 2;
-
-            // size can not be larger than this, in fact it should be smaller
-            vlcp->size = scup - 2;
-
-            ui32 d = *vlcp->data--;                  // read one byte (this is a half byte)
-            vlcp->tmp = d >> 4;                      // both initialize and set
-            vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); // check standard
-            vlcp->unstuff = (d | 0xF) > 0x8F;        // this is useful for the next byte
-
-            // This code is designed for an architecture that read address should
-            //  align to the read size (address multiple of 4 if read size is 4)
-            // These few lines take care of the case where data is not at a multiple
-            //  of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
-            //  To read 32 bits, read from (vlcp->data - 3)
-            int num = 1 + (int)(intptr_t(vlcp->data) & 0x3);
-            int tnum = num < vlcp->size ? num : vlcp->size;
-            for (int i = 0; i < tnum; ++i)
-            {
-                ui64 d;
-                d = *vlcp->data--; // read one byte and move read pointer
-                // check if the last byte was >0x8F (unstuff == true) and this is 0x7F
-                ui32 d_bits = 8 - ((vlcp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-                vlcp->tmp |= d << vlcp->bits; // move data to vlcp->tmp
-                vlcp->bits += d_bits;
-                vlcp->unstuff = d > 0x8F; // for next byte
-            }
-            vlcp->size -= tnum;
-            rev_read(vlcp); // read another 32 buts
-        }
-
-        //************************************************************************/
-        /** @brief Retrieves 32 bits from the head of a rev_struct structure
-         *
-         *  By the end of this call, vlcp->tmp must have no less than 33 bits
-         *
-         *  @param [in]  vlcp is a pointer to rev_struct structure
-         */
-        static inline ui32 rev_fetch(rev_struct *vlcp)
-        {
-            if (vlcp->bits < 32) // if there are less then 32 bits, read more
-            {
-                rev_read(vlcp);      // read 32 bits, but unstuffing might reduce this
-                if (vlcp->bits < 32) // if there is still space in vlcp->tmp for 32 bits
-                    rev_read(vlcp);  // read another 32
-            }
-            return (ui32)vlcp->tmp; // return the head (bottom-most) of vlcp->tmp
-        }
-
-        //************************************************************************/
-        /** @brief Consumes num_bits from a rev_struct structure
-         *
-         *  @param [in]  vlcp is a pointer to rev_struct structure
-         *  @param [in]  num_bits is the number of bits to be removed
-         */
-        static inline ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
-        {
-            assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
-            vlcp->tmp >>= num_bits;         // remove bits
-            vlcp->bits -= num_bits;         // decrement the number of bits
-            return (ui32)vlcp->tmp;
-        }
-
-        //************************************************************************/
-        /** @brief Reads and unstuffs from rev_struct
-         *
-         *  This is different than rev_read in that this fills in zeros when the
-         *  the available data is consumed.  The other does not care about the
-         *  values when all data is consumed.
-         *
-         *  See rev_read for more information about unstuffing
-         *
-         *  @param [in]  mrp is a pointer to rev_struct structure
-         */
-        static inline void rev_read_mrp(rev_struct *mrp)
-        {
-            // process 4 bytes at a time
-            if (mrp->bits > 32)
-                return;
-            ui32 val = 0;
-            if (mrp->size > 3)                  // If there are 3 byte or more
-            {                                   // (mrp->data - 3) move pointer back to read 32 bits at once
-                val = *(ui32 *)(mrp->data - 3); // read 32 bits
-                mrp->data -= 4;                 // move back pointer
-                mrp->size -= 4;                 // reduce count
-            }
-            else if (mrp->size > 0)
-            {
-                int i = 24;
-                while (mrp->size > 0)
-                {
-                    ui32 v = *mrp->data--; // read one byte at a time
-                    val |= (v << i);       // put byte in its correct location
-                    --mrp->size;
-                    i -= 8;
-                }
-            }
-
-            // accumulate in tmp, and keep count in bits
-            ui32 bits, tmp = val >> 24;
-
-            // test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
-            bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
-            bool unstuff = (val >> 24) > 0x8F;
-
-            // process the next byte
-            tmp |= ((val >> 16) & 0xFF) << bits;
-            bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = ((val >> 16) & 0xFF) > 0x8F;
-
-            tmp |= ((val >> 8) & 0xFF) << bits;
-            bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = ((val >> 8) & 0xFF) > 0x8F;
-
-            tmp |= (val & 0xFF) << bits;
-            bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = (val & 0xFF) > 0x8F;
-
-            mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
-            mrp->bits += bits;
-            mrp->unstuff = unstuff; // next byte
-        }
-
-        //************************************************************************/
-        /** @brief Initialized rev_struct structure for MRP segment, and reads
-         *         a number of bytes such that the next 32 bits read are from
-         *         an address that is a multiple of 4. Note this is designed for
-         *         an architecture that read size must be compatible with the
-         *         alignment of the read address
-         *
-         *  There is another similar subroutine rev_init.  This subroutine does
-         *  NOT skip the first 12 bits, and starts with unstuff set to true.
-         *
-         *  @param [in]  mrp is a pointer to rev_struct structure
-         *  @param [in]  data is a pointer to byte at the start of the cleanup pass
-         *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-         *  @param [in]  len2 is the length of SPP+MRP segments
-         */
-        static inline void rev_init_mrp(rev_struct *mrp, ui8 *data, int lcup, int len2)
-        {
-            mrp->data = data + lcup + len2 - 1;
-            mrp->size = len2;
-            mrp->unstuff = true;
-            mrp->bits = 0;
-            mrp->tmp = 0;
-
-            // This code is designed for an architecture that read address should
-            //  align to the read size (address multiple of 4 if read size is 4)
-            // These few lines take care of the case where data is not at a multiple
-            //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
-            int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
-            for (int i = 0; i < num; ++i)
-            {
-                ui64 d;
-                // read a byte, 0 if no more data
-                d = (mrp->size-- > 0) ? *mrp->data-- : 0;
-                // check if unstuffing is needed
-                ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-                mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
-                mrp->bits += d_bits;
-                mrp->unstuff = d > 0x8F; // for next byte
-            }
-            rev_read_mrp(mrp);
-        }
-
-        //************************************************************************/
-        /** @brief Retrieves 32 bits from the head of a rev_struct structure
-         *
-         *  By the end of this call, mrp->tmp must have no less than 33 bits
-         *
-         *  @param [in]  mrp is a pointer to rev_struct structure
-         */
-        static inline ui32 rev_fetch_mrp(rev_struct *mrp)
-        {
-            if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
-            {
-                rev_read_mrp(mrp);     // read 30-32 bits from mrp
-                if (mrp->bits < 32)    // if there is a space of 32 bits
-                    rev_read_mrp(mrp); // read more
-            }
-            return (ui32)mrp->tmp; // return the head of mrp->tmp
-        }
-
-        //************************************************************************/
-        /** @brief Consumes num_bits from a rev_struct structure
-         *
-         *  @param [in]  mrp is a pointer to rev_struct structure
-         *  @param [in]  num_bits is the number of bits to be removed
-         */
-        static inline ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
-        {
-            assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
-            mrp->tmp >>= num_bits;         // discard the lowest num_bits bits
-            mrp->bits -= num_bits;
-            return (ui32)mrp->tmp; // return data after consumption
-        }
-
-        //************************************************************************/
-        /** @brief State structure for reading and unstuffing of forward-growing
-         *         bitstreams; these are: MagSgn and SPP bitstreams
-         */
-        struct frwd_struct32
-        {
-            const ui8 *data; //!< pointer to bitstream
-            ui64 tmp;        //!< temporary buffer of read data
-            ui32 bits;       //!< number of bits stored in tmp
-            ui32 unstuff;    //!< 1 if a bit needs to be unstuffed from next byte
-            int size;        //!< size of data
-        };
-
-        //************************************************************************/
-        /** @brief Read and unstuffs 32 bits from forward-growing bitstream
-         *
-         *  A template is used to accommodate a different requirement for
-         *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
-         *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
-         *  X controls this value.
-         *
-         *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
-         *  in the conpressed sequence.  So whenever a value of 0xFF is coded, the
-         *  MSB of the next byte is set 0 and must be ignored during decoding.
-         *
-         *  Reading can go beyond the end of buffer by up to 3 bytes.
-         *
-         *  @tparam       X is the value fed in when the bitstream is exhausted
-         *  @param  [in]  msp is a pointer to frwd_struct32 structure
-         *
-         */
-        template <int X>
-        static inline void frwd_read(frwd_struct32 *msp)
-        {
-            assert(msp->bits <= 32); // assert that there is a space for 32 bits
-
-            ui32 val = 0;
-            if (msp->size > 3)
-            {
-                val = *(ui32 *)msp->data; // read 32 bits
-                msp->data += 4;           // increment pointer
-                msp->size -= 4;           // reduce size
-            }
-            else if (msp->size > 0)
-            {
-                int i = 0;
-                val = X != 0 ? 0xFFFFFFFFu : 0;
-                while (msp->size > 0)
-                {
-                    ui32 v = *msp->data++;      // read one byte at a time
-                    ui32 m = ~(0xFFu << i);     // mask of location
-                    val = (val & m) | (v << i); // put one byte in its correct location
-                    --msp->size;
-                    i += 8;
-                }
-            }
-            else
-                val = X != 0 ? 0xFFFFFFFFu : 0;
-
-            // we accumulate in t and keep a count of the number of bits in bits
-            ui32 bits = 8 - msp->unstuff;
-            ui32 t = val & 0xFF;
-            bool unstuff = ((val & 0xFF) == 0xFF); // Do we need unstuffing next?
-
-            t |= ((val >> 8) & 0xFF) << bits;
-            bits += 8 - unstuff;
-            unstuff = (((val >> 8) & 0xFF) == 0xFF);
-
-            t |= ((val >> 16) & 0xFF) << bits;
-            bits += 8 - unstuff;
-            unstuff = (((val >> 16) & 0xFF) == 0xFF);
-
-            t |= ((val >> 24) & 0xFF) << bits;
-            bits += 8 - unstuff;
-            msp->unstuff = (((val >> 24) & 0xFF) == 0xFF); // for next byte
-
-            msp->tmp |= ((ui64)t) << msp->bits; // move data to msp->tmp
-            msp->bits += bits;
-        }
-
-        //************************************************************************/
-        /** @brief Initialize frwd_struct32 struct and reads some bytes
-         *
-         *  @tparam      X is the value fed in when the bitstream is exhausted.
-         *               See frwd_read regarding the template
-         *  @param [in]  msp is a pointer to frwd_struct32
-         *  @param [in]  data is a pointer to the start of data
-         *  @param [in]  size is the number of byte in the bitstream
-         */
-        template <int X>
-        static inline void frwd_init(frwd_struct32 *msp, const ui8 *data, int size)
-        {
-            msp->data = data;
-            msp->tmp = 0;
-            msp->bits = 0;
-            msp->unstuff = 0;
-            msp->size = size;
-
-            // This code is designed for an architecture that read address should
-            //  align to the read size (address multiple of 4 if read size is 4)
-            // These few lines take care of the case where data is not at a multiple
-            //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the bitstream
-            int num = 4 - (int)(intptr_t(msp->data) & 0x3);
-            for (int i = 0; i < num; ++i)
-            {
-                ui64 d;
-                // read a byte if the buffer is not exhausted, otherwise set it to X
-                d = msp->size-- > 0 ? *msp->data++ : X;
-                msp->tmp |= (d << msp->bits);        // store data in msp->tmp
-                msp->bits += 8 - msp->unstuff;       // number of bits added to msp->tmp
-                msp->unstuff = ((d & 0xFF) == 0xFF); // unstuffing for next byte
-            }
-            frwd_read<X>(msp); // read 32 bits more
-        }
-
-        //************************************************************************/
-        /** @brief Consume num_bits bits from the bitstream of frwd_struct32
-         *
-         *  @param [in]  msp is a pointer to frwd_struct32
-         *  @param [in]  num_bits is the number of bit to consume
-         */
-        static inline void frwd_advance(frwd_struct32 *msp, ui32 num_bits)
-        {
-            assert(num_bits <= msp->bits);
-            msp->tmp >>= num_bits; // consume num_bits
-            msp->bits -= num_bits;
-        }
-
-        //************************************************************************/
-        /** @brief Fetches 32 bits from the frwd_struct32 bitstream
-         *
-         *  @tparam      X is the value fed in when the bitstream is exhausted.
-         *               See frwd_read regarding the template
-         *  @param [in]  msp is a pointer to frwd_struct32
-         */
-        template <int X>
-        static inline ui32 frwd_fetch(frwd_struct32 *msp)
-        {
-            if (msp->bits < 32)
-            {
-                frwd_read<X>(msp);
-                if (msp->bits < 32) // need to test
-                    frwd_read<X>(msp);
-            }
-            return (ui32)msp->tmp;
-        }
-
-        //************************************************************************/
-        /** @brief Decodes one codeblock, processing the cleanup, siginificance
-         *         propagation, and magnitude refinement pass
-         *
-         *  @param [in]   coded_data is a pointer to bitstream
-         *  @param [in]   decoded_data is a pointer to decoded codeblock data buf.
-         *  @param [in]   missing_msbs is the number of missing MSBs
-         *  @param [in]   num_passes is the number of passes: 1 if CUP only,
-         *                2 for CUP+SPP, and 3 for CUP+SPP+MRP
-         *  @param [in]   lengths1 is the length of cleanup pass
-         *  @param [in]   lengths2 is the length of refinement passes (either SPP
-         *                only or SPP+MRP)
-         *  @param [in]   width is the decoded codeblock width
-         *  @param [in]   height is the decoded codeblock height
-         *  @param [in]   stride is the decoded codeblock buffer stride
-         *  @param [in]   stripe_causal is true for stripe causal mode
-         */
-        bool ojph_decode_codeblock32(ui8 *coded_data, ui32 *decoded_data,
-                                     ui32 missing_msbs, ui32 num_passes,
-                                     ui32 lengths1, ui32 lengths2,
-                                     ui32 width, ui32 height, ui32 stride,
-                                     bool stripe_causal)
-        {
-            static bool insufficient_precision = false;
-            static bool modify_code = false;
-            static bool truncate_spp_mrp = false;
-
-            if (num_passes > 1 && lengths2 == 0)
-            {
-                OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
-                                      "one coding pass, but zero length for "
-                                      "2nd and potential 3rd pass.");
-                num_passes = 1;
-            }
-
-            if (num_passes > 3)
-            {
-                OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
-                                      "This codeblocks has %d passes.",
-                          num_passes);
-                return false;
-            }
-
-            if (missing_msbs > 30) // p < 0
-            {
-                if (insufficient_precision == false)
-                {
-                    insufficient_precision = true;
-                    OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
-                                          "codeblock. This message will not be "
-                                          "displayed again.");
-                }
-                return false;
-            }
-            else if (missing_msbs == 30) // p == 0
-            {                            // not enough precision to decode and set the bin center to 1
-                if (modify_code == false)
-                {
-                    modify_code = true;
-                    OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
-                                          "pass. The code can be modified to support "
-                                          "this case. This message will not be "
-                                          "displayed again.");
-                }
-                return false; // 32 bits are not enough to decode this
-            }
-            else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
-            {
-                if (num_passes > 1)
-                {
-                    num_passes = 1;
-                    if (truncate_spp_mrp == false)
-                    {
-                        truncate_spp_mrp = true;
-                        OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
-                                              "nor MagRef passes; both will be skipped. "
-                                              "This message will not be displayed "
-                                              "again.");
-                    }
-                }
-            }
-            ui32 p = 30 - missing_msbs; // The least significant bitplane for CUP
-            // There is a way to handle the case of p == 0, but a different path
-            // is required
-
-            if (lengths1 < 2)
-            {
-                OJPH_WARN(0x00010006, "Wrong codeblock length.");
-                return false;
-            }
-
-            // read scup and fix the bytes there
-            int lcup, scup;
-            lcup = (int)lengths1; // length of CUP
-            // scup is the length of MEL + VLC
-            scup = (((int)coded_data[lcup - 1]) << 4) + (coded_data[lcup - 2] & 0xF);
-            if (scup < 2 || scup > lcup || scup > 4079) // something is wrong
-                return false;
-
-            // The temporary storage scratch holds two types of data in an
-            // interleaved fashion. The interleaving allows us to use one
-            // memory pointer.
-            // We have one entry for a decoded VLC code, and one entry for UVLC.
-            // Entries are 16 bits each, corresponding to one quad,
-            // but since we want to use XMM registers of the SSE family
-            // of SIMD; we allocated 16 bytes or more per quad row; that is,
-            // the width is no smaller than 16 bytes (or 8 entries), and the
-            // height is 512 quads
-            // Each VLC entry contains, in the following order, starting
-            // from MSB
-            // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
-            // Each entry in UVLC contains u_q
-            // One extra row to handle the case of SPP propagating downwards
-            // when codeblock width is 4
-            ui16 scratch[8 * 513] = {0}; // 8 kB
-
-            // We need an extra two entries (one inf and one u_q) beyond
-            // the last column.
-            // If the block width is 4 (2 quads), then we use sstr of 8
-            // (enough for 4 quads). If width is 8 (4 quads) we use
-            // sstr is 16 (enough for 8 quads). For a width of 16 (8
-            // quads), we use 24 (enough for 12 quads).
-            ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
-
-            ui32 mmsbp2 = missing_msbs + 2;
-
-            // The cleanup pass is decoded in two steps; in step one,
-            // the VLC and MEL segments are decoded, generating a record that
-            // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
-            // This information should be sufficient for the next step.
-            // In step 2, we decode the MagSgn segment.
-
-            // step 1 decoding VLC and MEL segments
-            {
-                // init structures
-                dec_mel_st mel;
-                mel_init(&mel, coded_data, lcup, scup);
-                rev_struct vlc;
-                rev_init(&vlc, coded_data, lcup, scup);
-
-                int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
-                                             // data represented as runs of 0 events
-                                             // See mel_decode description
-
-                ui32 vlc_val;
-                ui32 c_q = 0;
-                ui16 *sp = scratch;
-                // initial quad row
-                for (ui32 x = 0; x < width; sp += 4)
-                {
-                    // decode VLC
-                    /////////////
-
-                    // first quad
-                    vlc_val = rev_fetch(&vlc);
-
-                    // decode VLC using the context c_q and the head of VLC bitstream
-                    ui16 t0 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
-
-                    // if context is zero, use one MEL event
-                    if (c_q == 0) // zero context
-                    {
-                        run -= 2; // subtract 2, since events number if multiplied by 2
-
-                        // Is the run terminated in 1? if so, use decoded VLC code,
-                        // otherwise, discard decoded data, since we will decoded again
-                        // using a different context
-                        t0 = (run == -1) ? t0 : 0;
-
-                        // is run -1 or -2? this means a run has been consumed
-                        if (run < 0)
-                            run = mel_get_run(&mel); // get another run
-                    }
-                    // run -= (c_q == 0) ? 2 : 0;
-                    // t0 = (c_q != 0 || run == -1) ? t0 : 0;
-                    // if (run < 0)
-                    //   run = mel_get_run(&mel);  // get another run
-                    sp[0] = t0;
-                    x += 2;
-
-                    // prepare context for the next quad; eqn. 1 in ITU T.814
-                    c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
-
-                    // remove data from vlc stream (0 bits are removed if vlc is not used)
-                    vlc_val = rev_advance(&vlc, t0 & 0x7);
-
-                    // second quad
-                    ui16 t1 = 0;
-
-                    // decode VLC using the context c_q and the head of VLC bitstream
-                    t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
-
-                    // if context is zero, use one MEL event
-                    if (c_q == 0 && x < width) // zero context
-                    {
-                        run -= 2; // subtract 2, since events number if multiplied by 2
-
-                        // if event is 0, discard decoded t1
-                        t1 = (run == -1) ? t1 : 0;
-
-                        if (run < 0)                 // have we consumed all events in a run
-                            run = mel_get_run(&mel); // if yes, then get another run
-                    }
-                    t1 = x < width ? t1 : 0;
-                    // run -= (c_q == 0 && x < width) ? 2 : 0;
-                    // t1 = (c_q != 0 || run == -1) ? t1 : 0;
-                    // if (run < 0)
-                    //   run = mel_get_run(&mel);  // get another run
-                    sp[2] = t1;
-                    x += 2;
-
-                    // prepare context for the next quad, eqn. 1 in ITU T.814
-                    c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
-
-                    // remove data from vlc stream, if qinf is not used, cwdlen is 0
-                    vlc_val = rev_advance(&vlc, t1 & 0x7);
-
-                    // decode u
-                    /////////////
-                    // uvlc_mode is made up of u_offset bits from the quad pair
-                    ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-                    if (uvlc_mode == 0xc0) // if both u_offset are set, get an event from
-                    {                      // the MEL run of events
-                        run -= 2;          // subtract 2, since events number if multiplied by 2
-
-                        uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
-                                                             // is 0x40
-
-                        if (run < 0) // if run is consumed (run is -1 or -2), get another run
-                            run = mel_get_run(&mel);
-                    }
-                    // run -= (uvlc_mode == 0xc0) ? 2 : 0;
-                    // uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
-                    // if (run < 0)
-                    //   run = mel_get_run(&mel);  // get another run
-
-                    // decode uvlc_mode to get u for both quads
-                    ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
-                    // remove total prefix length
-                    vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-                    uvlc_entry >>= 3;
-                    // extract suffixes for quad 0 and 1
-                    ui32 len = uvlc_entry & 0xF;           // suffix length for 2 quads
-                    ui32 tmp = vlc_val & ((1 << len) - 1); // suffix value for 2 quads
-                    vlc_val = rev_advance(&vlc, len);
-                    uvlc_entry >>= 4;
-                    // quad 0 length
-                    len = uvlc_entry & 0x7; // quad 0 suffix length
-                    uvlc_entry >>= 3;
-                    ui16 u_q = (ui16)(1 + (uvlc_entry & 7) + (tmp & ~(0xFFU << len))); // kap. 1
-                    sp[1] = u_q;
-                    u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len)); // kappa == 1
-                    sp[3] = u_q;
-                }
-                sp[0] = sp[1] = 0;
-
-                // non initial quad rows
-                for (ui32 y = 2; y < height; y += 2)
-                {
-                    c_q = 0;                              // context
-                    ui16 *sp = scratch + (y >> 1) * sstr; // this row of quads
-
-                    for (ui32 x = 0; x < width; sp += 4)
-                    {
-                        // decode VLC
-                        /////////////
-
-                        // sigma_q (n, ne, nf)
-                        c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
-                        c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
-
-                        // first quad
-                        vlc_val = rev_fetch(&vlc);
-
-                        // decode VLC using the context c_q and the head of VLC bitstream
-                        ui16 t0 = vlc_tbl1[c_q + (vlc_val & 0x7F)];
-
-                        // if context is zero, use one MEL event
-                        if (c_q == 0) // zero context
-                        {
-                            run -= 2; // subtract 2, since events number is multiplied by 2
-
-                            // Is the run terminated in 1? if so, use decoded VLC code,
-                            // otherwise, discard decoded data, since we will decoded again
-                            // using a different context
-                            t0 = (run == -1) ? t0 : 0;
-
-                            // is run -1 or -2? this means a run has been consumed
-                            if (run < 0)
-                                run = mel_get_run(&mel); // get another run
-                        }
-                        // run -= (c_q == 0) ? 2 : 0;
-                        // t0 = (c_q != 0 || run == -1) ? t0 : 0;
-                        // if (run < 0)
-                        //   run = mel_get_run(&mel);  // get another run
-                        sp[0] = t0;
-                        x += 2;
-
-                        // prepare context for the next quad; eqn. 2 in ITU T.814
-                        // sigma_q (w, sw)
-                        c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
-                        // sigma_q (nw)
-                        c_q |= sp[0 - (si32)sstr] & 0x80;
-                        // sigma_q (n, ne, nf)
-                        c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
-                        c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
-
-                        // remove data from vlc stream (0 bits are removed if vlc is unused)
-                        vlc_val = rev_advance(&vlc, t0 & 0x7);
-
-                        // second quad
-                        ui16 t1 = 0;
-
-                        // decode VLC using the context c_q and the head of VLC bitstream
-                        t1 = vlc_tbl1[c_q + (vlc_val & 0x7F)];
-
-                        // if context is zero, use one MEL event
-                        if (c_q == 0 && x < width) // zero context
-                        {
-                            run -= 2; // subtract 2, since events number if multiplied by 2
-
-                            // if event is 0, discard decoded t1
-                            t1 = (run == -1) ? t1 : 0;
-
-                            if (run < 0)                 // have we consumed all events in a run
-                                run = mel_get_run(&mel); // if yes, then get another run
-                        }
-                        t1 = x < width ? t1 : 0;
-                        // run -= (c_q == 0 && x < width) ? 2 : 0;
-                        // t1 = (c_q != 0 || run == -1) ? t1 : 0;
-                        // if (run < 0)
-                        //   run = mel_get_run(&mel);  // get another run
-                        sp[2] = t1;
-                        x += 2;
-
-                        // partial c_q, will be completed when we process the next quad
-                        // sigma_q (w, sw)
-                        c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
-                        // sigma_q (nw)
-                        c_q |= sp[2 - (si32)sstr] & 0x80;
-
-                        // remove data from vlc stream, if qinf is not used, cwdlen is 0
-                        vlc_val = rev_advance(&vlc, t1 & 0x7);
-
-                        // decode u
-                        /////////////
-                        // uvlc_mode is made up of u_offset bits from the quad pair
-                        ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-                        ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
-                        // remove total prefix length
-                        vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-                        uvlc_entry >>= 3;
-                        // extract suffixes for quad 0 and 1
-                        ui32 len = uvlc_entry & 0xF;           // suffix length for 2 quads
-                        ui32 tmp = vlc_val & ((1 << len) - 1); // suffix value for 2 quads
-                        vlc_val = rev_advance(&vlc, len);
-                        uvlc_entry >>= 4;
-                        // quad 0 length
-                        len = uvlc_entry & 0x7; // quad 0 suffix length
-                        uvlc_entry >>= 3;
-                        ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
-                        sp[1] = u_q;
-                        u_q = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
-                        sp[3] = u_q;
-                    }
-                    sp[0] = sp[1] = 0;
-                }
-            }
-
-            // step2 we decode magsgn
-            {
-                // We allocate a scratch row for storing v_n values.
-                // We have 512 quads horizontally.
-                // We need an extra entry to handle the case of vp[1]
-                // when vp is at the last column.
-                // Here, we allocate 4 instead of 1 to make the buffer size
-                // a multipled of 16 bytes.
-                const int v_n_size = 512 + 4;
-                ui32 v_n_scratch[v_n_size] = {0}; // 2+ kB
-
-                frwd_struct32 magsgn;
-                frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
-
-                ui16 *sp = scratch;
-                ui32 *vp = v_n_scratch;
-                ui32 *dp = decoded_data;
-
-                ui32 prev_v_n = 0;
-                for (ui32 x = 0; x < width; sp += 2, ++vp)
-                {
-                    ui32 inf = sp[0];
-                    ui32 U_q = sp[1];
-                    if (U_q > mmsbp2)
-                        return false;
-
-                    ui32 v_n;
-                    ui32 val = 0;
-                    ui32 bit = 0;
-                    if (inf & (1 << (4 + bit)))
-                    {
-                        // get 32 bits of magsgn data
-                        ui32 ms_val = frwd_fetch<0xFF>(&magsgn);
-                        ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-                        frwd_advance(&magsgn, m_n);                 // consume m_n
-
-                        val = ms_val << 31;                     // get sign bit
-                        v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
-                        v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-                        v_n |= 1;                               // add center of bin
-                        // v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-                        // add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-                        val |= (v_n + 2) << (p - 1);
-                    }
-                    dp[0] = val;
-
-                    v_n = 0;
-                    val = 0;
-                    bit = 1;
-                    if (inf & (1 << (4 + bit)))
-                    {
-                        // get 32 bits of magsgn data
-                        ui32 ms_val = frwd_fetch<0xFF>(&magsgn);
-                        ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-                        frwd_advance(&magsgn, m_n);                 // consume m_n
-
-                        val = ms_val << 31;                     // get sign bit
-                        v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
-                        v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-                        v_n |= 1;                               // add center of bin
-                        // v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-                        // add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-                        val |= (v_n + 2) << (p - 1);
-                    }
-                    dp[stride] = val;
-                    vp[0] = prev_v_n | v_n;
-                    prev_v_n = 0;
-                    ++dp;
-                    if (++x >= width)
-                    {
-                        ++vp;
-                        break;
-                    }
-
-                    val = 0;
-                    bit = 2;
-                    if (inf & (1 << (4 + bit)))
-                    {
-                        // get 32 bits of magsgn data
-                        ui32 ms_val = frwd_fetch<0xFF>(&magsgn);
-                        ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-                        frwd_advance(&magsgn, m_n);                 // consume m_n
-
-                        val = ms_val << 31;                     // get sign bit
-                        v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
-                        v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-                        v_n |= 1;                               // add center of bin
-                        // v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-                        // add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-                        val |= (v_n + 2) << (p - 1);
-                    }
-                    dp[0] = val;
-
-                    v_n = 0;
-                    val = 0;
-                    bit = 3;
-                    if (inf & (1 << (4 + bit)))
-                    {
-                        // get 32 bits of magsgn data
-                        ui32 ms_val = frwd_fetch<0xFF>(&magsgn);
-                        ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-                        frwd_advance(&magsgn, m_n);                 // consume m_n
-
-                        val = ms_val << 31;                     // get sign bit
-                        v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
-                        v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-                        v_n |= 1;                               // add center of bin
-                        // v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-                        // add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-                        val |= (v_n + 2) << (p - 1);
-                    }
-                    dp[stride] = val;
-                    prev_v_n = v_n;
-                    ++dp;
-                    ++x;
-                }
-                vp[0] = prev_v_n;
-
-                for (ui32 y = 2; y < height; y += 2)
-                {
-                    ui16 *sp = scratch + (y >> 1) * sstr;
-                    ui32 *vp = v_n_scratch;
-                    ui32 *dp = decoded_data + y * stride;
-
-                    prev_v_n = 0;
-                    for (ui32 x = 0; x < width; sp += 2, ++vp)
-                    {
-                        ui32 inf = sp[0];
-                        ui32 u_q = sp[1];
-
-                        ui32 gamma = inf & 0xF0;
-                        gamma &= gamma - 0x10; // is gamma_q 1?
-                        ui32 emax = vp[0] | vp[1];
-                        emax = 31 - count_leading_zeros(emax | 2); // emax - 1
-                        ui32 kappa = gamma ? emax : 1;
-
-                        ui32 U_q = u_q + kappa;
-                        if (U_q > mmsbp2)
-                            return false;
-
-                        ui32 v_n;
-                        ui32 val = 0;
-                        ui32 bit = 0;
-                        if (inf & (1 << (4 + bit)))
-                        {
-                            // get 32 bits of magsgn data
-                            ui32 ms_val = frwd_fetch<0xFF>(&magsgn);
-                            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-                            frwd_advance(&magsgn, m_n);                 // consume m_n
-
-                            val = ms_val << 31;                     // get sign bit
-                            v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
-                            v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-                            v_n |= 1;                               // add center of bin
-                            // v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-                            // add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-                            val |= (v_n + 2) << (p - 1);
-                        }
-                        dp[0] = val;
-
-                        v_n = 0;
-                        val = 0;
-                        bit = 1;
-                        if (inf & (1 << (4 + bit)))
-                        {
-                            // get 32 bits of magsgn data
-                            ui32 ms_val = frwd_fetch<0xFF>(&magsgn);
-                            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-                            frwd_advance(&magsgn, m_n);                 // consume m_n
-
-                            val = ms_val << 31;                     // get sign bit
-                            v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
-                            v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-                            v_n |= 1;                               // add center of bin
-                            // v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-                            // add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-                            val |= (v_n + 2) << (p - 1);
-                        }
-                        dp[stride] = val;
-                        vp[0] = prev_v_n | v_n;
-                        prev_v_n = 0;
-                        ++dp;
-                        if (++x >= width)
-                        {
-                            ++vp;
-                            break;
-                        }
-
-                        val = 0;
-                        bit = 2;
-                        if (inf & (1 << (4 + bit)))
-                        {
-                            // get 32 bits of magsgn data
-                            ui32 ms_val = frwd_fetch<0xFF>(&magsgn);
-                            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-                            frwd_advance(&magsgn, m_n);                 // consume m_n
-
-                            val = ms_val << 31;                     // get sign bit
-                            v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
-                            v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-                            v_n |= 1;                               // add center of bin
-                            // v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-                            // add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-                            val |= (v_n + 2) << (p - 1);
-                        }
-                        dp[0] = val;
-
-                        v_n = 0;
-                        val = 0;
-                        bit = 3;
-                        if (inf & (1 << (4 + bit)))
-                        {
-                            // get 32 bits of magsgn data
-                            ui32 ms_val = frwd_fetch<0xFF>(&magsgn);
-                            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-                            frwd_advance(&magsgn, m_n);                 // consume m_n
-
-                            val = ms_val << 31;                     // get sign bit
-                            v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
-                            v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-                            v_n |= 1;                               // add center of bin
-                            // v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-                            // add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-                            val |= (v_n + 2) << (p - 1);
-                        }
-                        dp[stride] = val;
-                        prev_v_n = v_n;
-                        ++dp;
-                        ++x;
-                    }
-                    vp[0] = prev_v_n;
-                }
-            }
-
-            if (num_passes > 1)
-            {
-                // We use scratch again, we can divide it into multiple regions
-                // sigma holds all the significant samples, and it cannot
-                // be modified after it is set.  it will be used during the
-                // Magnitude Refinement Pass
-                ui16 *const sigma = scratch;
-
-                ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
-                                                 // ui16 contains 4 columns
-                mstr = ((mstr + 2u) + 7u) & ~7u; // multiples of 8
-
-                // We re-arrange quad significance, where each 4 consecutive
-                // bits represent one quad, into column significance, where,
-                // each 4 consequtive bits represent one column of 4 rows
-                {
-                    ui32 y;
-                    for (y = 0; y < height; y += 4)
-                    {
-                        ui16 *sp = scratch + (y >> 1) * sstr;
-                        ui16 *dp = sigma + (y >> 2) * mstr;
-                        for (ui32 x = 0; x < width; x += 4, sp += 4, ++dp)
-                        {
-                            ui32 t0 = 0, t1 = 0;
-                            t0 = ((sp[0] & 0x30u) >> 4) | ((sp[0] & 0xC0u) >> 2);
-                            t0 |= ((sp[2] & 0x30u) << 4) | ((sp[2] & 0xC0u) << 6);
-                            t1 = ((sp[0 + sstr] & 0x30u) >> 2) | ((sp[0 + sstr] & 0xC0u));
-                            t1 |= ((sp[2 + sstr] & 0x30u) << 6) | ((sp[2 + sstr] & 0xC0u) << 8);
-                            dp[0] = (ui16)(t0 | t1);
-                        }
-                        dp[0] = 0; // set an extra entry on the right with 0
-                    }
-                    {
-                        // reset one row after the codeblock
-                        ui16 *dp = sigma + (y >> 2) * mstr;
-                        for (ui32 x = 0; x < width; x += 4, ++dp)
-                            dp[0] = 0;
-                        dp[0] = 0; // set an extra entry on the right with 0
-                    }
-                }
-
-                // We perform Significance Propagation Pass here
-                {
-                    // This stores significance information of the previous
-                    // 4 rows.  Significance information in this array includes
-                    // all signicant samples in bitplane p - 1; that is,
-                    // significant samples for bitplane p (discovered during the
-                    // cleanup pass and stored in sigma) and samples that have recently
-                    // became significant (during the SPP) in bitplane p-1.
-                    // We store enough for the widest row, containing 1024 columns,
-                    // which is equivalent to 256 of ui16, since each stores 4 columns.
-                    // We add an extra 8 entries, just in case we need more
-                    ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
-
-                    frwd_struct32 sigprop;
-                    frwd_init<0>(&sigprop, coded_data + lengths1, (int)lengths2);
-
-                    for (ui32 y = 0; y < height; y += 4)
-                    {
-                        ui32 pattern = 0xFFFFu; // a pattern needed samples
-                        if (height - y < 4)
-                        {
-                            pattern = 0x7777u;
-                            if (height - y < 3)
-                            {
-                                pattern = 0x3333u;
-                                if (height - y < 2)
-                                    pattern = 0x1111u;
-                            }
-                        }
-
-                        // prev holds sign. info. for the previous quad, together
-                        // with the rows on top of it and below it.
-                        ui32 prev = 0;
-                        ui16 *prev_sig = prev_row_sig;
-                        ui16 *cur_sig = sigma + (y >> 2) * mstr;
-                        ui32 *dpp = decoded_data + y * stride;
-                        for (ui32 x = 0; x < width; x += 4, ++cur_sig, ++prev_sig)
-                        {
-                            // only rows and columns inside the stripe are included
-                            si32 s = (si32)x + 4 - (si32)width;
-                            s = ojph_max(s, 0);
-                            pattern = pattern >> (s * 4);
-
-                            // We first find locations that need to be tested (potential
-                            // SPP members); these location will end up in mbr
-                            // In each iteration, we produce 16 bits because cwd can have
-                            // up to 16 bits of significance information, followed by the
-                            // corresponding 16 bits of sign information; therefore, it is
-                            // sufficient to fetch 32 bit data per loop.
-
-                            // Althougth we are interested in 16 bits only, we load 32 bits.
-                            // For the 16 bits we are producing, we need the next 4 bits --
-                            // We need data for at least 5 columns out of 8.
-                            // Therefore loading 32 bits is easier than loading 16 bits
-                            // twice.
-                            ui32 ps = *(ui32 *)prev_sig;
-                            ui32 ns = *(ui32 *)(cur_sig + mstr);
-                            ui32 u = (ps & 0x88888888) >> 3; // the row on top
-                            if (!stripe_causal)
-                                u |= (ns & 0x11111111) << 3; // the row below
-
-                            ui32 cs = *(ui32 *)cur_sig;
-                            // vertical integration
-                            ui32 mbr = cs;                 // this sig. info.
-                            mbr |= (cs & 0x77777777) << 1; // above neighbors
-                            mbr |= (cs & 0xEEEEEEEE) >> 1; // below neighbors
-                            mbr |= u;
-                            // horizontal integration
-                            ui32 t = mbr;
-                            mbr |= t << 4;     // neighbors on the left
-                            mbr |= t >> 4;     // neighbors on the right
-                            mbr |= prev >> 12; // significance of previous group
-
-                            // remove outside samples, and already significant samples
-                            mbr &= pattern;
-                            mbr &= ~cs;
-
-                            // find samples that become significant during the SPP
-                            ui32 new_sig = mbr;
-                            if (new_sig)
-                            {
-                                ui32 cwd = frwd_fetch<0>(&sigprop);
-
-                                ui32 cnt = 0;
-                                ui32 col_mask = 0xFu;
-                                ui32 inv_sig = ~cs & pattern;
-                                for (int i = 0; i < 16; i += 4, col_mask <<= 4)
-                                {
-                                    if ((col_mask & new_sig) == 0)
-                                        continue;
-
-                                    // scan one column
-                                    ui32 sample_mask = 0x1111u & col_mask;
-                                    if (new_sig & sample_mask)
-                                    {
-                                        new_sig &= ~sample_mask;
-                                        if (cwd & 1)
-                                        {
-                                            ui32 t = 0x33u << i;
-                                            new_sig |= t & inv_sig;
-                                        }
-                                        cwd >>= 1;
-                                        ++cnt;
-                                    }
-
-                                    sample_mask <<= 1;
-                                    if (new_sig & sample_mask)
-                                    {
-                                        new_sig &= ~sample_mask;
-                                        if (cwd & 1)
-                                        {
-                                            ui32 t = 0x76u << i;
-                                            new_sig |= t & inv_sig;
-                                        }
-                                        cwd >>= 1;
-                                        ++cnt;
-                                    }
-
-                                    sample_mask <<= 1;
-                                    if (new_sig & sample_mask)
-                                    {
-                                        new_sig &= ~sample_mask;
-                                        if (cwd & 1)
-                                        {
-                                            ui32 t = 0xECu << i;
-                                            new_sig |= t & inv_sig;
-                                        }
-                                        cwd >>= 1;
-                                        ++cnt;
-                                    }
-
-                                    sample_mask <<= 1;
-                                    if (new_sig & sample_mask)
-                                    {
-                                        new_sig &= ~sample_mask;
-                                        if (cwd & 1)
-                                        {
-                                            ui32 t = 0xC8u << i;
-                                            new_sig |= t & inv_sig;
-                                        }
-                                        cwd >>= 1;
-                                        ++cnt;
-                                    }
-                                }
-
-                                if (new_sig)
-                                {
-                                    // new_sig has newly-discovered sig. samples during SPP
-                                    // find the signs and update decoded_data
-                                    ui32 *dp = dpp + x;
-                                    ui32 val = 3u << (p - 2);
-                                    col_mask = 0xFu;
-                                    for (int i = 0; i < 4; ++i, ++dp, col_mask <<= 4)
-                                    {
-                                        if ((col_mask & new_sig) == 0)
-                                            continue;
-
-                                        // scan 4 signs
-                                        ui32 sample_mask = 0x1111u & col_mask;
-                                        if (new_sig & sample_mask)
-                                        {
-                                            assert(dp[0] == 0);
-                                            dp[0] = (cwd << 31) | val;
-                                            cwd >>= 1;
-                                            ++cnt;
-                                        }
-
-                                        sample_mask += sample_mask;
-                                        if (new_sig & sample_mask)
-                                        {
-                                            assert(dp[stride] == 0);
-                                            dp[stride] = (cwd << 31) | val;
-                                            cwd >>= 1;
-                                            ++cnt;
-                                        }
-
-                                        sample_mask += sample_mask;
-                                        if (new_sig & sample_mask)
-                                        {
-                                            assert(dp[2 * stride] == 0);
-                                            dp[2 * stride] = (cwd << 31) | val;
-                                            cwd >>= 1;
-                                            ++cnt;
-                                        }
-
-                                        sample_mask += sample_mask;
-                                        if (new_sig & sample_mask)
-                                        {
-                                            assert(dp[3 * stride] == 0);
-                                            dp[3 * stride] = (cwd << 31) | val;
-                                            cwd >>= 1;
-                                            ++cnt;
-                                        }
-                                    }
-                                }
-                                frwd_advance(&sigprop, cnt);
-                            }
-
-                            new_sig |= cs;
-                            *prev_sig = (ui16)(new_sig);
-
-                            // vertical integration for the new sig. info.
-                            t = new_sig;
-                            new_sig |= (t & 0x7777) << 1; // above neighbors
-                            new_sig |= (t & 0xEEEE) >> 1; // below neighbors
-                            // add sig. info. from the row on top and below
-                            prev = new_sig | u;
-                            // we need only the bits in 0xF000
-                            prev &= 0xF000;
-                        }
-                    }
-                }
-
-                // We perform Magnitude Refinement Pass here
-                if (num_passes > 2)
-                {
-                    rev_struct magref;
-                    rev_init_mrp(&magref, coded_data, (int)lengths1, (int)lengths2);
-
-                    for (ui32 y = 0; y < height; y += 4)
-                    {
-                        ui32 *cur_sig = (ui32 *)(sigma + (y >> 2) * mstr);
-                        ui32 *dpp = decoded_data + y * stride;
-                        ui32 half = 1 << (p - 2);
-                        for (ui32 i = 0; i < width; i += 8)
-                        {
-                            // Process one entry from sigma array at a time
-                            //  Each nibble (4 bits) in the sigma array represents 4 rows,
-                            //  and the 32 bits contain 8 columns
-                            ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
-                            ui32 sig = *cur_sig++;             // 32 bit that will be processed now
-                            ui32 col_mask = 0xFu;              // a mask for a column in sig
-                            if (sig)                           // if any of the 32 bits are set
-                            {
-                                for (int j = 0; j < 8; ++j) // one column at a time
-                                {
-                                    if (sig & col_mask) // lowest nibble
-                                    {
-                                        ui32 *dp = dpp + i + j;                    // next column in decoded samples
-                                        ui32 sample_mask = 0x11111111u & col_mask; // LSB
-
-                                        for (int k = 0; k < 4; ++k)
-                                        {
-                                            if (sig & sample_mask) // if LSB is set
-                                            {
-                                                assert(dp[0] != 0);          // decoded value cannot be zero
-                                                assert((dp[0] & half) == 0); // no half
-                                                ui32 sym = cwd & 1;          // get it value
-                                                sym = (1 - sym) << (p - 1);  // previous center of bin
-                                                sym |= half;                 // put half the center of bin
-                                                dp[0] ^= sym;                // remove old bin center and put new
-                                                cwd >>= 1;                   // consume word
-                                            }
-                                            sample_mask += sample_mask; // next row
-                                            dp += stride;               // next samples row
-                                        }
-                                    }
-                                    col_mask <<= 4; // next column
-                                }
-                            }
-                            // consume data according to the number of bits set
-                            rev_advance_mrp(&magref, population_count(sig));
-                        }
-                    }
-                }
-            }
-            return true;
-        }
+        // size equal to 1
+        ui32 v = *melp->data++;    // the one before the last is different 
+        v |= 0xF;                  // MEL and VLC segments can overlap
+        ui32 m = ~(0xFFu << i);
+        val = (val & m) | (v << i);
+        --melp->size;
+      }
+      
+      // next we unstuff them before adding them to the buffer
+      int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
+                                     // the previously read byte requires 
+                                     // unstuffing
+
+      // data is unstuffed and accumulated in t
+      // bits has the number of bits in t
+      ui32 t = val & 0xFF; 
+      bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
+      bits -= unstuff; // there is one less bit in t if unstuffing is needed
+      t = t << (8 - unstuff); // move up to make room for the next byte
+
+      //this is a repeat of the above
+      t |= (val>>8) & 0xFF;
+      unstuff = (((val >> 8) & 0xFF) == 0xFF);
+      bits -= unstuff;
+      t = t << (8 - unstuff);
+
+      t |= (val>>16) & 0xFF;
+      unstuff = (((val >> 16) & 0xFF) == 0xFF);
+      bits -= unstuff;
+      t = t << (8 - unstuff);
+
+      t |= (val>>24) & 0xFF;
+      melp->unstuff = (((val >> 24) & 0xFF) == 0xFF);
+
+      // move t to tmp, and push the result all the way up, so we read from
+      // the MSB
+      melp->tmp |= ((ui64)t) << (64 - bits - melp->bits);
+      melp->bits += bits; //increment the number of bits in tmp
     }
+
+    //************************************************************************/
+    /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
+     * 
+     *  Runs are stored in "runs" and the number of runs in "num_runs".
+     *  Each run represents a number of zero events that may or may not 
+     *  terminate in a 1 event.
+     *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
+     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating 
+     *  with 1, contain the number of consecutive 0 zero events * 2; for the 
+     *  case terminating with 0, they store (number of consecutive 0 zero 
+     *  events - 1) * 2.
+     *  A total of 6 bits (made up of 1 + 5) should have been enough.
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     */
+    static inline
+    void mel_decode(dec_mel_st *melp)
+    {
+      static const int mel_exp[13] = { //MEL exponents
+        0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5
+      };
+
+      if (melp->bits < 6) // if there are less than 6 bits in tmp
+        mel_read(melp);   // then read from the MEL bitstream
+                          // 6 bits is the largest decodable MEL cwd
+
+      //repeat so long that there is enough decodable bits in tmp,
+      // and the runs store is not full (num_runs < 8)
+      while (melp->bits >= 6 && melp->num_runs < 8)
+      {
+        int eval = mel_exp[melp->k]; // number of bits associated with state
+        int run = 0;
+        if (melp->tmp & (1ull<<63)) //The next bit to decode (stored in MSB)
+        { //one is found
+          run = 1 << eval;  
+          run--; // consecutive runs of 0 events - 1
+          melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12;//increment, max is 12
+          melp->tmp <<= 1; // consume one bit from tmp
+          melp->bits -= 1;
+          run = run << 1; // a stretch of zeros not terminating in one
+        }
+        else
+        { //0 is found
+          run = (int)(melp->tmp >> (63 - eval)) & ((1 << eval) - 1);
+          melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; //decrement, min is 0
+          melp->tmp <<= eval + 1; //consume eval + 1 bits (max is 6)
+          melp->bits -= eval + 1;
+          run = (run << 1) + 1; // a stretch of zeros terminating with one
+        }
+        eval = melp->num_runs * 7;           // 7 bits per run
+        melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
+        melp->runs |= ((ui64)run) << eval;   // store the value in runs
+        melp->num_runs++;                    // increment count  
+      }
+    }
+
+    //************************************************************************/
+    /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
+     *         some bytes in order to get the read address to a multiple
+     *         of 4 
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     *  @param [in]  bbuf is a pointer to byte buffer
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  scup is the length of MEL+VLC segments
+     */
+    static inline
+    void mel_init(dec_mel_st *melp, ui8* bbuf, int lcup, int scup)
+    {
+      melp->data = bbuf + lcup - scup; // move the pointer to the start of MEL
+      melp->bits = 0;                  // 0 bits in tmp
+      melp->tmp = 0;                   //
+      melp->unstuff = false;           // no unstuffing
+      melp->size = scup - 1;           // size is the length of MEL+VLC-1
+      melp->k = 0;                     // 0 for state 
+      melp->num_runs = 0;              // num_runs is 0
+      melp->runs = 0;                  //
+
+      //This code is borrowed; original is for a different architecture
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
+      int num = 4 - (int)(intptr_t(melp->data) & 0x3);
+      for (int i = 0; i < num; ++i) { // this code is similar to mel_read
+        assert(melp->unstuff == false || melp->data[0] <= 0x8F);
+        ui64 d = (melp->size > 0) ? *melp->data : 0xFF;//if buffer is consumed
+                                                       //set data to 0xFF
+        if (melp->size == 1) d |= 0xF; //if this is MEL+VLC-1, set LSBs to 0xF
+                                       // see the standard
+        melp->data += melp->size-- > 0; //increment if the end is not reached
+        int d_bits = 8 - melp->unstuff; //if unstuffing is needed, reduce by 1
+        melp->tmp = (melp->tmp << d_bits) | d; //store bits in tmp
+        melp->bits += d_bits;  //increment tmp by number of bits
+        melp->unstuff = ((d & 0xFF) == 0xFF); //true of next byte needs 
+                                              //unstuffing
+      }
+      melp->tmp <<= (64 - melp->bits); //push all the way up so the first bit
+                                       // is the MSB
+    }
+
+    //************************************************************************/
+    /** @brief Retrieves one run from dec_mel_st; if there are no runs stored
+     *         MEL segment is decoded
+     *
+     * @param [in]  melp is a pointer to dec_mel_st structure
+     */    
+    static inline
+    int mel_get_run(dec_mel_st *melp)
+    {
+      if (melp->num_runs == 0)  //if no runs, decode more bit from MEL segment
+        mel_decode(melp);
+
+      int t = melp->runs & 0x7F; //retrieve one run
+      melp->runs >>= 7;  // remove the retrieved run
+      melp->num_runs--;
+      return t; // return run
+    }
+
+    //************************************************************************/
+    /** @brief A structure for reading and unstuffing a segment that grows
+     *         backward, such as VLC and MRP
+     */ 
+    struct rev_struct {
+      rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
+      {}
+      //storage
+      ui8* data;     //!<pointer to where to read data
+      ui64 tmp;	     //!<temporary buffer of read data
+      ui32 bits;     //!<number of bits stored in tmp
+      int size;      //!<number of bytes left
+      bool unstuff;  //!<true if the last byte is more than 0x8F
+                     //!<then the current byte is unstuffed if it is 0x7F
+    };
+
+    //************************************************************************/
+    /** @brief Read and unstuff data from a backwardly-growing segment
+     *
+     *  This reader can read up to 8 bytes from before the VLC segment.
+     *  Care must be taken not read from unreadable memory, causing a 
+     *  segmentation fault.
+     * 
+     *  Note that there is another subroutine rev_read_mrp that is slightly
+     *  different.  The other one fills zeros when the buffer is exhausted.
+     *  This one basically does not care if the bytes are consumed, because
+     *  any extra data should not be used in the actual decoding.
+     *
+     *  Unstuffing is needed to prevent sequences more than 0xFF8F from 
+     *  appearing in the bits stream; since we are reading backward, we keep
+     *  watch when a value larger than 0x8F appears in the bitstream. 
+     *  If the byte following this is 0x7F, we unstuff this byte (ignore the 
+     *  MSB of that byte, which should be 0).
+     *
+     *  @param [in]  vlcp is a pointer to rev_struct structure
+     */
+    static inline 
+    void rev_read(rev_struct *vlcp)
+    {
+      //process 4 bytes at a time
+      if (vlcp->bits > 32)  // if there are more than 32 bits in tmp, then 
+        return;             // reading 32 bits can overflow vlcp->tmp
+      ui32 val = 0;
+      //the next line (the if statement) needs to be tested first
+      if (vlcp->size > 3)  // if there are more than 3 bytes left in VLC
+      {
+        // (vlcp->data - 3) move pointer back to read 32 bits at once
+        val = load_le_ui32(vlcp->data - 3); // then read 32 bits
+        vlcp->data -= 4;          // move data pointer back by 4
+        vlcp->size -= 4;          // reduce available byte by 4
+      }
+      else if (vlcp->size > 0)
+      { // 4 or less
+        int i = 24;
+        while (vlcp->size > 0) {   
+          ui32 v = *vlcp->data--; // read one byte at a time
+          val |= (v << i);        // put byte in its correct location
+          --vlcp->size;
+          i -= 8;
+        }
+      }
+
+      //accumulate in tmp, number of bits in tmp are stored in bits
+      ui32 tmp = val >> 24;  //start with the MSB byte
+      ui32 bits;
+
+      // test unstuff (previous byte is >0x8F), and this byte is 0x7F
+      bits = 8 - ((vlcp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
+      bool unstuff = (val >> 24) > 0x8F; //this is for the next byte
+
+      tmp |= ((val >> 16) & 0xFF) << bits; //process the next byte
+      bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = ((val >> 16) & 0xFF) > 0x8F;
+
+      tmp |= ((val >> 8) & 0xFF) << bits;
+      bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = ((val >> 8) & 0xFF) > 0x8F;
+
+      tmp |= (val & 0xFF) << bits;
+      bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = (val & 0xFF) > 0x8F;
+
+      // now move the read and unstuffed bits into vlcp->tmp
+      vlcp->tmp |= (ui64)tmp << vlcp->bits;
+      vlcp->bits += bits;
+      vlcp->unstuff = unstuff; // this for the next read
+    }
+
+    //************************************************************************/
+    /** @brief Initiates the rev_struct structure and reads a few bytes to 
+     *         move the read address to multiple of 4
+     *
+     *  There is another similar rev_init_mrp subroutine.  The difference is
+     *  that this one, rev_init, discards the first 12 bits (they have the
+     *  sum of the lengths of VLC and MEL segments), and first unstuff depends
+     *  on first 4 bits.
+     *
+     *  @param [in]  vlcp is a pointer to rev_struct structure
+     *  @param [in]  data is a pointer to byte at the start of the cleanup pass
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  scup is the length of MEL+VLC segments
+     */
+    static inline 
+    void rev_init(rev_struct *vlcp, ui8* data, int lcup, int scup)
+    {
+      //first byte has only the upper 4 bits
+      vlcp->data = data + lcup - 2;
+
+      //size can not be larger than this, in fact it should be smaller
+      vlcp->size = scup - 2;
+
+      ui32 d = *vlcp->data--; // read one byte (this is a half byte)
+      vlcp->tmp = d >> 4;    // both initialize and set
+      vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); //check standard
+      vlcp->unstuff = (d | 0xF) > 0x8F; //this is useful for the next byte
+
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
+      // To read 32 bits, read from (vlcp->data - 3)
+      int num = 1 + (int)(intptr_t(vlcp->data) & 0x3);
+      int tnum = num < vlcp->size ? num : vlcp->size;
+      for (int i = 0; i < tnum; ++i) {
+        ui64 d;
+        d = *vlcp->data--;  // read one byte and move read pointer
+        //check if the last byte was >0x8F (unstuff == true) and this is 0x7F
+        ui32 d_bits = 8 - ((vlcp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
+        vlcp->tmp |= d << vlcp->bits; // move data to vlcp->tmp
+        vlcp->bits += d_bits;
+        vlcp->unstuff = d > 0x8F; // for next byte
+      }
+      vlcp->size -= tnum;
+      rev_read(vlcp);  // read another 32 buts
+    }
+
+    //************************************************************************/
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
+     *
+     *  By the end of this call, vlcp->tmp must have no less than 33 bits
+     *
+     *  @param [in]  vlcp is a pointer to rev_struct structure
+     */
+    static inline 
+    ui32 rev_fetch(rev_struct *vlcp)
+    {
+      if (vlcp->bits < 32)  // if there are less then 32 bits, read more
+      {
+        rev_read(vlcp);     // read 32 bits, but unstuffing might reduce this
+        if (vlcp->bits < 32)// if there is still space in vlcp->tmp for 32 bits
+          rev_read(vlcp);   // read another 32
+      }
+      return (ui32)vlcp->tmp; // return the head (bottom-most) of vlcp->tmp
+    }
+
+    //************************************************************************/
+    /** @brief Consumes num_bits from a rev_struct structure
+     *
+     *  @param [in]  vlcp is a pointer to rev_struct structure
+     *  @param [in]  num_bits is the number of bits to be removed
+     */
+    static inline 
+    ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
+    {
+      assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
+      vlcp->tmp >>= num_bits;         // remove bits
+      vlcp->bits -= num_bits;         // decrement the number of bits
+      return (ui32)vlcp->tmp;
+    }
+
+    //************************************************************************/
+    /** @brief Reads and unstuffs from rev_struct
+     *
+     *  This is different than rev_read in that this fills in zeros when the
+     *  the available data is consumed.  The other does not care about the
+     *  values when all data is consumed.
+     *
+     *  See rev_read for more information about unstuffing
+     *
+     *  @param [in]  mrp is a pointer to rev_struct structure
+     */
+    static inline 
+    void rev_read_mrp(rev_struct *mrp)
+    {
+      //process 4 bytes at a time
+      if (mrp->bits > 32)
+        return;
+      ui32 val = 0;
+      if (mrp->size > 3) // If there are 3 byte or more
+      { // (mrp->data - 3) move pointer back to read 32 bits at once
+        val = load_le_ui32(mrp->data - 3); // read 32 bits
+        mrp->data -= 4;                // move back pointer
+        mrp->size -= 4;                // reduce count
+      }
+      else if (mrp->size > 0)
+      {
+        int i = 24;
+        while (mrp->size > 0) {   
+          ui32 v = *mrp->data--; // read one byte at a time
+          val |= (v << i);       // put byte in its correct location
+          --mrp->size;
+          i -= 8;
+        }
+      }
+
+      //accumulate in tmp, and keep count in bits
+      ui32 bits, tmp = val >> 24;
+
+      //test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
+      bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
+      bool unstuff = (val >> 24) > 0x8F;
+
+      //process the next byte
+      tmp |= ((val >> 16) & 0xFF) << bits;
+      bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = ((val >> 16) & 0xFF) > 0x8F;
+
+      tmp |= ((val >> 8) & 0xFF) << bits;
+      bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = ((val >> 8) & 0xFF) > 0x8F;
+
+      tmp |= (val & 0xFF) << bits;
+      bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = (val & 0xFF) > 0x8F;
+
+      mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
+      mrp->bits += bits;
+      mrp->unstuff = unstuff;             // next byte
+    }
+
+    //************************************************************************/
+    /** @brief Initialized rev_struct structure for MRP segment, and reads
+     *         a number of bytes such that the next 32 bits read are from
+     *         an address that is a multiple of 4. Note this is designed for
+     *         an architecture that read size must be compatible with the
+     *         alignment of the read address
+     *
+     *  There is another similar subroutine rev_init.  This subroutine does 
+     *  NOT skip the first 12 bits, and starts with unstuff set to true.
+     *
+     *  @param [in]  mrp is a pointer to rev_struct structure
+     *  @param [in]  data is a pointer to byte at the start of the cleanup pass
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  len2 is the length of SPP+MRP segments
+     */
+    static inline 
+    void rev_init_mrp(rev_struct *mrp, ui8* data, int lcup, int len2)
+    {
+      mrp->data = data + lcup + len2 - 1;
+      mrp->size = len2;
+      mrp->unstuff = true;
+      mrp->bits = 0;
+      mrp->tmp = 0;
+
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
+      int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
+      for (int i = 0; i < num; ++i) {
+        ui64 d;
+        //read a byte, 0 if no more data
+        d = (mrp->size-- > 0) ? *mrp->data-- : 0; 
+        //check if unstuffing is needed
+        ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
+        mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
+        mrp->bits += d_bits;
+        mrp->unstuff = d > 0x8F; // for next byte
+      }
+      rev_read_mrp(mrp);
+    }
+
+    //************************************************************************/
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
+     *
+     *  By the end of this call, mrp->tmp must have no less than 33 bits
+     *
+     *  @param [in]  mrp is a pointer to rev_struct structure
+     */
+    static inline 
+    ui32 rev_fetch_mrp(rev_struct *mrp)
+    {
+      if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
+      {
+        rev_read_mrp(mrp);    // read 30-32 bits from mrp
+        if (mrp->bits < 32)   // if there is a space of 32 bits
+          rev_read_mrp(mrp);  // read more
+      }
+      return (ui32)mrp->tmp;  // return the head of mrp->tmp
+    }
+
+    //************************************************************************/
+    /** @brief Consumes num_bits from a rev_struct structure
+     *
+     *  @param [in]  mrp is a pointer to rev_struct structure
+     *  @param [in]  num_bits is the number of bits to be removed
+     */
+    static inline 
+    ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
+    {
+      assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
+      mrp->tmp >>= num_bits;  // discard the lowest num_bits bits
+      mrp->bits -= num_bits;
+      return (ui32)mrp->tmp;  // return data after consumption
+    }
+
+    //************************************************************************/
+    /** @brief State structure for reading and unstuffing of forward-growing 
+     *         bitstreams; these are: MagSgn and SPP bitstreams
+     */
+    struct frwd_struct32 {
+      const ui8* data;  //!<pointer to bitstream
+      ui64 tmp;         //!<temporary buffer of read data
+      ui32 bits;        //!<number of bits stored in tmp
+      ui32 unstuff;     //!<1 if a bit needs to be unstuffed from next byte
+      int size;         //!<size of data
+    };
+
+    //************************************************************************/
+    /** @brief Read and unstuffs 32 bits from forward-growing bitstream
+     *  
+     *  A template is used to accommodate a different requirement for
+     *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
+     *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
+     *  X controls this value.
+     *
+     *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
+     *  in the conpressed sequence.  So whenever a value of 0xFF is coded, the
+     *  MSB of the next byte is set 0 and must be ignored during decoding.
+     *
+     *  Reading can go beyond the end of buffer by up to 3 bytes.
+     *
+     *  @tparam       X is the value fed in when the bitstream is exhausted
+     *  @param  [in]  msp is a pointer to frwd_struct32 structure
+     *
+     */ 
+    template<int X>
+    static inline 
+    void frwd_read(frwd_struct32 *msp)
+    {
+      assert(msp->bits <= 32); // assert that there is a space for 32 bits
+
+      ui32 val = 0;
+      if (msp->size > 3) {
+        val = load_le_ui32(msp->data); // read 32 bits
+        msp->data += 4;           // increment pointer
+        msp->size -= 4;           // reduce size
+      }
+      else if (msp->size > 0)
+      {
+        int i = 0;
+        val = X != 0 ? 0xFFFFFFFFu : 0;
+        while (msp->size > 0) {   
+          ui32 v = *msp->data++;    // read one byte at a time
+          ui32 m = ~(0xFFu << i);    // mask of location
+          val = (val & m) | (v << i);// put one byte in its correct location
+          --msp->size;
+          i += 8;          
+        }
+      }
+      else
+        val = X != 0 ? 0xFFFFFFFFu : 0;
+
+      // we accumulate in t and keep a count of the number of bits in bits
+      ui32 bits = 8 - msp->unstuff;        
+      ui32 t = val & 0xFF;
+      bool unstuff = ((val & 0xFF) == 0xFF);  // Do we need unstuffing next?
+
+      t |= ((val >> 8) & 0xFF) << bits;
+      bits += 8 - unstuff;
+      unstuff = (((val >> 8) & 0xFF) == 0xFF);
+
+      t |= ((val >> 16) & 0xFF) << bits;
+      bits += 8 - unstuff;
+      unstuff = (((val >> 16) & 0xFF) == 0xFF);
+
+      t |= ((val >> 24) & 0xFF) << bits;
+      bits += 8 - unstuff;
+      msp->unstuff = (((val >> 24) & 0xFF) == 0xFF); // for next byte
+
+      msp->tmp |= ((ui64)t) << msp->bits;  // move data to msp->tmp
+      msp->bits += bits;
+    }
+
+    //************************************************************************/
+    /** @brief Initialize frwd_struct32 struct and reads some bytes
+     *  
+     *  @tparam      X is the value fed in when the bitstream is exhausted.
+     *               See frwd_read regarding the template
+     *  @param [in]  msp is a pointer to frwd_struct32
+     *  @param [in]  data is a pointer to the start of data
+     *  @param [in]  size is the number of byte in the bitstream
+     */
+    template<int X>
+    static inline
+    void frwd_init(frwd_struct32 *msp, const ui8* data, int size)
+    {
+      msp->data = data;
+      msp->tmp = 0;
+      msp->bits = 0;
+      msp->unstuff = 0;
+      msp->size = size;
+
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the bitstream
+      int num = 4 - (int)(intptr_t(msp->data) & 0x3);
+      for (int i = 0; i < num; ++i)
+      {
+        ui64 d;
+        //read a byte if the buffer is not exhausted, otherwise set it to X
+        d = msp->size-- > 0 ? *msp->data++ : X;
+        msp->tmp |= (d << msp->bits);      // store data in msp->tmp
+        msp->bits += 8 - msp->unstuff;     // number of bits added to msp->tmp
+        msp->unstuff = ((d & 0xFF) == 0xFF); // unstuffing for next byte
+      }
+      frwd_read<X>(msp); // read 32 bits more
+    }
+
+    //************************************************************************/
+    /** @brief Consume num_bits bits from the bitstream of frwd_struct32
+     *
+     *  @param [in]  msp is a pointer to frwd_struct32
+     *  @param [in]  num_bits is the number of bit to consume
+     */
+    static inline 
+    void frwd_advance(frwd_struct32 *msp, ui32 num_bits)
+    {
+      assert(num_bits <= msp->bits);
+      msp->tmp >>= num_bits;  // consume num_bits
+      msp->bits -= num_bits;
+    }
+
+    //************************************************************************/
+    /** @brief Fetches 32 bits from the frwd_struct32 bitstream
+     *
+     *  @tparam      X is the value fed in when the bitstream is exhausted.
+     *               See frwd_read regarding the template
+     *  @param [in]  msp is a pointer to frwd_struct32
+     */
+    template<int X>
+    static inline 
+    ui32 frwd_fetch(frwd_struct32 *msp)
+    {
+      if (msp->bits < 32)
+      {
+        frwd_read<X>(msp);
+        if (msp->bits < 32) //need to test
+          frwd_read<X>(msp);
+      }
+      return (ui32)msp->tmp;
+    }
+
+    //************************************************************************/
+    /** @brief Decodes one codeblock, processing the cleanup, siginificance
+     *         propagation, and magnitude refinement pass
+     *
+     *  @param [in]   coded_data is a pointer to bitstream
+     *  @param [in]   decoded_data is a pointer to decoded codeblock data buf.
+     *  @param [in]   missing_msbs is the number of missing MSBs
+     *  @param [in]   num_passes is the number of passes: 1 if CUP only,
+     *                2 for CUP+SPP, and 3 for CUP+SPP+MRP
+     *  @param [in]   lengths1 is the length of cleanup pass
+     *  @param [in]   lengths2 is the length of refinement passes (either SPP
+     *                only or SPP+MRP)
+     *  @param [in]   width is the decoded codeblock width 
+     *  @param [in]   height is the decoded codeblock height
+     *  @param [in]   stride is the decoded codeblock buffer stride 
+     *  @param [in]   stripe_causal is true for stripe causal mode
+     */
+    bool ojph_decode_codeblock32(ui8* coded_data, ui32* decoded_data,
+                                 ui32 missing_msbs, ui32 num_passes,
+                                 ui32 lengths1, ui32 lengths2,
+                                 ui32 width, ui32 height, ui32 stride,
+                                 bool stripe_causal)
+    {
+      static bool insufficient_precision = false;
+      static bool modify_code = false;
+      static bool truncate_spp_mrp = false;
+
+      if (num_passes > 1 && lengths2 == 0)
+      {
+        OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
+                              "one coding pass, but zero length for "
+                              "2nd and potential 3rd pass.");
+        num_passes = 1;
+      }
+
+      if (num_passes > 3)
+      {
+        OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
+                              "This codeblocks has %d passes.",
+                              num_passes);
+        return false;
+      }
+
+      if (missing_msbs > 30) // p < 0
+      {
+        if (insufficient_precision == false) 
+        {
+          insufficient_precision = true;
+          OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
+                                "codeblock. This message will not be "
+                                "displayed again.");
+        }
+        return false;
+      }       
+      else if (missing_msbs == 30) // p == 0
+      { // not enough precision to decode and set the bin center to 1
+        if (modify_code == false) {
+          modify_code = true;
+          OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
+                                "pass. The code can be modified to support "
+                                "this case. This message will not be "
+                                "displayed again.");
+        }
+         return false;         // 32 bits are not enough to decode this
+       }
+      else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
+      {
+        if (num_passes > 1) {
+          num_passes = 1;
+          if (truncate_spp_mrp == false) {
+            truncate_spp_mrp = true;
+            OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
+                                  "nor MagRef passes; both will be skipped. "
+                                  "This message will not be displayed "
+                                  "again.");
+          }
+        }
+      }
+      ui32 p = 30 - missing_msbs; // The least significant bitplane for CUP
+      // There is a way to handle the case of p == 0, but a different path
+      // is required
+
+      if (lengths1 < 2)
+      {
+        OJPH_WARN(0x00010006, "Wrong codeblock length.");
+        return false;
+      }
+
+      // read scup and fix the bytes there
+      int lcup, scup;
+      lcup = (int)lengths1;  // length of CUP
+      //scup is the length of MEL + VLC
+      scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
+      if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
+        return false;
+
+      // The temporary storage scratch holds two types of data in an 
+      // interleaved fashion. The interleaving allows us to use one
+      // memory pointer.
+      // We have one entry for a decoded VLC code, and one entry for UVLC.
+      // Entries are 16 bits each, corresponding to one quad, 
+      // but since we want to use XMM registers of the SSE family 
+      // of SIMD; we allocated 16 bytes or more per quad row; that is,
+      // the width is no smaller than 16 bytes (or 8 entries), and the
+      // height is 512 quads
+      // Each VLC entry contains, in the following order, starting 
+      // from MSB
+      // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
+      // Each entry in UVLC contains u_q
+      // One extra row to handle the case of SPP propagating downwards
+      // when codeblock width is 4
+      ui16 scratch[8 * 513] = {0};       // 8 kB
+
+      // We need an extra two entries (one inf and one u_q) beyond
+      // the last column. 
+      // If the block width is 4 (2 quads), then we use sstr of 8 
+      // (enough for 4 quads). If width is 8 (4 quads) we use 
+      // sstr is 16 (enough for 8 quads). For a width of 16 (8 
+      // quads), we use 24 (enough for 12 quads).
+      ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
+
+      ui32 mmsbp2 = missing_msbs + 2;
+
+      // The cleanup pass is decoded in two steps; in step one,
+      // the VLC and MEL segments are decoded, generating a record that 
+      // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
+      // This information should be sufficient for the next step.
+      // In step 2, we decode the MagSgn segment.
+
+      // step 1 decoding VLC and MEL segments
+      {
+        // init structures
+        dec_mel_st mel;
+        mel_init(&mel, coded_data, lcup, scup);
+        rev_struct vlc;
+        rev_init(&vlc, coded_data, lcup, scup);
+
+        int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
+                                     // data represented as runs of 0 events
+                                     // See mel_decode description
+
+        ui32 vlc_val;
+        ui32 c_q = 0;
+        ui16 *sp = scratch;
+        //initial quad row
+        for (ui32 x = 0; x < width; sp += 4)
+        {
+          // decode VLC
+          /////////////
+
+          // first quad
+          vlc_val = rev_fetch(&vlc);
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
+
+          // if context is zero, use one MEL event
+          if (c_q == 0) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // Is the run terminated in 1? if so, use decoded VLC code, 
+            // otherwise, discard decoded data, since we will decoded again 
+            // using a different context
+            t0 = (run == -1) ? t0 : 0;
+
+            // is run -1 or -2? this means a run has been consumed
+            if (run < 0) 
+              run = mel_get_run(&mel);  // get another run
+          }
+          //run -= (c_q == 0) ? 2 : 0;
+          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[0] = t0;
+          x += 2;
+
+          // prepare context for the next quad; eqn. 1 in ITU T.814
+          c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
+
+          //remove data from vlc stream (0 bits are removed if vlc is not used)
+          vlc_val = rev_advance(&vlc, t0 & 0x7);
+
+          //second quad
+          ui16 t1 = 0;
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)]; 
+
+          // if context is zero, use one MEL event
+          if (c_q == 0 && x < width) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // if event is 0, discard decoded t1
+            t1 = (run == -1) ? t1 : 0;
+
+            if (run < 0) // have we consumed all events in a run
+              run = mel_get_run(&mel); // if yes, then get another run
+          }
+          t1 = x < width ? t1 : 0;
+          //run -= (c_q == 0 && x < width) ? 2 : 0;
+          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[2] = t1;
+          x += 2;
+
+          //prepare context for the next quad, eqn. 1 in ITU T.814
+          c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
+
+          //remove data from vlc stream, if qinf is not used, cwdlen is 0
+          vlc_val = rev_advance(&vlc, t1 & 0x7);
+          
+          // decode u
+          /////////////
+          // uvlc_mode is made up of u_offset bits from the quad pair
+          ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
+          {                     // the MEL run of events
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
+                                                 // is 0x40
+
+            if (run < 0)//if run is consumed (run is -1 or -2), get another run
+              run = mel_get_run(&mel);
+          }
+          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
+          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+
+          //decode uvlc_mode to get u for both quads
+          ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
+          //remove total prefix length
+          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7); 
+          uvlc_entry >>= 3; 
+          //extract suffixes for quad 0 and 1
+          ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+          ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
+          vlc_val = rev_advance(&vlc, len);
+          uvlc_entry >>= 4;
+          // quad 0 length
+          len = uvlc_entry & 0x7; // quad 0 suffix length
+          uvlc_entry >>= 3;
+          ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len)));//kap. 1
+          sp[1] = u_q;
+          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
+          sp[3]= u_q;
+        }
+        sp[0] = sp[1] = 0;
+
+        //non initial quad rows
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          c_q = 0;                                // context
+          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
+
+          for (ui32 x = 0; x < width; sp += 4)
+          {
+            // decode VLC
+            /////////////
+
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
+
+            // first quad
+            vlc_val = rev_fetch(&vlc);
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
+
+            // if context is zero, use one MEL event
+            if (c_q == 0) //zero context
+            {
+              run -= 2; //subtract 2, since events number is multiplied by 2
+
+              // Is the run terminated in 1? if so, use decoded VLC code, 
+              // otherwise, discard decoded data, since we will decoded again 
+              // using a different context
+              t0 = (run == -1) ? t0 : 0;
+
+              // is run -1 or -2? this means a run has been consumed
+              if (run < 0) 
+                run = mel_get_run(&mel);  // get another run
+            }
+            //run -= (c_q == 0) ? 2 : 0;
+            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[0] = t0;
+            x += 2;
+
+            // prepare context for the next quad; eqn. 2 in ITU T.814
+            // sigma_q (w, sw)
+            c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[0 - (si32)sstr] & 0x80;
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
+
+            //remove data from vlc stream (0 bits are removed if vlc is unused)
+            vlc_val = rev_advance(&vlc, t0 & 0x7);
+
+            //second quad
+            ui16 t1 = 0;
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)]; 
+
+            // if context is zero, use one MEL event
+            if (c_q == 0 && x < width) //zero context
+            {
+              run -= 2; //subtract 2, since events number if multiplied by 2
+
+              // if event is 0, discard decoded t1
+              t1 = (run == -1) ? t1 : 0;
+
+              if (run < 0) // have we consumed all events in a run
+                run = mel_get_run(&mel); // if yes, then get another run
+            }
+            t1 = x < width ? t1 : 0;
+            //run -= (c_q == 0 && x < width) ? 2 : 0;
+            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[2] = t1;
+            x += 2;
+
+            // partial c_q, will be completed when we process the next quad
+            // sigma_q (w, sw)
+            c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[2 - (si32)sstr] & 0x80;
+
+            //remove data from vlc stream, if qinf is not used, cwdlen is 0
+            vlc_val = rev_advance(&vlc, t1 & 0x7);
+          
+            // decode u
+            /////////////
+            // uvlc_mode is made up of u_offset bits from the quad pair
+            ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+            ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
+            //remove total prefix length
+            vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
+            uvlc_entry >>= 3;
+            //extract suffixes for quad 0 and 1
+            ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+            ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
+            vlc_val = rev_advance(&vlc, len);
+            uvlc_entry >>= 4;
+            // quad 0 length
+            len = uvlc_entry & 0x7; // quad 0 suffix length
+            uvlc_entry >>= 3;
+            ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
+            sp[1] = u_q;
+            u_q = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
+            sp[3] = u_q;
+          }
+          sp[0] = sp[1] = 0;
+        }
+      }
+
+      // step2 we decode magsgn
+      {
+        // We allocate a scratch row for storing v_n values.
+        // We have 512 quads horizontally.
+        // We need an extra entry to handle the case of vp[1]
+        // when vp is at the last column.
+        // Here, we allocate 4 instead of 1 to make the buffer size
+        // a multipled of 16 bytes.
+        const int v_n_size = 512 + 4;
+        ui32 v_n_scratch[v_n_size] = {0};  // 2+ kB
+
+        frwd_struct32 magsgn;
+        frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
+
+        ui16 *sp = scratch;
+        ui32 *vp = v_n_scratch;
+        ui32 *dp = decoded_data;
+
+        ui32 prev_v_n = 0;
+        for (ui32 x = 0; x < width; sp += 2, ++vp)
+        {
+          ui32 inf = sp[0];
+          ui32 U_q = sp[1];
+          if (U_q > mmsbp2)
+            return false;
+
+          ui32 v_n;
+          ui32 val = 0;
+          ui32 bit = 0;
+          if (inf & (1 << (4 + bit)))
+          {
+            //get 32 bits of magsgn data
+            ui32 ms_val = frwd_fetch<0xFF>(&magsgn); 
+            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+            frwd_advance(&magsgn, m_n);                 //consume m_n
+
+            val = ms_val << 31;                     // get sign bit
+            v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
+            v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+            v_n |= 1;                               // add center of bin    
+            //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+            //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+            val |= (v_n + 2) << (p - 1);
+          }
+          dp[0] = val;
+
+          v_n = 0;
+          val = 0;
+          bit = 1;
+          if (inf & (1 << (4 + bit)))
+          {
+            //get 32 bits of magsgn data
+            ui32 ms_val = frwd_fetch<0xFF>(&magsgn); 
+            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+            frwd_advance(&magsgn, m_n);                 //consume m_n
+
+            val = ms_val << 31;                      // get sign bit
+            v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
+            v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+            v_n |= 1;                               // add center of bin    
+            //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+            //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+            val |= (v_n + 2) << (p - 1);
+          }
+          dp[stride] = val;
+          vp[0] = prev_v_n | v_n;
+          prev_v_n = 0;
+          ++dp;
+          if (++x >= width)
+          { ++vp; break; }
+
+          val = 0;
+          bit = 2;
+          if (inf & (1 << (4 + bit)))
+          {
+            //get 32 bits of magsgn data
+            ui32 ms_val = frwd_fetch<0xFF>(&magsgn); 
+            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+            frwd_advance(&magsgn, m_n);                 //consume m_n
+
+            val = ms_val << 31;                     // get sign bit
+            v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
+            v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+            v_n |= 1;                               // add center of bin    
+            //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+            //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+            val |= (v_n + 2) << (p - 1);
+          }
+          dp[0] = val;
+
+          v_n = 0;
+          val = 0;
+          bit = 3;
+          if (inf & (1 << (4 + bit)))
+          {
+            //get 32 bits of magsgn data
+            ui32 ms_val = frwd_fetch<0xFF>(&magsgn); 
+            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+            frwd_advance(&magsgn, m_n);                 //consume m_n
+
+            val = ms_val << 31;                     // get sign bit
+            v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
+            v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+            v_n |= 1;                               // add center of bin    
+            //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+            //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+            val |= (v_n + 2) << (p - 1);
+          }
+          dp[stride] = val;
+          prev_v_n = v_n;
+          ++dp;
+          ++x;
+        }
+        vp[0] = prev_v_n;
+
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          ui16 *sp = scratch + (y >> 1) * sstr;
+          ui32 *vp = v_n_scratch;
+          ui32 *dp = decoded_data + y * stride;
+
+          prev_v_n = 0;
+          for (ui32 x = 0; x < width; sp += 2, ++vp)
+          {
+            ui32 inf = sp[0];
+            ui32 u_q = sp[1];
+
+            ui32 gamma = inf & 0xF0; gamma &= gamma - 0x10; //is gamma_q 1?
+            ui32 emax = vp[0] | vp[1];
+            emax = 31 - count_leading_zeros(emax | 2); // emax - 1
+            ui32 kappa = gamma ? emax : 1;
+
+            ui32 U_q = u_q + kappa;
+            if (U_q > mmsbp2)
+              return false;
+
+            ui32 v_n;
+            ui32 val = 0;
+            ui32 bit = 0;
+            if (inf & (1 << (4 + bit)))
+            {
+              //get 32 bits of magsgn data
+              ui32 ms_val = frwd_fetch<0xFF>(&magsgn); 
+              ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+              frwd_advance(&magsgn, m_n);                 //consume m_n
+
+              val = ms_val << 31;                     // get sign bit
+              v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
+              v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+              v_n |= 1;                               // add center of bin    
+              //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+              //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+              val |= (v_n + 2) << (p - 1);
+            }
+            dp[0] = val;
+
+            v_n = 0;
+            val = 0;
+            bit = 1;
+            if (inf & (1 << (4 + bit)))
+            {
+              //get 32 bits of magsgn data
+              ui32 ms_val = frwd_fetch<0xFF>(&magsgn); 
+              ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+              frwd_advance(&magsgn, m_n);                 //consume m_n
+
+              val = ms_val << 31;                     // get sign bit
+              v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
+              v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+              v_n |= 1;                               // add center of bin    
+              //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+              //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+              val |= (v_n + 2) << (p - 1);
+            }
+            dp[stride] = val;
+            vp[0] = prev_v_n | v_n;
+            prev_v_n = 0;
+            ++dp;
+            if (++x >= width)
+            { ++vp; break; }
+
+            val = 0;
+            bit = 2;
+            if (inf & (1 << (4 + bit)))
+            {
+              //get 32 bits of magsgn data
+              ui32 ms_val = frwd_fetch<0xFF>(&magsgn); 
+              ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+              frwd_advance(&magsgn, m_n);                 //consume m_n
+
+              val = ms_val << 31;                     // get sign bit
+              v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
+              v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+              v_n |= 1;                               // add center of bin    
+              //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+              //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+              val |= (v_n + 2) << (p - 1);
+            }
+            dp[0] = val;
+
+            v_n = 0;
+            val = 0;
+            bit = 3;
+            if (inf & (1 << (4 + bit)))
+            {
+              //get 32 bits of magsgn data
+              ui32 ms_val = frwd_fetch<0xFF>(&magsgn); 
+              ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+              frwd_advance(&magsgn, m_n);                 //consume m_n
+
+              val = ms_val << 31;                     // get sign bit
+              v_n = ms_val & ((1 << m_n) - 1);        // keep only m_n bits
+              v_n |= ((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+              v_n |= 1;                               // add center of bin    
+              //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+              //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+              val |= (v_n + 2) << (p - 1);
+            }
+            dp[stride] = val;
+            prev_v_n = v_n;
+            ++dp;
+            ++x;
+          }
+          vp[0] = prev_v_n;
+        }
+      }
+
+      if (num_passes > 1)
+      {
+        // We use scratch again, we can divide it into multiple regions
+        // sigma holds all the significant samples, and it cannot
+        // be modified after it is set.  it will be used during the
+        // Magnitude Refinement Pass
+        ui16* const sigma = scratch;
+
+        ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
+                                         // ui16 contains 4 columns
+        mstr = ((mstr + 2u) + 7u) & ~7u; // multiples of 8
+
+        // We re-arrange quad significance, where each 4 consecutive
+        // bits represent one quad, into column significance, where,
+        // each 4 consequtive bits represent one column of 4 rows
+        {
+          ui32 y;
+          for (y = 0; y < height; y += 4)
+          {
+            ui16* sp = scratch + (y >> 1) * sstr;
+            ui16* dp = sigma + (y >> 2) * mstr;
+            for (ui32 x = 0; x < width; x += 4, sp += 4, ++dp) {
+              ui32 t0 = 0, t1 = 0;
+              t0  = ((sp[0     ] & 0x30u) >> 4)  | ((sp[0     ] & 0xC0u) >> 2);
+              t0 |= ((sp[2     ] & 0x30u) << 4)  | ((sp[2     ] & 0xC0u) << 6);
+              t1  = ((sp[0+sstr] & 0x30u) >> 2)  | ((sp[0+sstr] & 0xC0u)     );
+              t1 |= ((sp[2+sstr] & 0x30u) << 6)  | ((sp[2+sstr] & 0xC0u) << 8);
+              dp[0] = (ui16)(t0 | t1);
+            }
+            dp[0] = 0; // set an extra entry on the right with 0
+          }
+          {
+            // reset one row after the codeblock
+            ui16* dp = sigma + (y >> 2) * mstr;
+            for (ui32 x = 0; x < width; x += 4, ++dp)
+              dp[0] = 0;
+            dp[0] = 0; // set an extra entry on the right with 0
+          }
+        }
+
+        // We perform Significance Propagation Pass here
+        {
+          // This stores significance information of the previous
+          // 4 rows.  Significance information in this array includes
+          // all signicant samples in bitplane p - 1; that is,
+          // significant samples for bitplane p (discovered during the
+          // cleanup pass and stored in sigma) and samples that have recently
+          // became significant (during the SPP) in bitplane p-1.
+          // We store enough for the widest row, containing 1024 columns,
+          // which is equivalent to 256 of ui16, since each stores 4 columns.
+          // We add an extra 8 entries, just in case we need more
+          ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
+
+          frwd_struct32 sigprop;
+          frwd_init<0>(&sigprop, coded_data + lengths1, (int)lengths2);
+
+          for (ui32 y = 0; y < height; y += 4)
+          {
+            ui32 pattern = 0xFFFFu; // a pattern needed samples
+            if (height - y < 4) {
+              pattern = 0x7777u;
+              if (height - y < 3) {
+                pattern = 0x3333u;
+                if (height - y < 2)
+                  pattern = 0x1111u;
+              }
+            }
+
+            // prev holds sign. info. for the previous quad, together
+            // with the rows on top of it and below it.
+            ui32 prev = 0;
+            ui16 *prev_sig = prev_row_sig;
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
+            ui32 *dpp = decoded_data + y * stride;
+            for (ui32 x = 0; x < width; x += 4, ++cur_sig, ++prev_sig)
+            {
+              // only rows and columns inside the stripe are included
+              si32 s = (si32)x + 4 - (si32)width;
+              s = ojph_max(s, 0);
+              pattern = pattern >> (s * 4);
+
+              // We first find locations that need to be tested (potential
+              // SPP members); these location will end up in mbr
+              // In each iteration, we produce 16 bits because cwd can have
+              // up to 16 bits of significance information, followed by the
+              // corresponding 16 bits of sign information; therefore, it is
+              // sufficient to fetch 32 bit data per loop.
+
+              // Althougth we are interested in 16 bits only, we load 32 bits.
+              // For the 16 bits we are producing, we need the next 4 bits --
+              // We need data for at least 5 columns out of 8.
+              // Therefore loading 32 bits is easier than loading 16 bits
+              // twice.
+              ui32 ps = load_le_ui16x2(prev_sig);
+              ui32 ns = load_le_ui16x2(cur_sig + mstr);
+              ui32 u = (ps & 0x88888888) >> 3; // the row on top
+              if (!stripe_causal)
+                u |= (ns & 0x11111111) << 3;   // the row below
+
+              ui32 cs = load_le_ui16x2(cur_sig);
+              // vertical integration
+              ui32 mbr =  cs;                // this sig. info.
+              mbr |= (cs & 0x77777777) << 1; //above neighbors
+              mbr |= (cs & 0xEEEEEEEE) >> 1; //below neighbors
+              mbr |= u;
+              // horizontal integration
+              ui32 t = mbr;
+              mbr |= t << 4;      // neighbors on the left
+              mbr |= t >> 4;      // neighbors on the right
+              mbr |= prev >> 12;  // significance of previous group
+
+              // remove outside samples, and already significant samples
+              mbr &= pattern;
+              mbr &= ~cs;
+
+              // find samples that become significant during the SPP
+              ui32 new_sig = mbr;
+              if (new_sig)
+              {
+                ui32 cwd = frwd_fetch<0>(&sigprop);
+
+                ui32 cnt = 0;
+                ui32 col_mask = 0xFu;
+                ui32 inv_sig = ~cs & pattern;
+                for (int i = 0; i < 16; i += 4, col_mask <<= 4)
+                {
+                  if ((col_mask & new_sig) == 0)
+                    continue;
+
+                  //scan one column
+                  ui32 sample_mask = 0x1111u & col_mask;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0x33u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0x76u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0xECu << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0xC8u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+                }
+
+                if (new_sig)
+                {
+                  // new_sig has newly-discovered sig. samples during SPP
+                  // find the signs and update decoded_data
+                  ui32 *dp = dpp + x;
+                  ui32 val = 3u << (p - 2);
+                  col_mask = 0xFu;
+                  for (int i = 0; i < 4; ++i, ++dp, col_mask <<= 4)
+                  {
+                    if ((col_mask & new_sig) == 0)
+                      continue;
+
+                    //scan 4 signs
+                    ui32 sample_mask = 0x1111u & col_mask;
+                    if (new_sig & sample_mask)
+                    {
+                      assert(dp[0] == 0);
+                      dp[0] = (cwd << 31) | val;
+                      cwd >>= 1; ++cnt;
+                    }
+
+                    sample_mask += sample_mask;
+                    if (new_sig & sample_mask)
+                    {
+                      assert(dp[stride] == 0);
+                      dp[stride] = (cwd << 31) | val;
+                      cwd >>= 1; ++cnt;
+                    }
+
+                    sample_mask += sample_mask;
+                    if (new_sig & sample_mask)
+                    {
+                      assert(dp[2 * stride] == 0);
+                      dp[2 * stride] = (cwd << 31) | val;
+                      cwd >>= 1; ++cnt;
+                    }
+
+                    sample_mask += sample_mask;
+                    if (new_sig & sample_mask)
+                    {
+                      assert(dp[3 * stride] == 0);
+                      dp[3 * stride] = (cwd << 31) | val;
+                      cwd >>= 1; ++cnt;
+                    }
+                  }
+                }
+                frwd_advance(&sigprop, cnt);
+              }
+
+              new_sig |= cs;
+              *prev_sig = (ui16)(new_sig);
+
+              // vertical integration for the new sig. info.
+              t = new_sig;
+              new_sig |= (t & 0x7777) << 1; //above neighbors
+              new_sig |= (t & 0xEEEE) >> 1; //below neighbors
+              // add sig. info. from the row on top and below
+              prev = new_sig | u;
+              // we need only the bits in 0xF000
+              prev &= 0xF000;
+            }
+          }
+        }
+
+        // We perform Magnitude Refinement Pass here
+        if (num_passes > 2)
+        {
+          rev_struct magref;
+          rev_init_mrp(&magref, coded_data, (int)lengths1, (int)lengths2);
+
+          for (ui32 y = 0; y < height; y += 4)
+          {
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
+            ui32 *dpp = decoded_data + y * stride;
+            ui32 half = 1 << (p - 2);
+            for (ui32 i = 0; i < width; i += 8, cur_sig += 2)
+            {
+              //Process one entry from sigma array at a time
+              // Each nibble (4 bits) in the sigma array represents 4 rows,
+              // and the 32 bits contain 8 columns
+              ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
+              ui32 sig = load_le_ui16x2(cur_sig); // 32 bits processed now
+              ui32 col_mask = 0xFu;  // a mask for a column in sig
+              if (sig) // if any of the 32 bits are set
+              {
+                for (int j = 0; j < 8; ++j) //one column at a time
+                {
+                  if (sig & col_mask) // lowest nibble
+                  {
+                    ui32 *dp = dpp + i + j; // next column in decoded samples
+                    ui32 sample_mask = 0x11111111u & col_mask; //LSB
+
+                    for (int k = 0; k < 4; ++k) {
+                      if (sig & sample_mask) //if LSB is set
+                      {
+                        assert(dp[0] != 0); // decoded value cannot be zero
+                        assert((dp[0] & half) == 0); // no half
+                        ui32 sym = cwd & 1;          // get it value
+                        sym = (1 - sym) << (p - 1); // previous center of bin
+                        sym |= half;            // put half the center of bin
+                        dp[0] ^= sym;    // remove old bin center and put new
+                        cwd >>= 1;       // consume word
+                      }
+                      sample_mask += sample_mask; //next row
+                      dp += stride; // next samples row
+                    }
+                  }
+                  col_mask <<= 4; //next column
+                }
+              }
+              // consume data according to the number of bits set
+              rev_advance_mrp(&magref, population_count(sig));
+            }
+          }
+        }
+      }
+      return true;
+    }
+  }
 }

--- a/Native/Common/OpenJPH/coding/ojph_block_decoder64.cpp
+++ b/Native/Common/OpenJPH/coding/ojph_block_decoder64.cpp
@@ -40,1624 +40,1624 @@
  *  @brief implements a HTJ2K block decoder
  */
 
- #include <string>
- #include <iostream>
- 
- #include <cassert>
- #include <cstring>
- #include "ojph_block_common.h"
- #include "ojph_block_decoder.h"
- #include "ojph_arch.h"
- #include "ojph_message.h"
- 
- namespace ojph {
-   namespace local {
- 
-     //************************************************************************/
-     /** @brief MEL state structure for reading and decoding the MEL bitstream
-      *
-      *  A number of events is decoded from the MEL bitstream ahead of time
-      *  and stored in run/num_runs.
-      *  Each run represents the number of zero events before a one event.
-      */ 
-     struct dec_mel_st {
-       dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
-         k(0), num_runs(0), runs(0)
-       {}
-       // data decoding machinery
-       ui8* data;    //!<the address of data (or bitstream)
-       ui64 tmp;     //!<temporary buffer for read data
-       int bits;     //!<number of bits stored in tmp
-       int size;     //!<number of bytes in MEL code
-       bool unstuff; //!<true if the next bit needs to be unstuffed
-       int k;        //!<state of MEL decoder
- 
-       // queue of decoded runs
-       int num_runs; //!<number of decoded runs left in runs (maximum 8)
-       ui64 runs;    //!<runs of decoded MEL codewords (7 bits/run)
-     };
- 
-     //************************************************************************/
-     /** @brief Reads and unstuffs the MEL bitstream
-      * 
-      *  This design needs more bytes in the codeblock buffer than the length
-      *  of the cleanup pass by up to 2 bytes.
-      *
-      *  Unstuffing removes the MSB of the byte following a byte whose
-      *  value is 0xFF; this prevents sequences larger than 0xFF7F in value
-      *  from appearing the bitstream.
-      *
-      *  @param [in]  melp is a pointer to dec_mel_st structure
-      */
-     static inline
-     void mel_read(dec_mel_st *melp)
-     {
-       if (melp->bits > 32)  //there are enough bits in the tmp variable
-         return;             // return without reading new data
- 
-       ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
-       if (melp->size > 4) {        // if there is data in the MEL segment
-         val = *(ui32*)melp->data;  // read 32 bits from MEL data
-         melp->data += 4;           // advance pointer
-         melp->size -= 4;           // reduce counter
-       }
-       else if (melp->size > 0)
-       { // 4 or less
-         int i = 0;
-         while (melp->size > 1) {   
-           ui32 v = *melp->data++;    // read one byte at a time
-           ui32 m = ~(0xFFu << i);    // mask of location
-           val = (val & m) | (v << i);// put one byte in its correct location
-           --melp->size;
-           i += 8;
-         }
-         // size equal to 1
-         ui32 v = *melp->data++;    // the one before the last is different 
-         v |= 0xF;                  // MEL and VLC segments can overlap
-         ui32 m = ~(0xFFu << i);
-         val = (val & m) | (v << i);
-         --melp->size;
-       }
-       
-       // next we unstuff them before adding them to the buffer
-       int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
-                                      // the previously read byte requires 
-                                      // unstuffing
- 
-       // data is unstuffed and accumulated in t
-       // bits has the number of bits in t
-       ui32 t = val & 0xFF; 
-       bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
-       bits -= unstuff; // there is one less bit in t if unstuffing is needed
-       t = t << (8 - unstuff); // move up to make room for the next byte
- 
-       //this is a repeat of the above
-       t |= (val>>8) & 0xFF;
-       unstuff = (((val >> 8) & 0xFF) == 0xFF);
-       bits -= unstuff;
-       t = t << (8 - unstuff);
- 
-       t |= (val>>16) & 0xFF;
-       unstuff = (((val >> 16) & 0xFF) == 0xFF);
-       bits -= unstuff;
-       t = t << (8 - unstuff);
- 
-       t |= (val>>24) & 0xFF;
-       melp->unstuff = (((val >> 24) & 0xFF) == 0xFF);
- 
-       // move t to tmp, and push the result all the way up, so we read from
-       // the MSB
-       melp->tmp |= ((ui64)t) << (64 - bits - melp->bits);
-       melp->bits += bits; //increment the number of bits in tmp
-     }
- 
-     //************************************************************************/
-     /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
-      * 
-      *  Runs are stored in "runs" and the number of runs in "num_runs".
-      *  Each run represents a number of zero events that may or may not 
-      *  terminate in a 1 event.
-      *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
-      *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating 
-      *  with 1, contain the number of consecutive 0 zero events * 2; for the 
-      *  case terminating with 0, they store (number of consecutive 0 zero 
-      *  events - 1) * 2.
-      *  A total of 6 bits (made up of 1 + 5) should have been enough.
-      *
-      *  @param [in]  melp is a pointer to dec_mel_st structure
-      */
-     static inline
-     void mel_decode(dec_mel_st *melp)
-     {
-       static const int mel_exp[13] = { //MEL exponents
-         0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5
-       };
- 
-       if (melp->bits < 6) // if there are less than 6 bits in tmp
-         mel_read(melp);   // then read from the MEL bitstream
-                           // 6 bits is the largest decodable MEL cwd
- 
-       //repeat so long that there is enough decodable bits in tmp,
-       // and the runs store is not full (num_runs < 8)
-       while (melp->bits >= 6 && melp->num_runs < 8)
-       {
-         int eval = mel_exp[melp->k]; // number of bits associated with state
-         int run = 0;
-         if (melp->tmp & (1ull<<63)) //The next bit to decode (stored in MSB)
-         { //one is found
-           run = 1 << eval;  
-           run--; // consecutive runs of 0 events - 1
-           melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12;//increment, max is 12
-           melp->tmp <<= 1; // consume one bit from tmp
-           melp->bits -= 1;
-           run = run << 1; // a stretch of zeros not terminating in one
-         }
-         else
-         { //0 is found
-           run = (int)(melp->tmp >> (63 - eval)) & ((1 << eval) - 1);
-           melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; //decrement, min is 0
-           melp->tmp <<= eval + 1; //consume eval + 1 bits (max is 6)
-           melp->bits -= eval + 1;
-           run = (run << 1) + 1; // a stretch of zeros terminating with one
-         }
-         eval = melp->num_runs * 7;           // 7 bits per run
-         melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
-         melp->runs |= ((ui64)run) << eval;   // store the value in runs
-         melp->num_runs++;                    // increment count  
-       }
-     }
- 
-     //************************************************************************/
-     /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
-      *         some bytes in order to get the read address to a multiple
-      *         of 4 
-      *
-      *  @param [in]  melp is a pointer to dec_mel_st structure
-      *  @param [in]  bbuf is a pointer to byte buffer
-      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-      *  @param [in]  scup is the length of MEL+VLC segments
-      */
-     static inline
-     void mel_init(dec_mel_st *melp, ui8* bbuf, int lcup, int scup)
-     {
-       melp->data = bbuf + lcup - scup; // move the pointer to the start of MEL
-       melp->bits = 0;                  // 0 bits in tmp
-       melp->tmp = 0;                   //
-       melp->unstuff = false;           // no unstuffing
-       melp->size = scup - 1;           // size is the length of MEL+VLC-1
-       melp->k = 0;                     // 0 for state 
-       melp->num_runs = 0;              // num_runs is 0
-       melp->runs = 0;                  //
- 
-       //This code is borrowed; original is for a different architecture
-       //These few lines take care of the case where data is not at a multiple
-       // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
-       int num = 4 - (int)(intptr_t(melp->data) & 0x3);
-       for (int i = 0; i < num; ++i) { // this code is similar to mel_read
-         assert(melp->unstuff == false || melp->data[0] <= 0x8F);
-         ui64 d = (melp->size > 0) ? *melp->data : 0xFF;//if buffer is consumed
-                                                        //set data to 0xFF
-         if (melp->size == 1) d |= 0xF; //if this is MEL+VLC-1, set LSBs to 0xF
-                                        // see the standard
-         melp->data += melp->size-- > 0; //increment if the end is not reached
-         int d_bits = 8 - melp->unstuff; //if unstuffing is needed, reduce by 1
-         melp->tmp = (melp->tmp << d_bits) | d; //store bits in tmp
-         melp->bits += d_bits;  //increment tmp by number of bits
-         melp->unstuff = ((d & 0xFF) == 0xFF); //true of next byte needs 
-                                               //unstuffing
-       }
-       melp->tmp <<= (64 - melp->bits); //push all the way up so the first bit
-                                        // is the MSB
-     }
- 
-     //************************************************************************/
-     /** @brief Retrieves one run from dec_mel_st; if there are no runs stored
-      *         MEL segment is decoded
-      *
-      * @param [in]  melp is a pointer to dec_mel_st structure
-      */    
-     static inline
-     int mel_get_run(dec_mel_st *melp)
-     {
-       if (melp->num_runs == 0)  //if no runs, decode more bit from MEL segment
-         mel_decode(melp);
- 
-       int t = melp->runs & 0x7F; //retrieve one run
-       melp->runs >>= 7;  // remove the retrieved run
-       melp->num_runs--;
-       return t; // return run
-     }
- 
-     //************************************************************************/
-     /** @brief A structure for reading and unstuffing a segment that grows
-      *         backward, such as VLC and MRP
-      */ 
-     struct rev_struct {
-       rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
-       {}
-       //storage
-       ui8* data;     //!<pointer to where to read data
-       ui64 tmp;	     //!<temporary buffer of read data
-       ui32 bits;     //!<number of bits stored in tmp
-       int size;      //!<number of bytes left
-       bool unstuff;  //!<true if the last byte is more than 0x8F
-                      //!<then the current byte is unstuffed if it is 0x7F
-     };
- 
-     //************************************************************************/
-     /** @brief Read and unstuff data from a backwardly-growing segment
-      *
-      *  This reader reads 8 bits from the VLC segment. It fills zeros when 
-      *  the buffer is exhausted; we basically do not care about these zeros 
-      *  because we should not need them -- any extra data should not be used 
-      *  in the actual decoding. If these bytes are needed, then there is a 
-      *  problem in the bitstream, but we do not flag this error.
-      *
-      *  Unstuffing is needed to prevent sequences larger than 0xFF8F from 
-      *  appearing in the bits stream; since we are reading backward, we keep
-      *  watch when a value larger than 0x8F appears in the bitstream. 
-      *  If the byte following this is 0x7F, we unstuff this byte (ignore the 
-      *  MSB of that byte, which should be 0).
-      *
-      *  @param [in]  vlcp is a pointer to rev_struct structure
-      */
-     static inline 
-     void rev_read8(rev_struct *vlcp)
-     {
-       // process 1 bytes
-       ui8 val = 0; // insert 0s at the end -- the standard says that the
-                    // bitstream must contain all needed bits. Therefore
-                    // if the whole bitstream is consumed and bits are still
-                    // needed, then this is an error condition, but we are
-                    // lenient -- it is also possible that we are decoding
-                    // more bits than what we are actually need.
-       if (vlcp->size > 0)  // if there are more than 3 bytes left in VLC
-       {
-         val = *vlcp->data; // then read 8 bits
-         --vlcp->data;      // increment data pointer
-         --vlcp->size;      // decrement number of bytes in the buffer
-       }
- 
-       // accumulate in tmp, and increment bits, check if unstuffing is needed
-       ui8 t = (vlcp->unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0;
-       val = (ui8)(val & (0xFFU >> t)); // protect against erroneous 1 in MSB
-       vlcp->tmp |= (ui64)val << vlcp->bits;
-       vlcp->bits += 8 - t;
-       vlcp->unstuff = val > 0x8F;
-     }
- 
-     //************************************************************************/
-     /** @brief Initiates the rev_struct structure and reads the first byte
-      *
-      *  This subroutine initializes the VLC decoder.  It discards the first 
-      *  12 bits (they have the sum of the lengths of VLC and MEL segments), 
-      *  and depending on unstuffing, stores 3 or 4 bits in the unstuffed
-      *  decoded buffer.
-      *
-      *  @param [in]  vlcp is a pointer to rev_struct structure
-      *  @param [in]  data is a pointer to byte at the start of the cleanup pass
-      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-      *  @param [in]  scup is the length of MEL+VLC segments
-      */
-     static inline 
-     void rev_init8(rev_struct *vlcp, ui8* data, int lcup, int scup)
-     {
-       //first byte has only the upper 4 bits
-       vlcp->data = data + lcup - 2;
- 
-       //size can not be larger than this, in fact it should be smaller
-       vlcp->size = scup - 2;
- 
-       ui8 val = *vlcp->data--; // read one byte (this is a half byte)
- 
-       // the first byte is treated different to other bytes, because only
-       // the MSB nibble is part of the VLC code.
-       val = (ui8)(val >> 4);
-       ui8 t = ((val & 0x7) == 0x7) ? 1 : 0; // unstuffing is needed
-       val = (ui8)(val & (0xFU >> t)); // protect against erroneous 1 in MSB
-       vlcp->tmp = val;
-       vlcp->bits = 4 - t;
-       vlcp->unstuff = val > 0x8; //this is useful for the next byte
-     }
- 
-     //************************************************************************/
-     /** @brief Fills the temporary variable (vlcp->tmp) by up to 64 bits
-      *
-      *  By the end of this call, vlcp->tmp must have no less than 56 bits
-      *
-      *  @param [in]  vlcp is a pointer to rev_struct structure
-      */
-     static inline 
-     ui64 rev_fetch64(rev_struct *vlcp)
-     {
-       while (vlcp->bits <= 56)
-         rev_read8(vlcp); // read 8 bits, but unstuffing might reduce this
-       return vlcp->tmp;  // return unstuff decoded bits
-     }    
- 
-     //************************************************************************/
-     /** @brief Consumes num_bits from a rev_struct structure
-      *
-      *  @param [in]  vlcp is a pointer to rev_struct structure
-      *  @param [in]  num_bits is the number of bits to be removed
-      */
-     static inline 
-     ui64 rev_advance64(rev_struct *vlcp, ui32 num_bits)
-     {
-       assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
-       vlcp->tmp >>= num_bits;         // remove bits
-       vlcp->bits -= num_bits;         // decrement the number of bits
-       return vlcp->tmp;
-     }    
- 
-     //************************************************************************/
-     /** @brief Reads and unstuffs from rev_struct
-      *
-      *  This is different than rev_read in that this fills in zeros when the
-      *  the available data is consumed.  The other does not care about the
-      *  values when all data is consumed.
-      *
-      *  See rev_read for more information about unstuffing
-      *
-      *  @param [in]  mrp is a pointer to rev_struct structure
-      */
-     static inline 
-     void rev_read_mrp(rev_struct *mrp)
-     {
-       //process 4 bytes at a time
-       if (mrp->bits > 32)
-         return;
-       ui32 val = 0;
-       if (mrp->size > 3) // If there are 3 byte or more
-       { // (mrp->data - 3) move pointer back to read 32 bits at once
-         val = *(ui32*)(mrp->data - 3); // read 32 bits
-         mrp->data -= 4;                // move back pointer
-         mrp->size -= 4;                // reduce count
-       }
-       else if (mrp->size > 0)
-       {
-         int i = 24;
-         while (mrp->size > 0) {   
-           ui32 v = *mrp->data--; // read one byte at a time
-           val |= (v << i);       // put byte in its correct location
-           --mrp->size;
-           i -= 8;
-         }
-       }
- 
-       //accumulate in tmp, and keep count in bits
-       ui32 bits, tmp = val >> 24;
- 
-       //test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
-       bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
-       bool unstuff = (val >> 24) > 0x8F;
- 
-       //process the next byte
-       tmp |= ((val >> 16) & 0xFF) << bits;
-       bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
-       unstuff = ((val >> 16) & 0xFF) > 0x8F;
- 
-       tmp |= ((val >> 8) & 0xFF) << bits;
-       bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
-       unstuff = ((val >> 8) & 0xFF) > 0x8F;
- 
-       tmp |= (val & 0xFF) << bits;
-       bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
-       unstuff = (val & 0xFF) > 0x8F;
- 
-       mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
-       mrp->bits += bits;
-       mrp->unstuff = unstuff;             // next byte
-     }
- 
-     //************************************************************************/
-     /** @brief Initialized rev_struct structure for MRP segment, and reads
-      *         a number of bytes such that the next 32 bits read are from
-      *         an address that is a multiple of 4. Note this is designed for
-      *         an architecture that read size must be compatible with the
-      *         alignment of the read address
-      *
-      *  There is another similar subroutine rev_init.  This subroutine does 
-      *  NOT skip the first 12 bits, and starts with unstuff set to true.
-      *
-      *  @param [in]  mrp is a pointer to rev_struct structure
-      *  @param [in]  data is a pointer to byte at the start of the cleanup pass
-      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-      *  @param [in]  len2 is the length of SPP+MRP segments
-      */
-     static inline 
-     void rev_init_mrp(rev_struct *mrp, ui8* data, int lcup, int len2)
-     {
-       mrp->data = data + lcup + len2 - 1;
-       mrp->size = len2;
-       mrp->unstuff = true;
-       mrp->bits = 0;
-       mrp->tmp = 0;
- 
-       //This code is designed for an architecture that read address should
-       // align to the read size (address multiple of 4 if read size is 4)
-       //These few lines take care of the case where data is not at a multiple
-       // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
-       int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
-       for (int i = 0; i < num; ++i) {
-         ui64 d;
-         //read a byte, 0 if no more data
-         d = (mrp->size-- > 0) ? *mrp->data-- : 0; 
-         //check if unstuffing is needed
-         ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-         mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
-         mrp->bits += d_bits;
-         mrp->unstuff = d > 0x8F; // for next byte
-       }
-       rev_read_mrp(mrp);
-     }
- 
-     //************************************************************************/
-     /** @brief Retrieves 32 bits from the head of a rev_struct structure 
-      *
-      *  By the end of this call, mrp->tmp must have no less than 33 bits
-      *
-      *  @param [in]  mrp is a pointer to rev_struct structure
-      */
-     static inline 
-     ui32 rev_fetch_mrp(rev_struct *mrp)
-     {
-       if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
-       {
-         rev_read_mrp(mrp);    // read 30-32 bits from mrp
-         if (mrp->bits < 32)   // if there is a space of 32 bits
-           rev_read_mrp(mrp);  // read more
-       }
-       return (ui32)mrp->tmp;  // return the head of mrp->tmp
-     }
- 
-     //************************************************************************/
-     /** @brief Consumes num_bits from a rev_struct structure
-      *
-      *  @param [in]  mrp is a pointer to rev_struct structure
-      *  @param [in]  num_bits is the number of bits to be removed
-      */
-     static inline 
-     ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
-     {
-       assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
-       mrp->tmp >>= num_bits;  // discard the lowest num_bits bits
-       mrp->bits -= num_bits;
-       return (ui32)mrp->tmp;  // return data after consumption
-     }
- 
-     //************************************************************************/
-     /** @brief State structure for reading and unstuffing of forward-growing 
-      *         bitstreams; these are: MagSgn and SPP bitstreams
-      */
-     struct frwd_struct64 {
-       const ui8* data;  //!<pointer to bitstream
-       ui64 tmp;         //!<temporary buffer of read data
-       ui32 bits;        //!<number of bits stored in tmp
-       ui32 unstuff;     //!<1 if a bit needs to be unstuffed from next byte
-       int size;         //!<size of data
-     };
- 
-     //************************************************************************/
-     /** @brief Read and unstuffs 32 bits from forward-growing bitstream
-      *  
-      *  A template is used to accommodate a different requirement for
-      *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
-      *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
-      *  X controls this value.
-      *
-      *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
-      *  in the conpressed sequence.  So whenever a value of 0xFF is coded, the
-      *  MSB of the next byte is set 0 and must be ignored during decoding.
-      *
-      *  Reading can go beyond the end of buffer by up to 3 bytes.
-      *
-      *  @tparam       X is the value fed in when the bitstream is exhausted
-      *  @param  [in]  msp is a pointer to frwd_struct64 structure
-      *
-      */ 
-     template<int X>
-     static inline 
-     void frwd_read(frwd_struct64 *msp)
-     {
-       assert(msp->bits <= 32); // assert that there is a space for 32 bits
- 
-       ui32 val = 0;
-       if (msp->size > 3) {
-         val = *(ui32*)msp->data;  // read 32 bits
-         msp->data += 4;           // increment pointer
-         msp->size -= 4;           // reduce size
-       }
-       else if (msp->size > 0)
-       {
-         int i = 0;
-         val = X != 0 ? 0xFFFFFFFFu : 0;
-         while (msp->size > 0) {   
-           ui32 v = *msp->data++;    // read one byte at a time
-           ui32 m = ~(0xFFu << i);    // mask of location
-           val = (val & m) | (v << i);// put one byte in its correct location
-           --msp->size;
-           i += 8;          
-         }
-       }
-       else
-         val = X != 0 ? 0xFFFFFFFFu : 0;
- 
-       // we accumulate in t and keep a count of the number of bits in bits
-       ui32 bits = 8 - msp->unstuff;        
-       ui32 t = val & 0xFF;
-       bool unstuff = ((val & 0xFF) == 0xFF);  // Do we need unstuffing next?
- 
-       t |= ((val >> 8) & 0xFF) << bits;
-       bits += 8 - unstuff;
-       unstuff = (((val >> 8) & 0xFF) == 0xFF);
- 
-       t |= ((val >> 16) & 0xFF) << bits;
-       bits += 8 - unstuff;
-       unstuff = (((val >> 16) & 0xFF) == 0xFF);
- 
-       t |= ((val >> 24) & 0xFF) << bits;
-       bits += 8 - unstuff;
-       msp->unstuff = (((val >> 24) & 0xFF) == 0xFF); // for next byte
- 
-       msp->tmp |= ((ui64)t) << msp->bits;  // move data to msp->tmp
-       msp->bits += bits;
-     }
- 
-     //************************************************************************/
-     /** @brief Read and unstuffs 8 bits from forward-growing bitstream
-      *  
-      *  A template is used to accommodate a different requirement for
-      *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
-      *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
-      *  X controls this value.
-      *
-      *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
-      *  in the conpressed sequence.  So whenever a value of 0xFF is coded, the
-      *  MSB of the next byte is set 0 and must be ignored during decoding.
-      *
-      *  @tparam       X is the value fed in when the bitstream is exhausted
-      *  @param  [in]  msp is a pointer to frwd_struct64 structure
-      *
-      */ 
-     template<ui8 X>
-     static inline 
-     void frwd_read8(frwd_struct64 *msp)
-     {
-       ui8 val = X;
-       if (msp->size > 0) {
-         val = *msp->data;  // read 8 bits
-         ++msp->data;      // increment pointer
-         --msp->size;      // reduce size
-       }
- 
-       // unstuff and accumulate
-       ui8 t = msp->unstuff ? 1 : 0;
-       val = (ui8)(val & (0xFFU >> t));
-       msp->unstuff = (val == 0xFF);
-       msp->tmp |= ((ui64)val) << msp->bits;  // move data to msp->tmp
-       msp->bits += 8 - t;
-     }
- 
-     //************************************************************************/
-     /** @brief Initialize frwd_struct64 struct and reads some bytes
-      *  
-      *  @tparam      X is the value fed in when the bitstream is exhausted.
-      *               See frwd_read regarding the template
-      *  @param [in]  msp is a pointer to frwd_struct64
-      *  @param [in]  data is a pointer to the start of data
-      *  @param [in]  size is the number of byte in the bitstream
-      */
-     template<int X>
-     static inline
-     void frwd_init(frwd_struct64 *msp, const ui8* data, int size)
-     {
-       msp->data = data;
-       msp->tmp = 0;
-       msp->bits = 0;
-       msp->unstuff = 0;
-       msp->size = size;
- 
-       //This code is designed for an architecture that read address should
-       // align to the read size (address multiple of 4 if read size is 4)
-       //These few lines take care of the case where data is not at a multiple
-       // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the bitstream
-       int num = 4 - (int)(intptr_t(msp->data) & 0x3);
-       for (int i = 0; i < num; ++i)
-       {
-         ui64 d;
-         //read a byte if the buffer is not exhausted, otherwise set it to X
-         d = msp->size-- > 0 ? *msp->data++ : X;
-         msp->tmp |= (d << msp->bits);      // store data in msp->tmp
-         msp->bits += 8 - msp->unstuff;     // number of bits added to msp->tmp
-         msp->unstuff = ((d & 0xFF) == 0xFF); // unstuffing for next byte
-       }
-       frwd_read<X>(msp); // read 32 bits more
-     }
- 
-     //************************************************************************/
-     /** @brief Initialize frwd_struct64 struct and reads some bytes
-      *  
-      *  @tparam      X is the value fed in when the bitstream is exhausted.
-      *               See frwd_read regarding the template
-      *  @param [in]  msp is a pointer to frwd_struct64
-      *  @param [in]  data is a pointer to the start of data
-      *  @param [in]  size is the number of byte in the bitstream
-      */
-     template<ui8 X>
-     static inline
-     void frwd_init8(frwd_struct64 *msp, const ui8* data, int size)
-     {
-       msp->data = data;
-       msp->tmp = 0;
-       msp->bits = 0;
-       msp->unstuff = 0;
-       msp->size = size;
-       frwd_read8<X>(msp); // read 8 bits
-     }
- 
-     //************************************************************************/
-     /** @brief Consume num_bits bits from the bitstream of frwd_struct64
-      *
-      *  @param [in]  msp is a pointer to frwd_struct64
-      *  @param [in]  num_bits is the number of bit to consume
-      */
-     static inline 
-     void frwd_advance(frwd_struct64 *msp, ui32 num_bits)
-     {
-       assert(num_bits <= msp->bits);
-       msp->tmp >>= num_bits;  // consume num_bits
-       msp->bits -= num_bits;
-     }
- 
-     //************************************************************************/
-     /** @brief Fetches 32 bits from the frwd_struct64 bitstream
-      *
-      *  @tparam      X is the value fed in when the bitstream is exhausted.
-      *               See frwd_read regarding the template
-      *  @param [in]  msp is a pointer to frwd_struct64
-      */
-     template<int X>
-     static inline 
-     ui32 frwd_fetch(frwd_struct64 *msp)
-     {
-       if (msp->bits < 32)
-       {
-         frwd_read<X>(msp);
-         if (msp->bits < 32) //need to test
-           frwd_read<X>(msp);
-       }
-       return (ui32)msp->tmp;
-     }
- 
-     //************************************************************************/
-     /** @brief Fetches up to 64 bits from the frwd_struct64 bitstream
-      *
-      *  @tparam      X is the value fed in when the bitstream is exhausted.
-      *               See frwd_read regarding the template
-      *  @param [in]  msp is a pointer to frwd_struct64
-      */
-     template<ui8 X>
-     static inline 
-     ui64 frwd_fetch64(frwd_struct64 *msp)
-     {
-       while (msp->bits <= 56)
-         frwd_read8<X>(msp);
-       return msp->tmp;
-     }    
- 
-     //************************************************************************/
-     /** @brief Decodes one codeblock, processing the cleanup, siginificance
-      *         propagation, and magnitude refinement pass
-      *
-      *  @param [in]   coded_data is a pointer to bitstream
-      *  @param [in]   decoded_data is a pointer to decoded codeblock data buf.
-      *  @param [in]   missing_msbs is the number of missing MSBs
-      *  @param [in]   num_passes is the number of passes: 1 if CUP only,
-      *                2 for CUP+SPP, and 3 for CUP+SPP+MRP
-      *  @param [in]   lengths1 is the length of cleanup pass
-      *  @param [in]   lengths2 is the length of refinement passes (either SPP
-      *                only or SPP+MRP)
-      *  @param [in]   width is the decoded codeblock width 
-      *  @param [in]   height is the decoded codeblock height
-      *  @param [in]   stride is the decoded codeblock buffer stride 
-      *  @param [in]   stripe_causal is true for stripe causal mode
-      */
-     bool ojph_decode_codeblock64(ui8* coded_data, ui64* decoded_data,
-                                  ui32 missing_msbs, ui32 num_passes,
-                                  ui32 lengths1, ui32 lengths2,
-                                  ui32 width, ui32 height, ui32 stride,
-                                  bool stripe_causal)
-     {
-       // static bool insufficient_precision = false;
-       // static bool modify_code = false;
-       // static bool truncate_spp_mrp = false;
- 
-       if (num_passes > 1 && lengths2 == 0)
-       {
-         OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
-                               "one coding pass, but zero length for "
-                               "2nd and potential 3rd pass.");
-         num_passes = 1;
-       }
- 
-       if (num_passes > 3)
-       {
-         OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
-                               "This codeblocks has %d passes.",
-                               num_passes);
-         return false;
-       }
- 
-       // if (missing_msbs > 30) // p < 0
-       // {
-       //   if (insufficient_precision == false) 
-       //   {
-       //     insufficient_precision = true;
-       //     OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
-       //                           "codeblock. This message will not be "
-       //                           "displayed again.");
-       //   }
-       //   return false;
-       // }       
-       // else if (missing_msbs == 30) // p == 0
-       // { // not enough precision to decode and set the bin center to 1
-       //   if (modify_code == false) {
-       //     modify_code = true;
-       //     OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
-       //                           "pass. The code can be modified to support "
-       //                           "this case. This message will not be "
-       //                           "displayed again.");
-       //   }
-       //    return false;         // 32 bits are not enough to decode this
-       //  }
-       // else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
-       // {
-       //   if (num_passes > 1) {
-       //     num_passes = 1;
-       //     if (truncate_spp_mrp == false) {
-       //       truncate_spp_mrp = true;
-       //       OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
-       //                             "nor MagRef passes; both will be skipped. "
-       //                             "This message will not be displayed "
-       //                             "again.");
-       //     }
-       //   }
-       // }
-       ui32 p = 62 - missing_msbs; // The least significant bitplane for CUP
-       // There is a way to handle the case of p == 0, but a different path
-       // is required
- 
-       if (lengths1 < 2)
-       {
-         OJPH_WARN(0x00010006, "Wrong codeblock length.");
-         return false;
-       }
- 
-       // read scup and fix the bytes there
-       int lcup, scup;
-       lcup = (int)lengths1;  // length of CUP
-       //scup is the length of MEL + VLC
-       scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
-       if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
-         return false;
- 
-       // The temporary storage scratch holds two types of data in an 
-       // interleaved fashion. The interleaving allows us to use one
-       // memory pointer.
-       // We have one entry for a decoded VLC code, and one entry for UVLC.
-       // Entries are 16 bits each, corresponding to one quad, 
-       // but since we want to use XMM registers of the SSE family 
-       // of SIMD; we allocated 16 bytes or more per quad row; that is,
-       // the width is no smaller than 16 bytes (or 8 entries), and the
-       // height is 512 quads
-       // Each VLC entry contains, in the following order, starting 
-       // from MSB
-       // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
-       // Each entry in UVLC contains u_q
-       // One extra row to handle the case of SPP propagating downwards
-       // when codeblock width is 4
-       ui16 scratch[8 * 513] = {0};       // 8 kB
- 
-       // We need an extra two entries (one inf and one u_q) beyond
-       // the last column. 
-       // If the block width is 4 (2 quads), then we use sstr of 8 
-       // (enough for 4 quads). If width is 8 (4 quads) we use 
-       // sstr is 16 (enough for 8 quads). For a width of 16 (8 
-       // quads), we use 24 (enough for 12 quads).
-       ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
- 
-       ui32 mmsbp2 = missing_msbs + 2;
- 
-       // The cleanup pass is decoded in two steps; in step one,
-       // the VLC and MEL segments are decoded, generating a record that 
-       // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
-       // This information should be sufficient for the next step.
-       // In step 2, we decode the MagSgn segment.
- 
-       // step 1 decoding VLC and MEL segments
-       {
-         // init structures
-         dec_mel_st mel;
-         mel_init(&mel, coded_data, lcup, scup);
-         rev_struct vlc;
-         rev_init8(&vlc, coded_data, lcup, scup);
- 
-         int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
-                                      // data represented as runs of 0 events
-                                      // See mel_decode description
- 
-         ui64 vlc_val;
-         ui32 c_q = 0;
-         ui16 *sp = scratch;
-         //initial quad row
-         for (ui32 x = 0; x < width; sp += 4)
-         {
-           // decode VLC
-           /////////////
- 
-           // first quad
-           vlc_val = rev_fetch64(&vlc);
- 
-           //decode VLC using the context c_q and the head of VLC bitstream
-           ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
- 
-           // if context is zero, use one MEL event
-           if (c_q == 0) //zero context
-           {
-             run -= 2; //subtract 2, since events number if multiplied by 2
- 
-             // Is the run terminated in 1? if so, use decoded VLC code, 
-             // otherwise, discard decoded data, since we will decoded again 
-             // using a different context
-             t0 = (run == -1) ? t0 : 0;
- 
-             // is run -1 or -2? this means a run has been consumed
-             if (run < 0) 
-               run = mel_get_run(&mel);  // get another run
-           }
-           //run -= (c_q == 0) ? 2 : 0;
-           //t0 = (c_q != 0 || run == -1) ? t0 : 0;
-           //if (run < 0)
-           //  run = mel_get_run(&mel);  // get another run
-           sp[0] = t0;
-           x += 2;
- 
-           // prepare context for the next quad; eqn. 1 in ITU T.814
-           c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
- 
-           //remove data from vlc stream (0 bits are removed if vlc is not used)
-           vlc_val = rev_advance64(&vlc, t0 & 0x7);
- 
-           //second quad
-           ui16 t1 = 0;
- 
-           //decode VLC using the context c_q and the head of VLC bitstream
-           t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)]; 
- 
-           // if context is zero, use one MEL event
-           if (c_q == 0 && x < width) //zero context
-           {
-             run -= 2; //subtract 2, since events number if multiplied by 2
- 
-             // if event is 0, discard decoded t1
-             t1 = (run == -1) ? t1 : 0;
- 
-             if (run < 0) // have we consumed all events in a run
-               run = mel_get_run(&mel); // if yes, then get another run
-           }
-           t1 = x < width ? t1 : 0;
-           //run -= (c_q == 0 && x < width) ? 2 : 0;
-           //t1 = (c_q != 0 || run == -1) ? t1 : 0;
-           //if (run < 0)
-           //  run = mel_get_run(&mel);  // get another run
-           sp[2] = t1;
-           x += 2;
- 
-           //prepare context for the next quad, eqn. 1 in ITU T.814
-           c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
- 
-           //remove data from vlc stream, if qinf is not used, cwdlen is 0
-           vlc_val = rev_advance64(&vlc, t1 & 0x7);
-           
-           // decode u
-           /////////////
-           // uvlc_mode is made up of u_offset bits from the quad pair
-           ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-           if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
-           {                     // the MEL run of events
-             run -= 2; //subtract 2, since events number if multiplied by 2
- 
-             uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
-                                                  // is 0x40
- 
-             if (run < 0)//if run is consumed (run is -1 or -2), get another run
-               run = mel_get_run(&mel);
-           }
-           //run -= (uvlc_mode == 0xc0) ? 2 : 0;
-           //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
-           //if (run < 0)
-           //  run = mel_get_run(&mel);  // get another run
- 
-           //decode uvlc_mode to get u for both quads
-           ui32 idx = uvlc_mode + (ui32)(vlc_val & 0x3F);
-           ui32 uvlc_entry = uvlc_tbl0[idx];
-           ui16 u_bias = uvlc_bias[idx];          
-           //remove total prefix length
-           vlc_val = rev_advance64(&vlc, uvlc_entry & 0x7); 
-           uvlc_entry >>= 3; 
-           //extract suffixes for quad 0 and 1
-           ui32 len = uvlc_entry & 0xF;             // suffix length for 2 quads
-           ui32 tmp = (ui32)(vlc_val&((1<<len)-1)); // suffix value for 2 quads
-           vlc_val = rev_advance64(&vlc, len);
-           uvlc_entry >>= 4;
-           // quad 0 length
-           len = uvlc_entry & 0x7; // quad 0 suffix length
-           uvlc_entry >>= 3;
-           ui16 u_q0 = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
-           ui16 u_q1 = (ui16)((uvlc_entry >> 3) + (tmp >> len));
- 
-           // decode u_q extensions, which is needed only when u_q > 32
-           ui16 u_ext; bool cond0, cond1;
-           cond0 = u_q0 - (u_bias & 0x3) > 32;
-           u_ext = (ui16)(cond0 ? (vlc_val & 0xF) : 0);
-           vlc_val = rev_advance64(&vlc, cond0 ? 4 : 0);
-           u_q0 = (ui16)(u_q0 + (u_ext << 2));
-           sp[1] = (ui16)(u_q0 + 1); // kappa = 1
-           cond1 = u_q1 - (u_bias >> 2) > 32;
-           u_ext = (ui16)(cond1 ? (vlc_val & 0xF) : 0);
-           vlc_val = rev_advance64(&vlc, cond1 ? 4 : 0);
-           u_q1 = (ui16)(u_q1 + (u_ext << 2));
-           sp[3] = (ui16)(u_q1 + 1); // kappa = 1
-         }
-         sp[0] = sp[1] = 0;
- 
-         //non initial quad rows
-         for (ui32 y = 2; y < height; y += 2)
-         {
-           c_q = 0;                                // context
-           ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
- 
-           for (ui32 x = 0; x < width; sp += 4)
-           {
-             // decode VLC
-             /////////////
- 
-             // sigma_q (n, ne, nf)
-             c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
-             c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
- 
-             // first quad
-             vlc_val = rev_fetch64(&vlc);
- 
-             //decode VLC using the context c_q and the head of VLC bitstream
-             ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
- 
-             // if context is zero, use one MEL event
-             if (c_q == 0) //zero context
-             {
-               run -= 2; //subtract 2, since events number is multiplied by 2
- 
-               // Is the run terminated in 1? if so, use decoded VLC code, 
-               // otherwise, discard decoded data, since we will decoded again 
-               // using a different context
-               t0 = (run == -1) ? t0 : 0;
- 
-               // is run -1 or -2? this means a run has been consumed
-               if (run < 0) 
-                 run = mel_get_run(&mel);  // get another run
-             }
-             //run -= (c_q == 0) ? 2 : 0;
-             //t0 = (c_q != 0 || run == -1) ? t0 : 0;
-             //if (run < 0)
-             //  run = mel_get_run(&mel);  // get another run
-             sp[0] = t0;
-             x += 2;
- 
-             // prepare context for the next quad; eqn. 2 in ITU T.814
-             // sigma_q (w, sw)
-             c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
-             // sigma_q (nw)
-             c_q |= sp[0 - (si32)sstr] & 0x80;
-             // sigma_q (n, ne, nf)
-             c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
-             c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
- 
-             //remove data from vlc stream (0 bits are removed if vlc is unused)
-             vlc_val = rev_advance64(&vlc, t0 & 0x7);
- 
-             //second quad
-             ui16 t1 = 0;
- 
-             //decode VLC using the context c_q and the head of VLC bitstream
-             t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)]; 
- 
-             // if context is zero, use one MEL event
-             if (c_q == 0 && x < width) //zero context
-             {
-               run -= 2; //subtract 2, since events number if multiplied by 2
- 
-               // if event is 0, discard decoded t1
-               t1 = (run == -1) ? t1 : 0;
- 
-               if (run < 0) // have we consumed all events in a run
-                 run = mel_get_run(&mel); // if yes, then get another run
-             }
-             t1 = x < width ? t1 : 0;
-             //run -= (c_q == 0 && x < width) ? 2 : 0;
-             //t1 = (c_q != 0 || run == -1) ? t1 : 0;
-             //if (run < 0)
-             //  run = mel_get_run(&mel);  // get another run
-             sp[2] = t1;
-             x += 2;
- 
-             // partial c_q, will be completed when we process the next quad
-             // sigma_q (w, sw)
-             c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
-             // sigma_q (nw)
-             c_q |= sp[2 - (si32)sstr] & 0x80;
- 
-             //remove data from vlc stream, if qinf is not used, cwdlen is 0
-             vlc_val = rev_advance64(&vlc, t1 & 0x7);
-           
-             // decode u
-             /////////////
-             // uvlc_mode is made up of u_offset bits from the quad pair
-             ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-             ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
-             //remove total prefix length
-             vlc_val = rev_advance64(&vlc, uvlc_entry & 0x7);
-             uvlc_entry >>= 3;
-             //extract suffixes for quad 0 and 1
-             ui32 len = uvlc_entry & 0xF;             //suffix length for 2 quads
-             ui32 tmp = (ui32)(vlc_val&((1<<len)-1)); //suffix value for 2 quads
-             vlc_val = rev_advance64(&vlc, len);
-             uvlc_entry >>= 4;
-             // quad 0 length
-             len = uvlc_entry & 0x7; // quad 0 suffix length
-             uvlc_entry >>= 3;
-             ui16 u_q0 = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
-             ui16 u_q1 = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
- 
-             // decode u_q extensions, which is needed only when u_q > 32
-             ui16 u_ext; bool cond0, cond1;
-             cond0 = u_q0 > 32;
-             u_ext = (ui16)(cond0 ? (vlc_val & 0xF) : 0);
-             vlc_val = rev_advance64(&vlc, cond0 ? 4 : 0);
-             u_q0 = (ui16)(u_q0 + (u_ext << 2));
-             sp[1] = u_q0;
-             cond1 = u_q1 > 32;
-             u_ext = (ui16)(cond1 ? (vlc_val & 0xF) : 0);
-             vlc_val = rev_advance64(&vlc, cond1 ? 4 : 0);
-             u_q1 = (ui16)(u_q1 + (u_ext << 2));
-             sp[3] = u_q1;
-           }
-           sp[0] = sp[1] = 0;
-         }
-       }
- 
-       // step2 we decode magsgn
-       {
-         // We allocate a scratch row for storing v_n values.
-         // We have 512 quads horizontally.
-         // We need an extra entry to handle the case of vp[1]
-         // when vp is at the last column.
-         // Here, we allocate 4 instead of 1 to make the buffer size
-         // a multipled of 16 bytes.
-         const int v_n_size = 512 + 4;
-         ui64 v_n_scratch[v_n_size] = {0};  // 4+ kB
- 
-         frwd_struct64 magsgn;
-         frwd_init8<0xFF>(&magsgn, coded_data, lcup - scup);
- 
-         const ui16 *sp = scratch;
-         ui64 *vp = v_n_scratch;
-         ui64 *dp = decoded_data;
- 
-         ui64 prev_v_n = 0;
-         for (ui32 x = 0; x < width; sp += 2, ++vp)
-         {
-           ui32 inf = sp[0];
-           ui32 U_q = sp[1];
-           if (U_q > mmsbp2)
-             return false;
- 
-           ui64 v_n;
-           ui64 val = 0;
-           ui32 bit = 0;
-           if (inf & (1 << (4 + bit)))
-           {
-             //get 32 bits of magsgn data
-             ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
-             ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-             frwd_advance(&magsgn, m_n);                 //consume m_n
- 
-             val = ms_val << 63;                           // get sign bit
-             v_n = ms_val & ((1ULL << m_n) - 1);           // keep only m_n bits
-             v_n |= (ui64)((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-             v_n |= 1;                                     // add center of bin    
-             //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-             //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-             val |= (v_n + 2) << (p - 1);
-           }
-           dp[0] = val;
- 
-           v_n = 0;
-           val = 0;
-           bit = 1;
-           if (inf & (1 << (4 + bit)))
-           {
-             //get 32 bits of magsgn data
-             ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
-             ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-             frwd_advance(&magsgn, m_n);                 //consume m_n
- 
-             val = ms_val << 63;                           // get sign bit
-             v_n = ms_val & ((1ULL << m_n) - 1);           // keep only m_n bits
-             v_n |= (ui64)((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-             v_n |= 1;                                     // add center of bin    
-             //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-             //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-             val |= (v_n + 2) << (p - 1);
-           }
-           dp[stride] = val;
-           vp[0] = prev_v_n | v_n;
-           prev_v_n = 0;
-           ++dp;
-           if (++x >= width)
-           { ++vp; break; }
- 
-           val = 0;
-           bit = 2;
-           if (inf & (1 << (4 + bit)))
-           {
-             //get 32 bits of magsgn data
-             ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
-             ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-             frwd_advance(&magsgn, m_n);                 //consume m_n
- 
-             val = ms_val << 63;                           // get sign bit
-             v_n = ms_val & ((1ULL << m_n) - 1);           // keep only m_n bits
-             v_n |= (ui64)((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-             v_n |= 1;                                     // add center of bin    
-             //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-             //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-             val |= (v_n + 2) << (p - 1);
-           }
-           dp[0] = val;
- 
-           v_n = 0;
-           val = 0;
-           bit = 3;
-           if (inf & (1 << (4 + bit)))
-           {
-             //get 32 bits of magsgn data
-             ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
-             ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-             frwd_advance(&magsgn, m_n);                 //consume m_n
- 
-             val = ms_val << 63;                           // get sign bit
-             v_n = ms_val & ((1ULL << m_n) - 1);           // keep only m_n bits
-             v_n |= (ui64)((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
-             v_n |= 1;                                     // add center of bin    
-             //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-             //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-             val |= (v_n + 2) << (p - 1);
-           }
-           dp[stride] = val;
-           prev_v_n = v_n;
-           ++dp;
-           ++x;
-         }
-         vp[0] = prev_v_n;
- 
-         for (ui32 y = 2; y < height; y += 2)
-         {
-           const ui16 *sp = scratch + (y >> 1) * sstr;
-           ui64 *vp = v_n_scratch;
-           ui64 *dp = decoded_data + y * stride;
- 
-           prev_v_n = 0;
-           for (ui32 x = 0; x < width; sp += 2, ++vp)
-           {
-             ui32 inf = sp[0];
-             ui32 u_q = sp[1];
- 
-             ui32 gamma = inf & 0xF0; gamma &= gamma - 0x10; //is gamma_q 1?
-             ui32 emax = 63 - count_leading_zeros(2 | vp[0] | vp[1]); // emax-1
-             ui32 kappa = gamma ? emax : 1;
- 
-             ui32 U_q = u_q + kappa;
-             if (U_q > mmsbp2)
-               return false;
- 
-             ui64 v_n;
-             ui64 val = 0;
-             ui32 bit = 0;
-             if (inf & (1 << (4 + bit)))
-             {
-               //get 32 bits of magsgn data
-               ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
-               ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-               frwd_advance(&magsgn, m_n);                 //consume m_n
- 
-               val = ms_val << 63;                         // get sign bit
-               v_n = ms_val & ((1ULL << m_n) - 1);         // keep only m_n bits
-               v_n |= (ui64)((inf >> (8+bit)) & 1) << m_n; // add EMB e_1 as MSB
-               v_n |= 1;                                   // add center of bin    
-               //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-               //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-               val |= (v_n + 2) << (p - 1);
-             }
-             dp[0] = val;
- 
-             v_n = 0;
-             val = 0;
-             bit = 1;
-             if (inf & (1 << (4 + bit)))
-             {
-               //get 32 bits of magsgn data
-               ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
-               ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-               frwd_advance(&magsgn, m_n);                 //consume m_n
- 
-               val = ms_val << 63;                         // get sign bit
-               v_n = ms_val & ((1ULL << m_n) - 1);         // keep only m_n bits
-               v_n |= (ui64)((inf >> (8+bit)) & 1) << m_n; // add EMB e_1 as MSB
-               v_n |= 1;                                   // add center of bin    
-               //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-               //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-               val |= (v_n + 2) << (p - 1);
-             }
-             dp[stride] = val;
-             vp[0] = prev_v_n | v_n;
-             prev_v_n = 0;
-             ++dp;
-             if (++x >= width)
-             { ++vp; break; }
- 
-             val = 0;
-             bit = 2;
-             if (inf & (1 << (4 + bit)))
-             {
-               //get 32 bits of magsgn data
-               ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
-               ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-               frwd_advance(&magsgn, m_n);                 //consume m_n
- 
-               val = ms_val << 63;                         // get sign bit
-               v_n = ms_val & ((1ULL << m_n) - 1);         // keep only m_n bits
-               v_n |= (ui64)((inf >> (8+bit)) & 1) << m_n; // add EMB e_1 as MSB
-               v_n |= 1;                                   // add center of bin    
-               //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-               //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-               val |= (v_n + 2) << (p - 1);
-             }
-             dp[0] = val;
- 
-             v_n = 0;
-             val = 0;
-             bit = 3;
-             if (inf & (1 << (4 + bit)))
-             {
-               //get 32 bits of magsgn data
-               ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
-               ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
-               frwd_advance(&magsgn, m_n);                 //consume m_n
- 
-               val = ms_val << 63;                         // get sign bit
-               v_n = ms_val & ((1ULL << m_n) - 1);         // keep only m_n bits
-               v_n |= (ui64)((inf >> (8+bit)) & 1) << m_n; // add EMB e_1 as MSB
-               v_n |= 1;                                   // add center of bin    
-               //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
-               //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
-               val |= (v_n + 2) << (p - 1);
-             }
-             dp[stride] = val;
-             prev_v_n = v_n;
-             ++dp;
-             ++x;
-           }
-           vp[0] = prev_v_n;
-         }
-       }
- 
-       if (num_passes > 1)
-       {
-         // We use scratch again, we can divide it into multiple regions
-         // sigma holds all the significant samples, and it cannot
-         // be modified after it is set.  it will be used during the
-         // Magnitude Refinement Pass
-         ui16* const sigma = scratch;
- 
-         ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
-                                          // ui16 contains 4 columns
-         mstr = ((mstr + 2u) + 7u) & ~7u; // multiples of 8
- 
-         // We re-arrange quad significance, where each 4 consecutive
-         // bits represent one quad, into column significance, where,
-         // each 4 consequtive bits represent one column of 4 rows
-         {
-           ui32 y;
-           for (y = 0; y < height; y += 4)
-           {
-             ui16* sp = scratch + (y >> 1) * sstr;
-             ui16* dp = sigma + (y >> 2) * mstr;
-             for (ui32 x = 0; x < width; x += 4, sp += 4, ++dp) {
-               ui32 t0 = 0, t1 = 0;
-               t0  = ((sp[0     ] & 0x30u) >> 4)  | ((sp[0     ] & 0xC0u) >> 2);
-               t0 |= ((sp[2     ] & 0x30u) << 4)  | ((sp[2     ] & 0xC0u) << 6);
-               t1  = ((sp[0+sstr] & 0x30u) >> 2)  | ((sp[0+sstr] & 0xC0u)     );
-               t1 |= ((sp[2+sstr] & 0x30u) << 6)  | ((sp[2+sstr] & 0xC0u) << 8);
-               dp[0] = (ui16)(t0 | t1);
-             }
-             dp[0] = 0; // set an extra entry on the right with 0
-           }
-           {
-             // reset one row after the codeblock
-             ui16* dp = sigma + (y >> 2) * mstr;
-             for (ui32 x = 0; x < width; x += 4, ++dp)
-               dp[0] = 0;
-             dp[0] = 0; // set an extra entry on the right with 0
-           }
-         }
- 
-         // We perform Significance Propagation Pass here
-         {
-           // This stores significance information of the previous
-           // 4 rows.  Significance information in this array includes
-           // all signicant samples in bitplane p - 1; that is,
-           // significant samples for bitplane p (discovered during the
-           // cleanup pass and stored in sigma) and samples that have recently
-           // became significant (during the SPP) in bitplane p-1.
-           // We store enough for the widest row, containing 1024 columns,
-           // which is equivalent to 256 of ui16, since each stores 4 columns.
-           // We add an extra 8 entries, just in case we need more
-           ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
- 
-           frwd_struct64 sigprop;
-           frwd_init<0>(&sigprop, coded_data + lengths1, (int)lengths2);
- 
-           for (ui32 y = 0; y < height; y += 4)
-           {
-             ui32 pattern = 0xFFFFu; // a pattern needed samples
-             if (height - y < 4) {
-               pattern = 0x7777u;
-               if (height - y < 3) {
-                 pattern = 0x3333u;
-                 if (height - y < 2)
-                   pattern = 0x1111u;
-               }
-             }
- 
-             // prev holds sign. info. for the previous quad, together
-             // with the rows on top of it and below it.
-             ui32 prev = 0;
-             ui16 *prev_sig = prev_row_sig;
-             ui16 *cur_sig = sigma + (y >> 2) * mstr;
-             ui64 *dpp = decoded_data + y * stride;
-             for (ui32 x = 0; x < width; x += 4, ++cur_sig, ++prev_sig)
-             {
-               // only rows and columns inside the stripe are included
-               si32 s = (si32)x + 4 - (si32)width;
-               s = ojph_max(s, 0);
-               pattern = pattern >> (s * 4);
- 
-               // We first find locations that need to be tested (potential
-               // SPP members); these location will end up in mbr
-               // In each iteration, we produce 16 bits because cwd can have
-               // up to 16 bits of significance information, followed by the
-               // corresponding 16 bits of sign information; therefore, it is
-               // sufficient to fetch 32 bit data per loop.
- 
-               // Althougth we are interested in 16 bits only, we load 32 bits.
-               // For the 16 bits we are producing, we need the next 4 bits --
-               // We need data for at least 5 columns out of 8.
-               // Therefore loading 32 bits is easier than loading 16 bits
-               // twice.
-               ui32 ps = *(ui32*)prev_sig;
-               ui32 ns = *(ui32*)(cur_sig + mstr);
-               ui32 u = (ps & 0x88888888) >> 3; // the row on top
-               if (!stripe_causal)
-                 u |= (ns & 0x11111111) << 3;   // the row below
- 
-               ui32 cs = *(ui32*)cur_sig;
-               // vertical integration
-               ui32 mbr =  cs;                // this sig. info.
-               mbr |= (cs & 0x77777777) << 1; //above neighbors
-               mbr |= (cs & 0xEEEEEEEE) >> 1; //below neighbors
-               mbr |= u;
-               // horizontal integration
-               ui32 t = mbr;
-               mbr |= t << 4;      // neighbors on the left
-               mbr |= t >> 4;      // neighbors on the right
-               mbr |= prev >> 12;  // significance of previous group
- 
-               // remove outside samples, and already significant samples
-               mbr &= pattern;
-               mbr &= ~cs;
- 
-               // find samples that become significant during the SPP
-               ui32 new_sig = mbr;
-               if (new_sig)
-               {
-                 ui64 cwd = frwd_fetch<0>(&sigprop);
- 
-                 ui32 cnt = 0;
-                 ui32 col_mask = 0xFu;
-                 ui32 inv_sig = ~cs & pattern;
-                 for (int i = 0; i < 16; i += 4, col_mask <<= 4)
-                 {
-                   if ((col_mask & new_sig) == 0)
-                     continue;
- 
-                   //scan one column
-                   ui32 sample_mask = 0x1111u & col_mask;
-                   if (new_sig & sample_mask)
-                   {
-                     new_sig &= ~sample_mask;
-                     if (cwd & 1)
-                     {
-                       ui32 t = 0x33u << i;
-                       new_sig |= t & inv_sig;
-                     }
-                     cwd >>= 1; ++cnt;
-                   }
- 
-                   sample_mask <<= 1;
-                   if (new_sig & sample_mask)
-                   {
-                     new_sig &= ~sample_mask;
-                     if (cwd & 1)
-                     {
-                       ui32 t = 0x76u << i;
-                       new_sig |= t & inv_sig;
-                     }
-                     cwd >>= 1; ++cnt;
-                   }
- 
-                   sample_mask <<= 1;
-                   if (new_sig & sample_mask)
-                   {
-                     new_sig &= ~sample_mask;
-                     if (cwd & 1)
-                     {
-                       ui32 t = 0xECu << i;
-                       new_sig |= t & inv_sig;
-                     }
-                     cwd >>= 1; ++cnt;
-                   }
- 
-                   sample_mask <<= 1;
-                   if (new_sig & sample_mask)
-                   {
-                     new_sig &= ~sample_mask;
-                     if (cwd & 1)
-                     {
-                       ui32 t = 0xC8u << i;
-                       new_sig |= t & inv_sig;
-                     }
-                     cwd >>= 1; ++cnt;
-                   }
-                 }
- 
-                 if (new_sig)
-                 {
-                   // new_sig has newly-discovered sig. samples during SPP
-                   // find the signs and update decoded_data
-                   ui64 *dp = dpp + x;
-                   ui64 val = 3u << (p - 2);
-                   col_mask = 0xFu;
-                   for (int i = 0; i < 4; ++i, ++dp, col_mask <<= 4)
-                   {
-                     if ((col_mask & new_sig) == 0)
-                       continue;
- 
-                     //scan 4 signs
-                     ui32 sample_mask = 0x1111u & col_mask;
-                     if (new_sig & sample_mask)
-                     {
-                       assert(dp[0] == 0);
-                       dp[0] = (cwd << 63) | val;
-                       cwd >>= 1; ++cnt;
-                     }
- 
-                     sample_mask += sample_mask;
-                     if (new_sig & sample_mask)
-                     {
-                       assert(dp[stride] == 0);
-                       dp[stride] = (cwd << 63) | val;
-                       cwd >>= 1; ++cnt;
-                     }
- 
-                     sample_mask += sample_mask;
-                     if (new_sig & sample_mask)
-                     {
-                       assert(dp[2 * stride] == 0);
-                       dp[2 * stride] = (cwd << 63) | val;
-                       cwd >>= 1; ++cnt;
-                     }
- 
-                     sample_mask += sample_mask;
-                     if (new_sig & sample_mask)
-                     {
-                       assert(dp[3 * stride] == 0);
-                       dp[3 * stride] = (cwd << 63) | val;
-                       cwd >>= 1; ++cnt;
-                     }
-                   }
-                 }
-                 frwd_advance(&sigprop, cnt);
-               }
- 
-               new_sig |= cs;
-               *prev_sig = (ui16)(new_sig);
- 
-               // vertical integration for the new sig. info.
-               t = new_sig;
-               new_sig |= (t & 0x7777) << 1; //above neighbors
-               new_sig |= (t & 0xEEEE) >> 1; //below neighbors
-               // add sig. info. from the row on top and below
-               prev = new_sig | u;
-               // we need only the bits in 0xF000
-               prev &= 0xF000;
-             }
-           }
-         }
- 
-         // We perform Magnitude Refinement Pass here
-         if (num_passes > 2)
-         {
-           rev_struct magref;
-           rev_init_mrp(&magref, coded_data, (int)lengths1, (int)lengths2);
- 
-           for (ui32 y = 0; y < height; y += 4)
-           {
-             ui32 *cur_sig = (ui32*)(sigma + (y >> 2) * mstr);
-             ui64 *dpp = decoded_data + y * stride;
-             ui64 half = 1ULL << (p - 2);
-             for (ui32 i = 0; i < width; i += 8)
-             {
-               //Process one entry from sigma array at a time
-               // Each nibble (4 bits) in the sigma array represents 4 rows,
-               // and the 32 bits contain 8 columns
-               ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
-               ui32 sig = *cur_sig++; // 32 bit that will be processed now
-               ui32 col_mask = 0xFu;  // a mask for a column in sig
-               if (sig) // if any of the 32 bits are set
-               {
-                 for (int j = 0; j < 8; ++j) //one column at a time
-                 {
-                   if (sig & col_mask) // lowest nibble
-                   {
-                     ui64 *dp = dpp + i + j; // next column in decoded samples
-                     ui32 sample_mask = 0x11111111u & col_mask; //LSB
- 
-                     for (int k = 0; k < 4; ++k) {
-                       if (sig & sample_mask) //if LSB is set
-                       {
-                         assert(dp[0] != 0); // decoded value cannot be zero
-                         assert((dp[0] & half) == 0); // no half
-                         ui64 sym = cwd & 1;          // get it value
-                         sym = (1 - sym) << (p - 1); // previous center of bin
-                         sym |= half;            // put half the center of bin
-                         dp[0] ^= sym;    // remove old bin center and put new
-                         cwd >>= 1;       // consume word
-                       }
-                       sample_mask += sample_mask; //next row
-                       dp += stride; // next samples row
-                     }
-                   }
-                   col_mask <<= 4; //next column
-                 }
-               }
-               // consume data according to the number of bits set
-               rev_advance_mrp(&magref, population_count(sig));
-             }
-           }
-         }
-       }
-       return true;
-     }
-   }
- }
+#include <string>
+#include <iostream>
+
+#include <cassert>
+#include <cstring>
+#include "ojph_block_common.h"
+#include "ojph_block_decoder.h"
+#include "ojph_arch.h"
+#include "ojph_message.h"
+
+namespace ojph {
+  namespace local {
+
+    //************************************************************************/
+    /** @brief MEL state structure for reading and decoding the MEL bitstream
+     *
+     *  A number of events is decoded from the MEL bitstream ahead of time
+     *  and stored in run/num_runs.
+     *  Each run represents the number of zero events before a one event.
+     */ 
+    struct dec_mel_st {
+      dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
+        k(0), num_runs(0), runs(0)
+      {}
+      // data decoding machinery
+      ui8* data;    //!<the address of data (or bitstream)
+      ui64 tmp;     //!<temporary buffer for read data
+      int bits;     //!<number of bits stored in tmp
+      int size;     //!<number of bytes in MEL code
+      bool unstuff; //!<true if the next bit needs to be unstuffed
+      int k;        //!<state of MEL decoder
+
+      // queue of decoded runs
+      int num_runs; //!<number of decoded runs left in runs (maximum 8)
+      ui64 runs;    //!<runs of decoded MEL codewords (7 bits/run)
+    };
+
+    //************************************************************************/
+    /** @brief Reads and unstuffs the MEL bitstream
+     * 
+     *  This design needs more bytes in the codeblock buffer than the length
+     *  of the cleanup pass by up to 2 bytes.
+     *
+     *  Unstuffing removes the MSB of the byte following a byte whose
+     *  value is 0xFF; this prevents sequences larger than 0xFF7F in value
+     *  from appearing the bitstream.
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     */
+    static inline
+    void mel_read(dec_mel_st *melp)
+    {
+      if (melp->bits > 32)  //there are enough bits in the tmp variable
+        return;             // return without reading new data
+
+      ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
+      if (melp->size > 4) {        // if there is data in the MEL segment
+        val = load_le_ui32(melp->data); // read 32 bits from MEL data
+        melp->data += 4;           // advance pointer
+        melp->size -= 4;           // reduce counter
+      }
+      else if (melp->size > 0)
+      { // 4 or less
+        int i = 0;
+        while (melp->size > 1) {   
+          ui32 v = *melp->data++;    // read one byte at a time
+          ui32 m = ~(0xFFu << i);    // mask of location
+          val = (val & m) | (v << i);// put one byte in its correct location
+          --melp->size;
+          i += 8;
+        }
+        // size equal to 1
+        ui32 v = *melp->data++;    // the one before the last is different 
+        v |= 0xF;                  // MEL and VLC segments can overlap
+        ui32 m = ~(0xFFu << i);
+        val = (val & m) | (v << i);
+        --melp->size;
+      }
+      
+      // next we unstuff them before adding them to the buffer
+      int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
+                                     // the previously read byte requires 
+                                     // unstuffing
+
+      // data is unstuffed and accumulated in t
+      // bits has the number of bits in t
+      ui32 t = val & 0xFF; 
+      bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
+      bits -= unstuff; // there is one less bit in t if unstuffing is needed
+      t = t << (8 - unstuff); // move up to make room for the next byte
+
+      //this is a repeat of the above
+      t |= (val>>8) & 0xFF;
+      unstuff = (((val >> 8) & 0xFF) == 0xFF);
+      bits -= unstuff;
+      t = t << (8 - unstuff);
+
+      t |= (val>>16) & 0xFF;
+      unstuff = (((val >> 16) & 0xFF) == 0xFF);
+      bits -= unstuff;
+      t = t << (8 - unstuff);
+
+      t |= (val>>24) & 0xFF;
+      melp->unstuff = (((val >> 24) & 0xFF) == 0xFF);
+
+      // move t to tmp, and push the result all the way up, so we read from
+      // the MSB
+      melp->tmp |= ((ui64)t) << (64 - bits - melp->bits);
+      melp->bits += bits; //increment the number of bits in tmp
+    }
+
+    //************************************************************************/
+    /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
+     * 
+     *  Runs are stored in "runs" and the number of runs in "num_runs".
+     *  Each run represents a number of zero events that may or may not 
+     *  terminate in a 1 event.
+     *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
+     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating 
+     *  with 1, contain the number of consecutive 0 zero events * 2; for the 
+     *  case terminating with 0, they store (number of consecutive 0 zero 
+     *  events - 1) * 2.
+     *  A total of 6 bits (made up of 1 + 5) should have been enough.
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     */
+    static inline
+    void mel_decode(dec_mel_st *melp)
+    {
+      static const int mel_exp[13] = { //MEL exponents
+        0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5
+      };
+
+      if (melp->bits < 6) // if there are less than 6 bits in tmp
+        mel_read(melp);   // then read from the MEL bitstream
+                          // 6 bits is the largest decodable MEL cwd
+
+      //repeat so long that there is enough decodable bits in tmp,
+      // and the runs store is not full (num_runs < 8)
+      while (melp->bits >= 6 && melp->num_runs < 8)
+      {
+        int eval = mel_exp[melp->k]; // number of bits associated with state
+        int run = 0;
+        if (melp->tmp & (1ull<<63)) //The next bit to decode (stored in MSB)
+        { //one is found
+          run = 1 << eval;  
+          run--; // consecutive runs of 0 events - 1
+          melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12;//increment, max is 12
+          melp->tmp <<= 1; // consume one bit from tmp
+          melp->bits -= 1;
+          run = run << 1; // a stretch of zeros not terminating in one
+        }
+        else
+        { //0 is found
+          run = (int)(melp->tmp >> (63 - eval)) & ((1 << eval) - 1);
+          melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; //decrement, min is 0
+          melp->tmp <<= eval + 1; //consume eval + 1 bits (max is 6)
+          melp->bits -= eval + 1;
+          run = (run << 1) + 1; // a stretch of zeros terminating with one
+        }
+        eval = melp->num_runs * 7;           // 7 bits per run
+        melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
+        melp->runs |= ((ui64)run) << eval;   // store the value in runs
+        melp->num_runs++;                    // increment count  
+      }
+    }
+
+    //************************************************************************/
+    /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
+     *         some bytes in order to get the read address to a multiple
+     *         of 4 
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     *  @param [in]  bbuf is a pointer to byte buffer
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  scup is the length of MEL+VLC segments
+     */
+    static inline
+    void mel_init(dec_mel_st *melp, ui8* bbuf, int lcup, int scup)
+    {
+      melp->data = bbuf + lcup - scup; // move the pointer to the start of MEL
+      melp->bits = 0;                  // 0 bits in tmp
+      melp->tmp = 0;                   //
+      melp->unstuff = false;           // no unstuffing
+      melp->size = scup - 1;           // size is the length of MEL+VLC-1
+      melp->k = 0;                     // 0 for state 
+      melp->num_runs = 0;              // num_runs is 0
+      melp->runs = 0;                  //
+
+      //This code is borrowed; original is for a different architecture
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
+      int num = 4 - (int)(intptr_t(melp->data) & 0x3);
+      for (int i = 0; i < num; ++i) { // this code is similar to mel_read
+        assert(melp->unstuff == false || melp->data[0] <= 0x8F);
+        ui64 d = (melp->size > 0) ? *melp->data : 0xFF;//if buffer is consumed
+                                                       //set data to 0xFF
+        if (melp->size == 1) d |= 0xF; //if this is MEL+VLC-1, set LSBs to 0xF
+                                       // see the standard
+        melp->data += melp->size-- > 0; //increment if the end is not reached
+        int d_bits = 8 - melp->unstuff; //if unstuffing is needed, reduce by 1
+        melp->tmp = (melp->tmp << d_bits) | d; //store bits in tmp
+        melp->bits += d_bits;  //increment tmp by number of bits
+        melp->unstuff = ((d & 0xFF) == 0xFF); //true of next byte needs 
+                                              //unstuffing
+      }
+      melp->tmp <<= (64 - melp->bits); //push all the way up so the first bit
+                                       // is the MSB
+    }
+
+    //************************************************************************/
+    /** @brief Retrieves one run from dec_mel_st; if there are no runs stored
+     *         MEL segment is decoded
+     *
+     * @param [in]  melp is a pointer to dec_mel_st structure
+     */    
+    static inline
+    int mel_get_run(dec_mel_st *melp)
+    {
+      if (melp->num_runs == 0)  //if no runs, decode more bit from MEL segment
+        mel_decode(melp);
+
+      int t = melp->runs & 0x7F; //retrieve one run
+      melp->runs >>= 7;  // remove the retrieved run
+      melp->num_runs--;
+      return t; // return run
+    }
+
+    //************************************************************************/
+    /** @brief A structure for reading and unstuffing a segment that grows
+     *         backward, such as VLC and MRP
+     */ 
+    struct rev_struct {
+      rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
+      {}
+      //storage
+      ui8* data;     //!<pointer to where to read data
+      ui64 tmp;	     //!<temporary buffer of read data
+      ui32 bits;     //!<number of bits stored in tmp
+      int size;      //!<number of bytes left
+      bool unstuff;  //!<true if the last byte is more than 0x8F
+                     //!<then the current byte is unstuffed if it is 0x7F
+    };
+
+    //************************************************************************/
+    /** @brief Read and unstuff data from a backwardly-growing segment
+     *
+     *  This reader reads 8 bits from the VLC segment. It fills zeros when 
+     *  the buffer is exhausted; we basically do not care about these zeros 
+     *  because we should not need them -- any extra data should not be used 
+     *  in the actual decoding. If these bytes are needed, then there is a 
+     *  problem in the bitstream, but we do not flag this error.
+     *
+     *  Unstuffing is needed to prevent sequences larger than 0xFF8F from 
+     *  appearing in the bits stream; since we are reading backward, we keep
+     *  watch when a value larger than 0x8F appears in the bitstream. 
+     *  If the byte following this is 0x7F, we unstuff this byte (ignore the 
+     *  MSB of that byte, which should be 0).
+     *
+     *  @param [in]  vlcp is a pointer to rev_struct structure
+     */
+    static inline 
+    void rev_read8(rev_struct *vlcp)
+    {
+      // process 1 bytes
+      ui8 val = 0; // insert 0s at the end -- the standard says that the
+                   // bitstream must contain all needed bits. Therefore
+                   // if the whole bitstream is consumed and bits are still
+                   // needed, then this is an error condition, but we are
+                   // lenient -- it is also possible that we are decoding
+                   // more bits than what we are actually need.
+      if (vlcp->size > 0)  // if there are more than 3 bytes left in VLC
+      {
+        val = *vlcp->data; // then read 8 bits
+        --vlcp->data;      // increment data pointer
+        --vlcp->size;      // decrement number of bytes in the buffer
+      }
+
+      // accumulate in tmp, and increment bits, check if unstuffing is needed
+      ui8 t = (vlcp->unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0;
+      val = (ui8)(val & (0xFFU >> t)); // protect against erroneous 1 in MSB
+      vlcp->tmp |= (ui64)val << vlcp->bits;
+      vlcp->bits += 8 - t;
+      vlcp->unstuff = val > 0x8F;
+    }
+
+    //************************************************************************/
+    /** @brief Initiates the rev_struct structure and reads the first byte
+     *
+     *  This subroutine initializes the VLC decoder.  It discards the first 
+     *  12 bits (they have the sum of the lengths of VLC and MEL segments), 
+     *  and depending on unstuffing, stores 3 or 4 bits in the unstuffed
+     *  decoded buffer.
+     *
+     *  @param [in]  vlcp is a pointer to rev_struct structure
+     *  @param [in]  data is a pointer to byte at the start of the cleanup pass
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  scup is the length of MEL+VLC segments
+     */
+    static inline 
+    void rev_init8(rev_struct *vlcp, ui8* data, int lcup, int scup)
+    {
+      //first byte has only the upper 4 bits
+      vlcp->data = data + lcup - 2;
+
+      //size can not be larger than this, in fact it should be smaller
+      vlcp->size = scup - 2;
+
+      ui8 val = *vlcp->data--; // read one byte (this is a half byte)
+
+      // the first byte is treated different to other bytes, because only
+      // the MSB nibble is part of the VLC code.
+      val = (ui8)(val >> 4);
+      ui8 t = ((val & 0x7) == 0x7) ? 1 : 0; // unstuffing is needed
+      val = (ui8)(val & (0xFU >> t)); // protect against erroneous 1 in MSB
+      vlcp->tmp = val;
+      vlcp->bits = 4 - t;
+      vlcp->unstuff = val > 0x8; //this is useful for the next byte
+    }
+
+    //************************************************************************/
+    /** @brief Fills the temporary variable (vlcp->tmp) by up to 64 bits
+     *
+     *  By the end of this call, vlcp->tmp must have no less than 56 bits
+     *
+     *  @param [in]  vlcp is a pointer to rev_struct structure
+     */
+    static inline 
+    ui64 rev_fetch64(rev_struct *vlcp)
+    {
+      while (vlcp->bits <= 56)
+        rev_read8(vlcp); // read 8 bits, but unstuffing might reduce this
+      return vlcp->tmp;  // return unstuff decoded bits
+    }    
+
+    //************************************************************************/
+    /** @brief Consumes num_bits from a rev_struct structure
+     *
+     *  @param [in]  vlcp is a pointer to rev_struct structure
+     *  @param [in]  num_bits is the number of bits to be removed
+     */
+    static inline 
+    ui64 rev_advance64(rev_struct *vlcp, ui32 num_bits)
+    {
+      assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
+      vlcp->tmp >>= num_bits;         // remove bits
+      vlcp->bits -= num_bits;         // decrement the number of bits
+      return vlcp->tmp;
+    }    
+
+    //************************************************************************/
+    /** @brief Reads and unstuffs from rev_struct
+     *
+     *  This is different than rev_read in that this fills in zeros when the
+     *  the available data is consumed.  The other does not care about the
+     *  values when all data is consumed.
+     *
+     *  See rev_read for more information about unstuffing
+     *
+     *  @param [in]  mrp is a pointer to rev_struct structure
+     */
+    static inline 
+    void rev_read_mrp(rev_struct *mrp)
+    {
+      //process 4 bytes at a time
+      if (mrp->bits > 32)
+        return;
+      ui32 val = 0;
+      if (mrp->size > 3) // If there are 3 byte or more
+      { // (mrp->data - 3) move pointer back to read 32 bits at once
+        val = load_le_ui32(mrp->data - 3); // read 32 bits
+        mrp->data -= 4;                // move back pointer
+        mrp->size -= 4;                // reduce count
+      }
+      else if (mrp->size > 0)
+      {
+        int i = 24;
+        while (mrp->size > 0) {   
+          ui32 v = *mrp->data--; // read one byte at a time
+          val |= (v << i);       // put byte in its correct location
+          --mrp->size;
+          i -= 8;
+        }
+      }
+
+      //accumulate in tmp, and keep count in bits
+      ui32 bits, tmp = val >> 24;
+
+      //test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
+      bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
+      bool unstuff = (val >> 24) > 0x8F;
+
+      //process the next byte
+      tmp |= ((val >> 16) & 0xFF) << bits;
+      bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = ((val >> 16) & 0xFF) > 0x8F;
+
+      tmp |= ((val >> 8) & 0xFF) << bits;
+      bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = ((val >> 8) & 0xFF) > 0x8F;
+
+      tmp |= (val & 0xFF) << bits;
+      bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
+      unstuff = (val & 0xFF) > 0x8F;
+
+      mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
+      mrp->bits += bits;
+      mrp->unstuff = unstuff;             // next byte
+    }
+
+    //************************************************************************/
+    /** @brief Initialized rev_struct structure for MRP segment, and reads
+     *         a number of bytes such that the next 32 bits read are from
+     *         an address that is a multiple of 4. Note this is designed for
+     *         an architecture that read size must be compatible with the
+     *         alignment of the read address
+     *
+     *  There is another similar subroutine rev_init.  This subroutine does 
+     *  NOT skip the first 12 bits, and starts with unstuff set to true.
+     *
+     *  @param [in]  mrp is a pointer to rev_struct structure
+     *  @param [in]  data is a pointer to byte at the start of the cleanup pass
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  len2 is the length of SPP+MRP segments
+     */
+    static inline 
+    void rev_init_mrp(rev_struct *mrp, ui8* data, int lcup, int len2)
+    {
+      mrp->data = data + lcup + len2 - 1;
+      mrp->size = len2;
+      mrp->unstuff = true;
+      mrp->bits = 0;
+      mrp->tmp = 0;
+
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
+      int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
+      for (int i = 0; i < num; ++i) {
+        ui64 d;
+        //read a byte, 0 if no more data
+        d = (mrp->size-- > 0) ? *mrp->data-- : 0; 
+        //check if unstuffing is needed
+        ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
+        mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
+        mrp->bits += d_bits;
+        mrp->unstuff = d > 0x8F; // for next byte
+      }
+      rev_read_mrp(mrp);
+    }
+
+    //************************************************************************/
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
+     *
+     *  By the end of this call, mrp->tmp must have no less than 33 bits
+     *
+     *  @param [in]  mrp is a pointer to rev_struct structure
+     */
+    static inline 
+    ui32 rev_fetch_mrp(rev_struct *mrp)
+    {
+      if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
+      {
+        rev_read_mrp(mrp);    // read 30-32 bits from mrp
+        if (mrp->bits < 32)   // if there is a space of 32 bits
+          rev_read_mrp(mrp);  // read more
+      }
+      return (ui32)mrp->tmp;  // return the head of mrp->tmp
+    }
+
+    //************************************************************************/
+    /** @brief Consumes num_bits from a rev_struct structure
+     *
+     *  @param [in]  mrp is a pointer to rev_struct structure
+     *  @param [in]  num_bits is the number of bits to be removed
+     */
+    static inline 
+    ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
+    {
+      assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
+      mrp->tmp >>= num_bits;  // discard the lowest num_bits bits
+      mrp->bits -= num_bits;
+      return (ui32)mrp->tmp;  // return data after consumption
+    }
+
+    //************************************************************************/
+    /** @brief State structure for reading and unstuffing of forward-growing 
+     *         bitstreams; these are: MagSgn and SPP bitstreams
+     */
+    struct frwd_struct64 {
+      const ui8* data;  //!<pointer to bitstream
+      ui64 tmp;         //!<temporary buffer of read data
+      ui32 bits;        //!<number of bits stored in tmp
+      ui32 unstuff;     //!<1 if a bit needs to be unstuffed from next byte
+      int size;         //!<size of data
+    };
+
+    //************************************************************************/
+    /** @brief Read and unstuffs 32 bits from forward-growing bitstream
+     *  
+     *  A template is used to accommodate a different requirement for
+     *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
+     *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
+     *  X controls this value.
+     *
+     *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
+     *  in the conpressed sequence.  So whenever a value of 0xFF is coded, the
+     *  MSB of the next byte is set 0 and must be ignored during decoding.
+     *
+     *  Reading can go beyond the end of buffer by up to 3 bytes.
+     *
+     *  @tparam       X is the value fed in when the bitstream is exhausted
+     *  @param  [in]  msp is a pointer to frwd_struct64 structure
+     *
+     */ 
+    template<int X>
+    static inline 
+    void frwd_read(frwd_struct64 *msp)
+    {
+      assert(msp->bits <= 32); // assert that there is a space for 32 bits
+
+      ui32 val = 0;
+      if (msp->size > 3) {
+        val = load_le_ui32(msp->data); // read 32 bits
+        msp->data += 4;           // increment pointer
+        msp->size -= 4;           // reduce size
+      }
+      else if (msp->size > 0)
+      {
+        int i = 0;
+        val = X != 0 ? 0xFFFFFFFFu : 0;
+        while (msp->size > 0) {   
+          ui32 v = *msp->data++;    // read one byte at a time
+          ui32 m = ~(0xFFu << i);    // mask of location
+          val = (val & m) | (v << i);// put one byte in its correct location
+          --msp->size;
+          i += 8;          
+        }
+      }
+      else
+        val = X != 0 ? 0xFFFFFFFFu : 0;
+
+      // we accumulate in t and keep a count of the number of bits in bits
+      ui32 bits = 8 - msp->unstuff;        
+      ui32 t = val & 0xFF;
+      bool unstuff = ((val & 0xFF) == 0xFF);  // Do we need unstuffing next?
+
+      t |= ((val >> 8) & 0xFF) << bits;
+      bits += 8 - unstuff;
+      unstuff = (((val >> 8) & 0xFF) == 0xFF);
+
+      t |= ((val >> 16) & 0xFF) << bits;
+      bits += 8 - unstuff;
+      unstuff = (((val >> 16) & 0xFF) == 0xFF);
+
+      t |= ((val >> 24) & 0xFF) << bits;
+      bits += 8 - unstuff;
+      msp->unstuff = (((val >> 24) & 0xFF) == 0xFF); // for next byte
+
+      msp->tmp |= ((ui64)t) << msp->bits;  // move data to msp->tmp
+      msp->bits += bits;
+    }
+
+    //************************************************************************/
+    /** @brief Read and unstuffs 8 bits from forward-growing bitstream
+     *  
+     *  A template is used to accommodate a different requirement for
+     *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
+     *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
+     *  X controls this value.
+     *
+     *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
+     *  in the conpressed sequence.  So whenever a value of 0xFF is coded, the
+     *  MSB of the next byte is set 0 and must be ignored during decoding.
+     *
+     *  @tparam       X is the value fed in when the bitstream is exhausted
+     *  @param  [in]  msp is a pointer to frwd_struct64 structure
+     *
+     */ 
+    template<ui8 X>
+    static inline 
+    void frwd_read8(frwd_struct64 *msp)
+    {
+      ui8 val = X;
+      if (msp->size > 0) {
+        val = *msp->data;  // read 8 bits
+        ++msp->data;      // increment pointer
+        --msp->size;      // reduce size
+      }
+
+      // unstuff and accumulate
+      ui8 t = msp->unstuff ? 1 : 0;
+      val = (ui8)(val & (0xFFU >> t));
+      msp->unstuff = (val == 0xFF);
+      msp->tmp |= ((ui64)val) << msp->bits;  // move data to msp->tmp
+      msp->bits += 8 - t;
+    }
+
+    //************************************************************************/
+    /** @brief Initialize frwd_struct64 struct and reads some bytes
+     *  
+     *  @tparam      X is the value fed in when the bitstream is exhausted.
+     *               See frwd_read regarding the template
+     *  @param [in]  msp is a pointer to frwd_struct64
+     *  @param [in]  data is a pointer to the start of data
+     *  @param [in]  size is the number of byte in the bitstream
+     */
+    template<int X>
+    static inline
+    void frwd_init(frwd_struct64 *msp, const ui8* data, int size)
+    {
+      msp->data = data;
+      msp->tmp = 0;
+      msp->bits = 0;
+      msp->unstuff = 0;
+      msp->size = size;
+
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the bitstream
+      int num = 4 - (int)(intptr_t(msp->data) & 0x3);
+      for (int i = 0; i < num; ++i)
+      {
+        ui64 d;
+        //read a byte if the buffer is not exhausted, otherwise set it to X
+        d = msp->size-- > 0 ? *msp->data++ : X;
+        msp->tmp |= (d << msp->bits);      // store data in msp->tmp
+        msp->bits += 8 - msp->unstuff;     // number of bits added to msp->tmp
+        msp->unstuff = ((d & 0xFF) == 0xFF); // unstuffing for next byte
+      }
+      frwd_read<X>(msp); // read 32 bits more
+    }
+
+    //************************************************************************/
+    /** @brief Initialize frwd_struct64 struct and reads some bytes
+     *  
+     *  @tparam      X is the value fed in when the bitstream is exhausted.
+     *               See frwd_read regarding the template
+     *  @param [in]  msp is a pointer to frwd_struct64
+     *  @param [in]  data is a pointer to the start of data
+     *  @param [in]  size is the number of byte in the bitstream
+     */
+    template<ui8 X>
+    static inline
+    void frwd_init8(frwd_struct64 *msp, const ui8* data, int size)
+    {
+      msp->data = data;
+      msp->tmp = 0;
+      msp->bits = 0;
+      msp->unstuff = 0;
+      msp->size = size;
+      frwd_read8<X>(msp); // read 8 bits
+    }
+
+    //************************************************************************/
+    /** @brief Consume num_bits bits from the bitstream of frwd_struct64
+     *
+     *  @param [in]  msp is a pointer to frwd_struct64
+     *  @param [in]  num_bits is the number of bit to consume
+     */
+    static inline 
+    void frwd_advance(frwd_struct64 *msp, ui32 num_bits)
+    {
+      assert(num_bits <= msp->bits);
+      msp->tmp >>= num_bits;  // consume num_bits
+      msp->bits -= num_bits;
+    }
+
+    //************************************************************************/
+    /** @brief Fetches 32 bits from the frwd_struct64 bitstream
+     *
+     *  @tparam      X is the value fed in when the bitstream is exhausted.
+     *               See frwd_read regarding the template
+     *  @param [in]  msp is a pointer to frwd_struct64
+     */
+    template<int X>
+    static inline 
+    ui32 frwd_fetch(frwd_struct64 *msp)
+    {
+      if (msp->bits < 32)
+      {
+        frwd_read<X>(msp);
+        if (msp->bits < 32) //need to test
+          frwd_read<X>(msp);
+      }
+      return (ui32)msp->tmp;
+    }
+
+    //************************************************************************/
+    /** @brief Fetches up to 64 bits from the frwd_struct64 bitstream
+     *
+     *  @tparam      X is the value fed in when the bitstream is exhausted.
+     *               See frwd_read regarding the template
+     *  @param [in]  msp is a pointer to frwd_struct64
+     */
+    template<ui8 X>
+    static inline 
+    ui64 frwd_fetch64(frwd_struct64 *msp)
+    {
+      while (msp->bits <= 56)
+        frwd_read8<X>(msp);
+      return msp->tmp;
+    }    
+
+    //************************************************************************/
+    /** @brief Decodes one codeblock, processing the cleanup, siginificance
+     *         propagation, and magnitude refinement pass
+     *
+     *  @param [in]   coded_data is a pointer to bitstream
+     *  @param [in]   decoded_data is a pointer to decoded codeblock data buf.
+     *  @param [in]   missing_msbs is the number of missing MSBs
+     *  @param [in]   num_passes is the number of passes: 1 if CUP only,
+     *                2 for CUP+SPP, and 3 for CUP+SPP+MRP
+     *  @param [in]   lengths1 is the length of cleanup pass
+     *  @param [in]   lengths2 is the length of refinement passes (either SPP
+     *                only or SPP+MRP)
+     *  @param [in]   width is the decoded codeblock width 
+     *  @param [in]   height is the decoded codeblock height
+     *  @param [in]   stride is the decoded codeblock buffer stride 
+     *  @param [in]   stripe_causal is true for stripe causal mode
+     */
+    bool ojph_decode_codeblock64(ui8* coded_data, ui64* decoded_data,
+                                 ui32 missing_msbs, ui32 num_passes,
+                                 ui32 lengths1, ui32 lengths2,
+                                 ui32 width, ui32 height, ui32 stride,
+                                 bool stripe_causal)
+    {
+      // static bool insufficient_precision = false;
+      // static bool modify_code = false;
+      // static bool truncate_spp_mrp = false;
+
+      if (num_passes > 1 && lengths2 == 0)
+      {
+        OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
+                              "one coding pass, but zero length for "
+                              "2nd and potential 3rd pass.");
+        num_passes = 1;
+      }
+
+      if (num_passes > 3)
+      {
+        OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
+                              "This codeblocks has %d passes.",
+                              num_passes);
+        return false;
+      }
+
+      // if (missing_msbs > 30) // p < 0
+      // {
+      //   if (insufficient_precision == false) 
+      //   {
+      //     insufficient_precision = true;
+      //     OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
+      //                           "codeblock. This message will not be "
+      //                           "displayed again.");
+      //   }
+      //   return false;
+      // }       
+      // else if (missing_msbs == 30) // p == 0
+      // { // not enough precision to decode and set the bin center to 1
+      //   if (modify_code == false) {
+      //     modify_code = true;
+      //     OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
+      //                           "pass. The code can be modified to support "
+      //                           "this case. This message will not be "
+      //                           "displayed again.");
+      //   }
+      //    return false;         // 32 bits are not enough to decode this
+      //  }
+      // else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
+      // {
+      //   if (num_passes > 1) {
+      //     num_passes = 1;
+      //     if (truncate_spp_mrp == false) {
+      //       truncate_spp_mrp = true;
+      //       OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
+      //                             "nor MagRef passes; both will be skipped. "
+      //                             "This message will not be displayed "
+      //                             "again.");
+      //     }
+      //   }
+      // }
+      ui32 p = 62 - missing_msbs; // The least significant bitplane for CUP
+      // There is a way to handle the case of p == 0, but a different path
+      // is required
+
+      if (lengths1 < 2)
+      {
+        OJPH_WARN(0x00010006, "Wrong codeblock length.");
+        return false;
+      }
+
+      // read scup and fix the bytes there
+      int lcup, scup;
+      lcup = (int)lengths1;  // length of CUP
+      //scup is the length of MEL + VLC
+      scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
+      if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
+        return false;
+
+      // The temporary storage scratch holds two types of data in an 
+      // interleaved fashion. The interleaving allows us to use one
+      // memory pointer.
+      // We have one entry for a decoded VLC code, and one entry for UVLC.
+      // Entries are 16 bits each, corresponding to one quad, 
+      // but since we want to use XMM registers of the SSE family 
+      // of SIMD; we allocated 16 bytes or more per quad row; that is,
+      // the width is no smaller than 16 bytes (or 8 entries), and the
+      // height is 512 quads
+      // Each VLC entry contains, in the following order, starting 
+      // from MSB
+      // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
+      // Each entry in UVLC contains u_q
+      // One extra row to handle the case of SPP propagating downwards
+      // when codeblock width is 4
+      ui16 scratch[8 * 513] = {0};       // 8 kB
+
+      // We need an extra two entries (one inf and one u_q) beyond
+      // the last column. 
+      // If the block width is 4 (2 quads), then we use sstr of 8 
+      // (enough for 4 quads). If width is 8 (4 quads) we use 
+      // sstr is 16 (enough for 8 quads). For a width of 16 (8 
+      // quads), we use 24 (enough for 12 quads).
+      ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
+
+      ui32 mmsbp2 = missing_msbs + 2;
+
+      // The cleanup pass is decoded in two steps; in step one,
+      // the VLC and MEL segments are decoded, generating a record that 
+      // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
+      // This information should be sufficient for the next step.
+      // In step 2, we decode the MagSgn segment.
+
+      // step 1 decoding VLC and MEL segments
+      {
+        // init structures
+        dec_mel_st mel;
+        mel_init(&mel, coded_data, lcup, scup);
+        rev_struct vlc;
+        rev_init8(&vlc, coded_data, lcup, scup);
+
+        int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
+                                     // data represented as runs of 0 events
+                                     // See mel_decode description
+
+        ui64 vlc_val;
+        ui32 c_q = 0;
+        ui16 *sp = scratch;
+        //initial quad row
+        for (ui32 x = 0; x < width; sp += 4)
+        {
+          // decode VLC
+          /////////////
+
+          // first quad
+          vlc_val = rev_fetch64(&vlc);
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
+
+          // if context is zero, use one MEL event
+          if (c_q == 0) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // Is the run terminated in 1? if so, use decoded VLC code, 
+            // otherwise, discard decoded data, since we will decoded again 
+            // using a different context
+            t0 = (run == -1) ? t0 : 0;
+
+            // is run -1 or -2? this means a run has been consumed
+            if (run < 0) 
+              run = mel_get_run(&mel);  // get another run
+          }
+          //run -= (c_q == 0) ? 2 : 0;
+          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[0] = t0;
+          x += 2;
+
+          // prepare context for the next quad; eqn. 1 in ITU T.814
+          c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
+
+          //remove data from vlc stream (0 bits are removed if vlc is not used)
+          vlc_val = rev_advance64(&vlc, t0 & 0x7);
+
+          //second quad
+          ui16 t1 = 0;
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)]; 
+
+          // if context is zero, use one MEL event
+          if (c_q == 0 && x < width) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // if event is 0, discard decoded t1
+            t1 = (run == -1) ? t1 : 0;
+
+            if (run < 0) // have we consumed all events in a run
+              run = mel_get_run(&mel); // if yes, then get another run
+          }
+          t1 = x < width ? t1 : 0;
+          //run -= (c_q == 0 && x < width) ? 2 : 0;
+          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[2] = t1;
+          x += 2;
+
+          //prepare context for the next quad, eqn. 1 in ITU T.814
+          c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
+
+          //remove data from vlc stream, if qinf is not used, cwdlen is 0
+          vlc_val = rev_advance64(&vlc, t1 & 0x7);
+          
+          // decode u
+          /////////////
+          // uvlc_mode is made up of u_offset bits from the quad pair
+          ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
+          {                     // the MEL run of events
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
+                                                 // is 0x40
+
+            if (run < 0)//if run is consumed (run is -1 or -2), get another run
+              run = mel_get_run(&mel);
+          }
+          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
+          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+
+          //decode uvlc_mode to get u for both quads
+          ui32 idx = uvlc_mode + (ui32)(vlc_val & 0x3F);
+          ui32 uvlc_entry = uvlc_tbl0[idx];
+          ui16 u_bias = uvlc_bias[idx];          
+          //remove total prefix length
+          vlc_val = rev_advance64(&vlc, uvlc_entry & 0x7); 
+          uvlc_entry >>= 3; 
+          //extract suffixes for quad 0 and 1
+          ui32 len = uvlc_entry & 0xF;             // suffix length for 2 quads
+          ui32 tmp = (ui32)(vlc_val&((1<<len)-1)); // suffix value for 2 quads
+          vlc_val = rev_advance64(&vlc, len);
+          uvlc_entry >>= 4;
+          // quad 0 length
+          len = uvlc_entry & 0x7; // quad 0 suffix length
+          uvlc_entry >>= 3;
+          ui16 u_q0 = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
+          ui16 u_q1 = (ui16)((uvlc_entry >> 3) + (tmp >> len));
+
+          // decode u_q extensions, which is needed only when u_q > 32
+          ui16 u_ext; bool cond0, cond1;
+          cond0 = u_q0 - (u_bias & 0x3) > 32;
+          u_ext = (ui16)(cond0 ? (vlc_val & 0xF) : 0);
+          vlc_val = rev_advance64(&vlc, cond0 ? 4 : 0);
+          u_q0 = (ui16)(u_q0 + (u_ext << 2));
+          sp[1] = (ui16)(u_q0 + 1); // kappa = 1
+          cond1 = u_q1 - (u_bias >> 2) > 32;
+          u_ext = (ui16)(cond1 ? (vlc_val & 0xF) : 0);
+          vlc_val = rev_advance64(&vlc, cond1 ? 4 : 0);
+          u_q1 = (ui16)(u_q1 + (u_ext << 2));
+          sp[3] = (ui16)(u_q1 + 1); // kappa = 1
+        }
+        sp[0] = sp[1] = 0;
+
+        //non initial quad rows
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          c_q = 0;                                // context
+          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
+
+          for (ui32 x = 0; x < width; sp += 4)
+          {
+            // decode VLC
+            /////////////
+
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
+
+            // first quad
+            vlc_val = rev_fetch64(&vlc);
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
+
+            // if context is zero, use one MEL event
+            if (c_q == 0) //zero context
+            {
+              run -= 2; //subtract 2, since events number is multiplied by 2
+
+              // Is the run terminated in 1? if so, use decoded VLC code, 
+              // otherwise, discard decoded data, since we will decoded again 
+              // using a different context
+              t0 = (run == -1) ? t0 : 0;
+
+              // is run -1 or -2? this means a run has been consumed
+              if (run < 0) 
+                run = mel_get_run(&mel);  // get another run
+            }
+            //run -= (c_q == 0) ? 2 : 0;
+            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[0] = t0;
+            x += 2;
+
+            // prepare context for the next quad; eqn. 2 in ITU T.814
+            // sigma_q (w, sw)
+            c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[0 - (si32)sstr] & 0x80;
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
+
+            //remove data from vlc stream (0 bits are removed if vlc is unused)
+            vlc_val = rev_advance64(&vlc, t0 & 0x7);
+
+            //second quad
+            ui16 t1 = 0;
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)]; 
+
+            // if context is zero, use one MEL event
+            if (c_q == 0 && x < width) //zero context
+            {
+              run -= 2; //subtract 2, since events number if multiplied by 2
+
+              // if event is 0, discard decoded t1
+              t1 = (run == -1) ? t1 : 0;
+
+              if (run < 0) // have we consumed all events in a run
+                run = mel_get_run(&mel); // if yes, then get another run
+            }
+            t1 = x < width ? t1 : 0;
+            //run -= (c_q == 0 && x < width) ? 2 : 0;
+            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[2] = t1;
+            x += 2;
+
+            // partial c_q, will be completed when we process the next quad
+            // sigma_q (w, sw)
+            c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[2 - (si32)sstr] & 0x80;
+
+            //remove data from vlc stream, if qinf is not used, cwdlen is 0
+            vlc_val = rev_advance64(&vlc, t1 & 0x7);
+          
+            // decode u
+            /////////////
+            // uvlc_mode is made up of u_offset bits from the quad pair
+            ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+            ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
+            //remove total prefix length
+            vlc_val = rev_advance64(&vlc, uvlc_entry & 0x7);
+            uvlc_entry >>= 3;
+            //extract suffixes for quad 0 and 1
+            ui32 len = uvlc_entry & 0xF;             //suffix length for 2 quads
+            ui32 tmp = (ui32)(vlc_val&((1<<len)-1)); //suffix value for 2 quads
+            vlc_val = rev_advance64(&vlc, len);
+            uvlc_entry >>= 4;
+            // quad 0 length
+            len = uvlc_entry & 0x7; // quad 0 suffix length
+            uvlc_entry >>= 3;
+            ui16 u_q0 = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
+            ui16 u_q1 = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
+
+            // decode u_q extensions, which is needed only when u_q > 32
+            ui16 u_ext; bool cond0, cond1;
+            cond0 = u_q0 > 32;
+            u_ext = (ui16)(cond0 ? (vlc_val & 0xF) : 0);
+            vlc_val = rev_advance64(&vlc, cond0 ? 4 : 0);
+            u_q0 = (ui16)(u_q0 + (u_ext << 2));
+            sp[1] = u_q0;
+            cond1 = u_q1 > 32;
+            u_ext = (ui16)(cond1 ? (vlc_val & 0xF) : 0);
+            vlc_val = rev_advance64(&vlc, cond1 ? 4 : 0);
+            u_q1 = (ui16)(u_q1 + (u_ext << 2));
+            sp[3] = u_q1;
+          }
+          sp[0] = sp[1] = 0;
+        }
+      }
+
+      // step2 we decode magsgn
+      {
+        // We allocate a scratch row for storing v_n values.
+        // We have 512 quads horizontally.
+        // We need an extra entry to handle the case of vp[1]
+        // when vp is at the last column.
+        // Here, we allocate 4 instead of 1 to make the buffer size
+        // a multipled of 16 bytes.
+        const int v_n_size = 512 + 4;
+        ui64 v_n_scratch[v_n_size] = {0};  // 4+ kB
+
+        frwd_struct64 magsgn;
+        frwd_init8<0xFF>(&magsgn, coded_data, lcup - scup);
+
+        const ui16 *sp = scratch;
+        ui64 *vp = v_n_scratch;
+        ui64 *dp = decoded_data;
+
+        ui64 prev_v_n = 0;
+        for (ui32 x = 0; x < width; sp += 2, ++vp)
+        {
+          ui32 inf = sp[0];
+          ui32 U_q = sp[1];
+          if (U_q > mmsbp2)
+            return false;
+
+          ui64 v_n;
+          ui64 val = 0;
+          ui32 bit = 0;
+          if (inf & (1 << (4 + bit)))
+          {
+            //get 32 bits of magsgn data
+            ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
+            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+            frwd_advance(&magsgn, m_n);                 //consume m_n
+
+            val = ms_val << 63;                           // get sign bit
+            v_n = ms_val & ((1ULL << m_n) - 1);           // keep only m_n bits
+            v_n |= (ui64)((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+            v_n |= 1;                                     // add center of bin    
+            //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+            //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+            val |= (v_n + 2) << (p - 1);
+          }
+          dp[0] = val;
+
+          v_n = 0;
+          val = 0;
+          bit = 1;
+          if (inf & (1 << (4 + bit)))
+          {
+            //get 32 bits of magsgn data
+            ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
+            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+            frwd_advance(&magsgn, m_n);                 //consume m_n
+
+            val = ms_val << 63;                           // get sign bit
+            v_n = ms_val & ((1ULL << m_n) - 1);           // keep only m_n bits
+            v_n |= (ui64)((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+            v_n |= 1;                                     // add center of bin    
+            //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+            //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+            val |= (v_n + 2) << (p - 1);
+          }
+          dp[stride] = val;
+          vp[0] = prev_v_n | v_n;
+          prev_v_n = 0;
+          ++dp;
+          if (++x >= width)
+          { ++vp; break; }
+
+          val = 0;
+          bit = 2;
+          if (inf & (1 << (4 + bit)))
+          {
+            //get 32 bits of magsgn data
+            ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
+            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+            frwd_advance(&magsgn, m_n);                 //consume m_n
+
+            val = ms_val << 63;                           // get sign bit
+            v_n = ms_val & ((1ULL << m_n) - 1);           // keep only m_n bits
+            v_n |= (ui64)((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+            v_n |= 1;                                     // add center of bin    
+            //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+            //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+            val |= (v_n + 2) << (p - 1);
+          }
+          dp[0] = val;
+
+          v_n = 0;
+          val = 0;
+          bit = 3;
+          if (inf & (1 << (4 + bit)))
+          {
+            //get 32 bits of magsgn data
+            ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
+            ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+            frwd_advance(&magsgn, m_n);                 //consume m_n
+
+            val = ms_val << 63;                           // get sign bit
+            v_n = ms_val & ((1ULL << m_n) - 1);           // keep only m_n bits
+            v_n |= (ui64)((inf >> (8 + bit)) & 1) << m_n; // add EMB e_1 as MSB
+            v_n |= 1;                                     // add center of bin    
+            //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+            //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+            val |= (v_n + 2) << (p - 1);
+          }
+          dp[stride] = val;
+          prev_v_n = v_n;
+          ++dp;
+          ++x;
+        }
+        vp[0] = prev_v_n;
+
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          const ui16 *sp = scratch + (y >> 1) * sstr;
+          ui64 *vp = v_n_scratch;
+          ui64 *dp = decoded_data + y * stride;
+
+          prev_v_n = 0;
+          for (ui32 x = 0; x < width; sp += 2, ++vp)
+          {
+            ui32 inf = sp[0];
+            ui32 u_q = sp[1];
+
+            ui32 gamma = inf & 0xF0; gamma &= gamma - 0x10; //is gamma_q 1?
+            ui32 emax = 63 - count_leading_zeros(2 | vp[0] | vp[1]); // emax-1
+            ui32 kappa = gamma ? emax : 1;
+
+            ui32 U_q = u_q + kappa;
+            if (U_q > mmsbp2)
+              return false;
+
+            ui64 v_n;
+            ui64 val = 0;
+            ui32 bit = 0;
+            if (inf & (1 << (4 + bit)))
+            {
+              //get 32 bits of magsgn data
+              ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
+              ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+              frwd_advance(&magsgn, m_n);                 //consume m_n
+
+              val = ms_val << 63;                         // get sign bit
+              v_n = ms_val & ((1ULL << m_n) - 1);         // keep only m_n bits
+              v_n |= (ui64)((inf >> (8+bit)) & 1) << m_n; // add EMB e_1 as MSB
+              v_n |= 1;                                   // add center of bin    
+              //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+              //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+              val |= (v_n + 2) << (p - 1);
+            }
+            dp[0] = val;
+
+            v_n = 0;
+            val = 0;
+            bit = 1;
+            if (inf & (1 << (4 + bit)))
+            {
+              //get 32 bits of magsgn data
+              ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
+              ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+              frwd_advance(&magsgn, m_n);                 //consume m_n
+
+              val = ms_val << 63;                         // get sign bit
+              v_n = ms_val & ((1ULL << m_n) - 1);         // keep only m_n bits
+              v_n |= (ui64)((inf >> (8+bit)) & 1) << m_n; // add EMB e_1 as MSB
+              v_n |= 1;                                   // add center of bin    
+              //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+              //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+              val |= (v_n + 2) << (p - 1);
+            }
+            dp[stride] = val;
+            vp[0] = prev_v_n | v_n;
+            prev_v_n = 0;
+            ++dp;
+            if (++x >= width)
+            { ++vp; break; }
+
+            val = 0;
+            bit = 2;
+            if (inf & (1 << (4 + bit)))
+            {
+              //get 32 bits of magsgn data
+              ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
+              ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+              frwd_advance(&magsgn, m_n);                 //consume m_n
+
+              val = ms_val << 63;                         // get sign bit
+              v_n = ms_val & ((1ULL << m_n) - 1);         // keep only m_n bits
+              v_n |= (ui64)((inf >> (8+bit)) & 1) << m_n; // add EMB e_1 as MSB
+              v_n |= 1;                                   // add center of bin    
+              //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+              //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+              val |= (v_n + 2) << (p - 1);
+            }
+            dp[0] = val;
+
+            v_n = 0;
+            val = 0;
+            bit = 3;
+            if (inf & (1 << (4 + bit)))
+            {
+              //get 32 bits of magsgn data
+              ui64 ms_val = frwd_fetch64<0xFF>(&magsgn); 
+              ui32 m_n = U_q - ((inf >> (12 + bit)) & 1); // remove e_k
+              frwd_advance(&magsgn, m_n);                 //consume m_n
+
+              val = ms_val << 63;                         // get sign bit
+              v_n = ms_val & ((1ULL << m_n) - 1);         // keep only m_n bits
+              v_n |= (ui64)((inf >> (8+bit)) & 1) << m_n; // add EMB e_1 as MSB
+              v_n |= 1;                                   // add center of bin    
+              //v_n now has 2 * (\mu - 1) + 0.5 with correct sign bit
+              //add 2 to make it 2*\mu+0.5, shift it up to missing MSBs
+              val |= (v_n + 2) << (p - 1);
+            }
+            dp[stride] = val;
+            prev_v_n = v_n;
+            ++dp;
+            ++x;
+          }
+          vp[0] = prev_v_n;
+        }
+      }
+
+      if (num_passes > 1)
+      {
+        // We use scratch again, we can divide it into multiple regions
+        // sigma holds all the significant samples, and it cannot
+        // be modified after it is set.  it will be used during the
+        // Magnitude Refinement Pass
+        ui16* const sigma = scratch;
+
+        ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
+                                         // ui16 contains 4 columns
+        mstr = ((mstr + 2u) + 7u) & ~7u; // multiples of 8
+
+        // We re-arrange quad significance, where each 4 consecutive
+        // bits represent one quad, into column significance, where,
+        // each 4 consequtive bits represent one column of 4 rows
+        {
+          ui32 y;
+          for (y = 0; y < height; y += 4)
+          {
+            ui16* sp = scratch + (y >> 1) * sstr;
+            ui16* dp = sigma + (y >> 2) * mstr;
+            for (ui32 x = 0; x < width; x += 4, sp += 4, ++dp) {
+              ui32 t0 = 0, t1 = 0;
+              t0  = ((sp[0     ] & 0x30u) >> 4)  | ((sp[0     ] & 0xC0u) >> 2);
+              t0 |= ((sp[2     ] & 0x30u) << 4)  | ((sp[2     ] & 0xC0u) << 6);
+              t1  = ((sp[0+sstr] & 0x30u) >> 2)  | ((sp[0+sstr] & 0xC0u)     );
+              t1 |= ((sp[2+sstr] & 0x30u) << 6)  | ((sp[2+sstr] & 0xC0u) << 8);
+              dp[0] = (ui16)(t0 | t1);
+            }
+            dp[0] = 0; // set an extra entry on the right with 0
+          }
+          {
+            // reset one row after the codeblock
+            ui16* dp = sigma + (y >> 2) * mstr;
+            for (ui32 x = 0; x < width; x += 4, ++dp)
+              dp[0] = 0;
+            dp[0] = 0; // set an extra entry on the right with 0
+          }
+        }
+
+        // We perform Significance Propagation Pass here
+        {
+          // This stores significance information of the previous
+          // 4 rows.  Significance information in this array includes
+          // all signicant samples in bitplane p - 1; that is,
+          // significant samples for bitplane p (discovered during the
+          // cleanup pass and stored in sigma) and samples that have recently
+          // became significant (during the SPP) in bitplane p-1.
+          // We store enough for the widest row, containing 1024 columns,
+          // which is equivalent to 256 of ui16, since each stores 4 columns.
+          // We add an extra 8 entries, just in case we need more
+          ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
+
+          frwd_struct64 sigprop;
+          frwd_init<0>(&sigprop, coded_data + lengths1, (int)lengths2);
+
+          for (ui32 y = 0; y < height; y += 4)
+          {
+            ui32 pattern = 0xFFFFu; // a pattern needed samples
+            if (height - y < 4) {
+              pattern = 0x7777u;
+              if (height - y < 3) {
+                pattern = 0x3333u;
+                if (height - y < 2)
+                  pattern = 0x1111u;
+              }
+            }
+
+            // prev holds sign. info. for the previous quad, together
+            // with the rows on top of it and below it.
+            ui32 prev = 0;
+            ui16 *prev_sig = prev_row_sig;
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
+            ui64 *dpp = decoded_data + y * stride;
+            for (ui32 x = 0; x < width; x += 4, ++cur_sig, ++prev_sig)
+            {
+              // only rows and columns inside the stripe are included
+              si32 s = (si32)x + 4 - (si32)width;
+              s = ojph_max(s, 0);
+              pattern = pattern >> (s * 4);
+
+              // We first find locations that need to be tested (potential
+              // SPP members); these location will end up in mbr
+              // In each iteration, we produce 16 bits because cwd can have
+              // up to 16 bits of significance information, followed by the
+              // corresponding 16 bits of sign information; therefore, it is
+              // sufficient to fetch 32 bit data per loop.
+
+              // Althougth we are interested in 16 bits only, we load 32 bits.
+              // For the 16 bits we are producing, we need the next 4 bits --
+              // We need data for at least 5 columns out of 8.
+              // Therefore loading 32 bits is easier than loading 16 bits
+              // twice.
+              ui32 ps = load_le_ui16x2(prev_sig);
+              ui32 ns = load_le_ui16x2(cur_sig + mstr);
+              ui32 u = (ps & 0x88888888) >> 3; // the row on top
+              if (!stripe_causal)
+                u |= (ns & 0x11111111) << 3;   // the row below
+
+              ui32 cs = load_le_ui16x2(cur_sig);
+              // vertical integration
+              ui32 mbr =  cs;                // this sig. info.
+              mbr |= (cs & 0x77777777) << 1; //above neighbors
+              mbr |= (cs & 0xEEEEEEEE) >> 1; //below neighbors
+              mbr |= u;
+              // horizontal integration
+              ui32 t = mbr;
+              mbr |= t << 4;      // neighbors on the left
+              mbr |= t >> 4;      // neighbors on the right
+              mbr |= prev >> 12;  // significance of previous group
+
+              // remove outside samples, and already significant samples
+              mbr &= pattern;
+              mbr &= ~cs;
+
+              // find samples that become significant during the SPP
+              ui32 new_sig = mbr;
+              if (new_sig)
+              {
+                ui64 cwd = frwd_fetch<0>(&sigprop);
+
+                ui32 cnt = 0;
+                ui32 col_mask = 0xFu;
+                ui32 inv_sig = ~cs & pattern;
+                for (int i = 0; i < 16; i += 4, col_mask <<= 4)
+                {
+                  if ((col_mask & new_sig) == 0)
+                    continue;
+
+                  //scan one column
+                  ui32 sample_mask = 0x1111u & col_mask;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0x33u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0x76u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0xECu << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0xC8u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+                }
+
+                if (new_sig)
+                {
+                  // new_sig has newly-discovered sig. samples during SPP
+                  // find the signs and update decoded_data
+                  ui64 *dp = dpp + x;
+                  ui64 val = 3u << (p - 2);
+                  col_mask = 0xFu;
+                  for (int i = 0; i < 4; ++i, ++dp, col_mask <<= 4)
+                  {
+                    if ((col_mask & new_sig) == 0)
+                      continue;
+
+                    //scan 4 signs
+                    ui32 sample_mask = 0x1111u & col_mask;
+                    if (new_sig & sample_mask)
+                    {
+                      assert(dp[0] == 0);
+                      dp[0] = (cwd << 63) | val;
+                      cwd >>= 1; ++cnt;
+                    }
+
+                    sample_mask += sample_mask;
+                    if (new_sig & sample_mask)
+                    {
+                      assert(dp[stride] == 0);
+                      dp[stride] = (cwd << 63) | val;
+                      cwd >>= 1; ++cnt;
+                    }
+
+                    sample_mask += sample_mask;
+                    if (new_sig & sample_mask)
+                    {
+                      assert(dp[2 * stride] == 0);
+                      dp[2 * stride] = (cwd << 63) | val;
+                      cwd >>= 1; ++cnt;
+                    }
+
+                    sample_mask += sample_mask;
+                    if (new_sig & sample_mask)
+                    {
+                      assert(dp[3 * stride] == 0);
+                      dp[3 * stride] = (cwd << 63) | val;
+                      cwd >>= 1; ++cnt;
+                    }
+                  }
+                }
+                frwd_advance(&sigprop, cnt);
+              }
+
+              new_sig |= cs;
+              *prev_sig = (ui16)(new_sig);
+
+              // vertical integration for the new sig. info.
+              t = new_sig;
+              new_sig |= (t & 0x7777) << 1; //above neighbors
+              new_sig |= (t & 0xEEEE) >> 1; //below neighbors
+              // add sig. info. from the row on top and below
+              prev = new_sig | u;
+              // we need only the bits in 0xF000
+              prev &= 0xF000;
+            }
+          }
+        }
+
+        // We perform Magnitude Refinement Pass here
+        if (num_passes > 2)
+        {
+          rev_struct magref;
+          rev_init_mrp(&magref, coded_data, (int)lengths1, (int)lengths2);
+
+          for (ui32 y = 0; y < height; y += 4)
+          {
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
+            ui64 *dpp = decoded_data + y * stride;
+            ui64 half = 1ULL << (p - 2);
+            for (ui32 i = 0; i < width; i += 8, cur_sig += 2)
+            {
+              //Process one entry from sigma array at a time
+              // Each nibble (4 bits) in the sigma array represents 4 rows,
+              // and the 32 bits contain 8 columns
+              ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
+              ui32 sig = load_le_ui16x2(cur_sig); // 32 bits processed now
+              ui32 col_mask = 0xFu;  // a mask for a column in sig
+              if (sig) // if any of the 32 bits are set
+              {
+                for (int j = 0; j < 8; ++j) //one column at a time
+                {
+                  if (sig & col_mask) // lowest nibble
+                  {
+                    ui64 *dp = dpp + i + j; // next column in decoded samples
+                    ui32 sample_mask = 0x11111111u & col_mask; //LSB
+
+                    for (int k = 0; k < 4; ++k) {
+                      if (sig & sample_mask) //if LSB is set
+                      {
+                        assert(dp[0] != 0); // decoded value cannot be zero
+                        assert((dp[0] & half) == 0); // no half
+                        ui64 sym = cwd & 1;          // get it value
+                        sym = (1 - sym) << (p - 1); // previous center of bin
+                        sym |= half;            // put half the center of bin
+                        dp[0] ^= sym;    // remove old bin center and put new
+                        cwd >>= 1;       // consume word
+                      }
+                      sample_mask += sample_mask; //next row
+                      dp += stride; // next samples row
+                    }
+                  }
+                  col_mask <<= 4; //next column
+                }
+              }
+              // consume data according to the number of bits set
+              rev_advance_mrp(&magref, population_count(sig));
+            }
+          }
+        }
+      }
+      return true;
+    }
+  }
+}

--- a/Native/Common/OpenJPH/coding/ojph_block_decoder_avx2.cpp
+++ b/Native/Common/OpenJPH/coding/ojph_block_decoder_avx2.cpp
@@ -6,6 +6,7 @@
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
 // Copyright (c) 2024, Intel Corporation
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -53,2020 +54,1923 @@
 
 #include <immintrin.h>
 
-namespace ojph
-{
-    namespace local
+namespace ojph {
+  namespace local {
+
+    //************************************************************************/
+    /** @brief MEL state structure for reading and decoding the MEL bitstream
+     *
+     *  A number of events is decoded from the MEL bitstream ahead of time
+     *  and stored in run/num_runs.
+     *  Each run represents the number of zero events before a one event.
+     */
+    struct dec_mel_st {
+      dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
+        k(0), num_runs(0), runs(0)
+      {}
+      // data decoding machinery
+      ui8* data;    //!<the address of data (or bitstream)
+      ui64 tmp;     //!<temporary buffer for read data
+      int bits;     //!<number of bits stored in tmp
+      int size;     //!<number of bytes in MEL code
+      bool unstuff; //!<true if the next bit needs to be unstuffed
+      int k;        //!<state of MEL decoder
+
+      // queue of decoded runs
+      int num_runs; //!<number of decoded runs left in runs (maximum 8)
+      ui64 runs;    //!<runs of decoded MEL codewords (7 bits/run)
+    };
+
+    //************************************************************************/
+    /** @brief Reads and unstuffs the MEL bitstream
+     *
+     *  This design needs more bytes in the codeblock buffer than the length
+     *  of the cleanup pass by up to 2 bytes.
+     *
+     *  Unstuffing removes the MSB of the byte following a byte whose
+     *  value is 0xFF; this prevents sequences larger than 0xFF7F in value
+     *  from appearing the bitstream.
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     */
+    static inline
+    void mel_read(dec_mel_st *melp)
     {
+      if (melp->bits > 32)  //there are enough bits in the tmp variable
+        return;             // return without reading new data
 
-        //************************************************************************/
-        /** @brief MEL state structure for reading and decoding the MEL bitstream
-         *
-         *  A number of events is decoded from the MEL bitstream ahead of time
-         *  and stored in run/num_runs.
-         *  Each run represents the number of zero events before a one event.
-         */
-        struct dec_mel_st
+      ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
+      if (melp->size > 4) {        // if there is data in the MEL segment
+        memcpy(&val, melp->data, 4);  // read 32 bits from MEL data
+        melp->data += 4;           // advance pointer
+        melp->size -= 4;           // reduce counter
+      }
+      else if (melp->size > 0)
+      { // 4 or less
+        int i = 0;
+        while (melp->size > 1) {
+          ui32 v = *melp->data++;    // read one byte at a time
+          ui32 m = ~(0xFFu << i);    // mask of location
+          val = (val & m) | (v << i);// put one byte in its correct location
+          --melp->size;
+          i += 8;
+        }
+        // size equal to 1
+        ui32 v = *melp->data++;    // the one before the last is different
+        v |= 0xF;                  // MEL and VLC segments can overlap
+        ui32 m = ~(0xFFu << i);
+        val = (val & m) | (v << i);
+        --melp->size;
+      }
+
+      // next we unstuff them before adding them to the buffer
+      int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
+                                     // the previously read byte requires
+                                     // unstuffing
+
+      // data is unstuffed and accumulated in t
+      // bits has the number of bits in t
+      ui32 t = val & 0xFF;
+      bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
+      bits -= unstuff; // there is one less bit in t if unstuffing is needed
+      t = t << (8 - unstuff); // move up to make room for the next byte
+
+      //this is a repeat of the above
+      t |= (val>>8) & 0xFF;
+      unstuff = (((val >> 8) & 0xFF) == 0xFF);
+      bits -= unstuff;
+      t = t << (8 - unstuff);
+
+      t |= (val>>16) & 0xFF;
+      unstuff = (((val >> 16) & 0xFF) == 0xFF);
+      bits -= unstuff;
+      t = t << (8 - unstuff);
+
+      t |= (val>>24) & 0xFF;
+      melp->unstuff = (((val >> 24) & 0xFF) == 0xFF);
+
+      // move t to tmp, and push the result all the way up, so we read from
+      // the MSB
+      melp->tmp |= ((ui64)t) << (64 - bits - melp->bits);
+      melp->bits += bits; //increment the number of bits in tmp
+    }
+
+    //************************************************************************/
+    /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
+     *
+     *  Runs are stored in "runs" and the number of runs in "num_runs".
+     *  Each run represents a number of zero events that may or may not
+     *  terminate in a 1 event.
+     *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
+     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating
+     *  with 1, contain the number of consecutive 0 zero events * 2; for the
+     *  case terminating with 0, they store (number of consecutive 0 zero
+     *  events - 1) * 2.
+     *  A total of 6 bits (made up of 1 + 5) should have been enough.
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     */
+    static inline
+    void mel_decode(dec_mel_st *melp)
+    {
+      static const int mel_exp[13] = { //MEL exponents
+        0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5
+      };
+
+      if (melp->bits < 6) // if there are less than 6 bits in tmp
+        mel_read(melp);   // then read from the MEL bitstream
+                          // 6 bits is the largest decodable MEL cwd
+
+      //repeat so long that there is enough decodable bits in tmp,
+      // and the runs store is not full (num_runs < 8)
+      while (melp->bits >= 6 && melp->num_runs < 8)
+      {
+        int eval = mel_exp[melp->k]; // number of bits associated with state
+        int run = 0;
+        if (melp->tmp & (1ull<<63)) //The next bit to decode (stored in MSB)
+        { //one is found
+          run = 1 << eval;
+          run--; // consecutive runs of 0 events - 1
+          melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12;//increment, max is 12
+          melp->tmp <<= 1; // consume one bit from tmp
+          melp->bits -= 1;
+          run = run << 1; // a stretch of zeros not terminating in one
+        }
+        else
+        { //0 is found
+          run = (int)(melp->tmp >> (63 - eval)) & ((1 << eval) - 1);
+          melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; //decrement, min is 0
+          melp->tmp <<= eval + 1; //consume eval + 1 bits (max is 6)
+          melp->bits -= eval + 1;
+          run = (run << 1) + 1; // a stretch of zeros terminating with one
+        }
+        eval = melp->num_runs * 7;           // 7 bits per run
+        melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
+        melp->runs |= ((ui64)run) << eval;   // store the value in runs
+        melp->num_runs++;                    // increment count
+      }
+    }
+
+    //************************************************************************/
+    /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
+     *         some bytes in order to get the read address to a multiple
+     *         of 4
+     *
+     *  @param [in]  melp is a pointer to dec_mel_st structure
+     *  @param [in]  bbuf is a pointer to byte buffer
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  scup is the length of MEL+VLC segments
+     */
+    static inline
+    void mel_init(dec_mel_st *melp, ui8* bbuf, int lcup, int scup)
+    {
+      melp->data = bbuf + lcup - scup; // move the pointer to the start of MEL
+      melp->bits = 0;                  // 0 bits in tmp
+      melp->tmp = 0;                   //
+      melp->unstuff = false;           // no unstuffing
+      melp->size = scup - 1;           // size is the length of MEL+VLC-1
+      melp->k = 0;                     // 0 for state
+      melp->num_runs = 0;              // num_runs is 0
+      melp->runs = 0;                  //
+
+      //This code is borrowed; original is for a different architecture
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
+      int num = 4 - (int)(intptr_t(melp->data) & 0x3);
+      for (int i = 0; i < num; ++i) { // this code is similar to mel_read
+        assert(melp->unstuff == false || melp->data[0] <= 0x8F);
+        ui64 d = (melp->size > 0) ? *melp->data : 0xFF;//if buffer is consumed
+                                                       //set data to 0xFF
+        if (melp->size == 1) d |= 0xF; //if this is MEL+VLC-1, set LSBs to 0xF
+                                       // see the standard
+        melp->data += melp->size-- > 0; //increment if the end is not reached
+        int d_bits = 8 - melp->unstuff; //if unstuffing is needed, reduce by 1
+        melp->tmp = (melp->tmp << d_bits) | d; //store bits in tmp
+        melp->bits += d_bits;  //increment tmp by number of bits
+        melp->unstuff = ((d & 0xFF) == 0xFF); //true of next byte needs
+                                              //unstuffing
+      }
+      melp->tmp <<= (64 - melp->bits); //push all the way up so the first bit
+                                       // is the MSB
+    }
+
+    //************************************************************************/
+    /** @brief Retrieves one run from dec_mel_st; if there are no runs stored
+     *         MEL segment is decoded
+     *
+     * @param [in]  melp is a pointer to dec_mel_st structure
+     */
+    static inline
+    int mel_get_run(dec_mel_st *melp)
+    {
+      if (melp->num_runs == 0)  //if no runs, decode more bit from MEL segment
+        mel_decode(melp);
+
+      int t = melp->runs & 0x7F; //retrieve one run
+      melp->runs >>= 7;  // remove the retrieved run
+      melp->num_runs--;
+      return t; // return run
+    }
+
+
+    //************************************************************************/
+    /** @brief De-stuffs a forward-growing bitstream into a flat buffer
+     *
+     *  This replicates, in one pass, the bit production of the frwd_struct
+     *  bitstream reader used by the other block decoders: a byte following
+     *  a 0xFF byte contributes only 7 bits (its MSB -- guaranteed 0 by the
+     *  encoder -- is OR'ed with the following bit), and bits beyond the
+     *  end of the data
+     *  read as X (1s for MagSgn, 0s for SPP).  With the stream flattened,
+     *  bits for any quad can be fetched at an absolute bit position (see
+     *  dfetch), removing the serial fetch/advance state from the decode
+     *  loops.
+     *
+     *  Writes at most cap + 1 destuffed bytes followed by 64 bytes of
+     *  padding; dst must have room for cap + 65 bytes.  cap must be
+     *  no smaller than the maximum number of bits the decoder can consume
+     *  divided by 8, so clipping the data at cap loses no decodable bits.
+     *
+     *  @tparam      X is the value fed in when the bitstream is exhausted
+     *  @param [in]  src is a pointer to the start of the bitstream data
+     *  @param [in]  size is the number of bytes in the bitstream data
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch; bytes at or beyond this
+     *               offset hold no stream bits (they read as X)
+     */
+    template<int X>
+    static inline
+    ui32 destuff_frwd(const ui8* src, int size, ui8* dst, ui32 cap)
+    {
+      if (size < 0)
+        size = 0;
+      ui8* o = dst;
+      ui8* o_end = dst + cap;
+      const ui8* s = src;
+      const ui8* s_end = src + size;
+      ui64 acc = 0;       // partial output byte, low nb bits are valid
+      ui32 nb = 0;        // number of valid bits in acc; always < 8
+      bool prev_ff = false;
+
+      // fast path; 16 source bytes at a time when they contain no 0xFF
+      while (s + 16 <= s_end && o + 24 <= o_end)
+      {
+        __m128i v = _mm_loadu_si128((const __m128i*)s);
+        int ff = _mm_movemask_epi8(_mm_cmpeq_epi8(v, _mm_set1_epi8(-1)));
+        if (ff != 0 || prev_ff)
+        { // process these 16 bytes one at a time
+          for (int i = 0; i < 16; ++i) {
+            ui8 b = *s++;
+            acc |= (ui64)b << nb;
+            nb += prev_ff ? 7u : 8u;
+            prev_ff = (b == 0xFFu);
+            if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+          }
+          continue;
+        }
+        ui64 v0, v1;
+        memcpy(&v0, s, 8);
+        memcpy(&v1, s + 8, 8);
+        ui64 w0 = acc | (v0 << nb);
+        ui64 w1 = (v1 << nb) | (nb ? (v0 >> (64 - nb)) : 0);
+        memcpy(o, &w0, 8);
+        memcpy(o + 8, &w1, 8);
+        acc = nb ? (v1 >> (64 - nb)) : 0;
+        o += 16;
+        s += 16;
+      }
+      // tail; one byte at a time
+      while (s < s_end && o < o_end)
+      {
+        ui8 b = *s++;
+        acc |= (ui64)b << nb;
+        nb += prev_ff ? 7u : 8u;
+        prev_ff = (b == 0xFFu);
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+      // fill the bits above nb with X, and pad with X bytes
+      ui32 fill = (X == 0xFF) ? (0xFFu << nb) : 0;
+      *o = (ui8)((ui32)acc | fill);
+      __m256i pad = _mm256_set1_epi8((char)X);
+      _mm256_storeu_si256((__m256i*)(o + 1), pad);
+      _mm256_storeu_si256((__m256i*)(o + 33), pad);
+      return (ui32)(o - dst) + 1;
+    }
+
+    //************************************************************************/
+    /** @brief Fetches 128 bits from a destuffed MagSgn buffer
+     *
+     *  Returns the 128 bits starting at bit position pos of the buffer
+     *  produced by destuff_frwd.  Unlike a stateful bitstream reader,
+     *  this carries no
+     *  serial state; fetches at independent positions can execute out of
+     *  order.  The byte offset is clamped to limit so that positions past
+     *  the end of the stream read as 1s without leaving the buffer.
+     *
+     *  @param [in]  dbuf is the destuffed MagSgn buffer
+     *  @param [in]  limit is the clamp offset returned by destuff_frwd
+     *  @param [in]  pos is the absolute bit position to fetch from
+     */
+    OJPH_FORCE_INLINE
+    __m128i dfetch(const ui8* dbuf, ui32 limit, ui32 pos)
+    {
+      ui32 off = pos >> 3;
+      off = off < limit ? off : limit;
+      const ui8* p = dbuf + off;
+      __m128i v = _mm_loadu_si128((const __m128i*)p);
+      __m128i w = _mm_loadu_si128((const __m128i*)(p + 8));
+      int k = (int)(pos & 7);
+      __m128i r = _mm_srl_epi64(v, _mm_cvtsi32_si128(k));
+      __m128i c = _mm_sll_epi64(w, _mm_cvtsi32_si128(64 - k));
+      return _mm_or_si128(r, c);
+    }
+
+    //************************************************************************/
+    /** @brief Fetches at least 57 bits from a destuffed bitstream
+     *
+     *  Scalar counterpart of dfetch; returns the bits starting at bit
+     *  position pos of a buffer produced by destuff_frwd, in the lower
+     *  bits of the result.  Bits above 64 - (pos & 7) are garbage.
+     *
+     *  @param [in]  dbuf is the destuffed bitstream buffer
+     *  @param [in]  limit is the clamp offset returned by destuff_frwd
+     *  @param [in]  pos is the absolute bit position to fetch from
+     */
+    OJPH_FORCE_INLINE
+    ui64 dfetch64(const ui8* dbuf, ui32 limit, ui32 pos)
+    {
+      ui32 off = pos >> 3;
+      off = off < limit ? off : limit;
+      ui64 v;
+      memcpy(&v, dbuf + off, 8);
+      return v >> (pos & 7);
+    }
+
+    //************************************************************************/
+    /** @brief Branchless refill of a register-resident bit window
+     *
+     *  Loads 8 bytes from a destuffed buffer and inserts whole bytes
+     *  above the bits remaining in the window, leaving 56 to 63 valid
+     *  bits.  Because the inserted bits land above the remaining ones,
+     *  consumers of the low bits need not wait for the load, keeping it
+     *  off the critical dependency chain.  The read offset is clamped to
+     *  limit so that, when consumption overruns the stream (truncated
+     *  codeblocks), reads come from the zero padding -- the bytes there
+     *  are exactly the fill the stream would produce -- instead of from
+     *  uninitialized buffer memory.
+     *
+     *  @param [in,out]  val is the bit window; its low bits are valid
+     *  @param [in,out]  bits is the number of valid bits in val
+     *  @param [in,out]  off is the read offset in the destuffed buffer
+     *  @param [in]      dbuf is the destuffed bitstream buffer
+     *  @param [in]      limit is the clamp offset returned by destuff_vlc
+     */
+    OJPH_FORCE_INLINE
+    void drefill(ui64& val, ui32& bits, ui32& off,
+                 const ui8* dbuf, ui32 limit)
+    {
+      ui64 v;
+      ui32 o = off < limit ? off : limit;
+      memcpy(&v, dbuf + o, 8);
+      val |= v << bits;
+      off += (63 - bits) >> 3;
+      bits |= 56;
+    }
+
+    //************************************************************************/
+    /** @brief Consumes bits from a window refilled by drefill
+     *
+     *  @param [in,out]  val is the bit window
+     *  @param [in,out]  bits is the number of valid bits in val
+     *  @param [in]      num_bits is the number of bits to consume
+     */
+    OJPH_FORCE_INLINE
+    void dconsume(ui64& val, ui32& bits, ui32 num_bits)
+    {
+      val >>= num_bits;
+      bits -= num_bits;
+    }
+
+    //************************************************************************/
+    /** @brief De-stuffs a backward-growing bitstream into a flat buffer
+     *
+     *  This replicates the bit production of the rev_struct bitstream
+     *  reader used by the other block decoders, for both its VLC and MRP
+     *  variants: reading backward from p, a byte contributes only 7 bits
+     *  (its MSB -- guaranteed 0 by the encoder -- is OR'ed with the
+     *  following bit) when the byte after it in memory is greater than
+     *  0x8F and its own low 7 bits are all 1s.  Bits beyond the end of
+     *  the data read as 0s, matching both readers.  The first byte is
+     *  processed with the caller-provided unstuff state; after that the
+     *  state always equals (p[1] > 0x8F), so the fast path can detect
+     *  stuffing with a pairwise byte comparison within the segment.
+     *
+     *  Writes at most cap + 1 destuffed bytes followed by 64 bytes of
+     *  zero padding; dst must have room for cap + 65 bytes.  cap must be
+     *  no smaller than the maximum number of bits the decoder can consume
+     *  divided by 8, so clipping the data at cap loses no decodable bits.
+     *
+     *  @param [in]  p is a pointer to the last byte of the segment, where
+     *               backward reading starts
+     *  @param [in]  size is the number of bytes in the segment
+     *  @param [in]  unstuff is the initial unstuffing state
+     *  @param [in]  acc holds bits produced by initialization, low nb bits
+     *  @param [in]  nb is the number of valid bits in acc; less than 8
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch/dfetch64; bytes at or beyond
+     *               this offset hold no stream bits (they read as 0s)
+     */
+    static inline
+    ui32 destuff_rev(const ui8* p, int size, bool unstuff,
+                     ui64 acc, ui32 nb, ui8* dst, ui32 cap)
+    {
+      ui8* o = dst;
+      ui8* o_end = dst + cap;
+
+      // process the first byte with the caller-provided unstuff state;
+      // afterwards the state is implied by the byte at p[1], which the
+      // fast path checks vectorially (and which stays inside the segment)
+      if (size > 0 && o < o_end)
+      {
+        ui32 d = *p--;
+        --size;
+        acc |= (ui64)d << nb;
+        nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+        unstuff = d > 0x8F;
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+
+      // fast path; 16 source bytes at a time when none needs unstuffing
+      while (size >= 16 && o + 24 <= o_end)
+      {
+        __m128i v = _mm_loadu_si128((const __m128i*)(p - 15));
+        __m128i nx = _mm_loadu_si128((const __m128i*)(p - 14));
+        __m128i is7f = _mm_cmpeq_epi8(
+            _mm_and_si128(v, _mm_set1_epi8(0x7F)), _mm_set1_epi8(0x7F));
+        // le8f is 0xFF where the byte after (in memory) is <= 0x8F
+        __m128i le8f = _mm_cmpeq_epi8(
+            _mm_subs_epu8(nx, _mm_set1_epi8((char)0x8F)),
+            _mm_setzero_si128());
+        __m128i stuff = _mm_andnot_si128(le8f, is7f);
+        if (!_mm_testz_si128(stuff, stuff))
+        { // process these 16 bytes one at a time
+          for (int i = 0; i < 16; ++i) {
+            ui32 d = *p--;
+            acc |= (ui64)d << nb;
+            nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+            unstuff = d > 0x8F;
+            if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+          }
+          size -= 16;
+          continue;
+        }
+        __m128i r = _mm_shuffle_epi8(v,
+            _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7,
+                         8, 9, 10, 11, 12, 13, 14, 15)); // reverse bytes
+#ifdef OJPH_ARCH_X86_64
+        ui64 v0 = (ui64)_mm_cvtsi128_si64(r);
+        ui64 v1 = (ui64)_mm_extract_epi64(r, 1);
+#else // 32-bit x86 lacks the 64-bit extract intrinsics
+        ui64 v0 = (ui32)_mm_cvtsi128_si32(r)
+                | ((ui64)(ui32)_mm_extract_epi32(r, 1) << 32);
+        ui64 v1 = (ui32)_mm_extract_epi32(r, 2)
+                | ((ui64)(ui32)_mm_extract_epi32(r, 3) << 32);
+#endif
+        ui64 w0 = acc | (v0 << nb);
+        ui64 w1 = (v1 << nb) | (nb ? (v0 >> (64 - nb)) : 0);
+        memcpy(o, &w0, 8);
+        memcpy(o + 8, &w1, 8);
+        acc = nb ? (v1 >> (64 - nb)) : 0;
+        o += 16;
+        p -= 16;
+        size -= 16;
+        unstuff = p[1] > 0x8F;
+      }
+      // tail; one byte at a time
+      while (size > 0 && o < o_end)
+      {
+        ui32 d = *p--;
+        --size;
+        acc |= (ui64)d << nb;
+        nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+        unstuff = d > 0x8F;
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+      // the bits above nb are already 0 = fill; pad with zero bytes
+      *o = (ui8)acc;
+      __m256i z = _mm256_setzero_si256();
+      _mm256_storeu_si256((__m256i*)(o + 1), z);
+      _mm256_storeu_si256((__m256i*)(o + 33), z);
+      return (ui32)(o - dst) + 1;
+    }
+
+    //************************************************************************/
+    /** @brief De-stuffs the VLC segment into a flat buffer
+     *
+     *  Performs the same initialization rev_init does -- the first byte
+     *  contributes only its upper 4 bits (3 bits if its lower 3 bits are
+     *  all 1s) -- then de-stuffs the remaining scup - 2 bytes backward;
+     *  see destuff_rev.
+     *
+     *  @param [in]  data is a pointer to byte at the start of the cleanup
+     *               pass
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  scup is the length of MEL+VLC segments
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch64
+     */
+    static inline
+    ui32 destuff_vlc(const ui8* data, int lcup, int scup,
+                     ui8* dst, ui32 cap)
+    {
+      const ui8* p = data + lcup - 2;
+      ui32 d = *p; // first byte, only the upper 4 bits are used
+      ui64 acc = d >> 4;
+      ui32 nb = 4 - ((acc & 7) == 7); // check standard
+      bool unstuff = (d | 0xF) > 0x8F;
+      return destuff_rev(p - 1, scup - 2, unstuff, acc, nb, dst, cap);
+    }
+
+    //************************************************************************/
+    /** @brief De-stuffs the MRP segment into a flat buffer
+     *
+     *  Performs the same initialization rev_init_mrp does -- reading
+     *  starts at the last byte of the SPP+MRP segments with the unstuff
+     *  state set -- then de-stuffs backward; see destuff_rev.
+     *
+     *  @param [in]  data is a pointer to byte at the start of the cleanup
+     *               pass
+     *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
+     *  @param [in]  len2 is the length of SPP+MRP segments
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch64
+     */
+    static inline
+    ui32 destuff_mrp(const ui8* data, int lcup, int len2,
+                     ui8* dst, ui32 cap)
+    {
+      return destuff_rev(data + lcup + len2 - 1, len2, true, 0, 0,
+                         dst, cap);
+    }
+
+    //************************************************************************/
+    /** @brief decodes twos consecutive quads (one octet), using 32 bit data
+     *
+     *  @param inf_u_q  decoded VLC code, with interleaved u values
+     *  @param U_q      U values
+     *  @param magsgn   structure for forward data buffer
+     *  @param p        bitplane at which we are decoding
+     *  @param vn       used for handling E values (stores v_n values)
+     *  @return __m256i decoded two quads
+     */
+    OJPH_FORCE_INLINE
+    __m256i decode_two_quad32_avx2(__m256i inf_u_q, __m256i U_q,
+                                   const ui8* dbuf, ui32 limit, ui32& pos,
+                                   ui32 p, __m128i& vn) {
+        __m256i row = _mm256_setzero_si256();
+
+        // we keeps e_k, e_1, and rho in w2
+        __m256i flags = _mm256_and_si256(inf_u_q, _mm256_set_epi32(0x8880, 0x4440, 0x2220, 0x1110, 0x8880, 0x4440, 0x2220, 0x1110));
+        __m256i insig = _mm256_cmpeq_epi32(flags, _mm256_setzero_si256());
+
+        if ((uint32_t)_mm256_movemask_epi8(insig) != (uint32_t)0xFFFFFFFF) //are all insignificant?
         {
-            dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
-                           k(0), num_runs(0), runs(0)
+            flags = _mm256_mullo_epi16(flags, _mm256_set_epi16(1, 1, 2, 2, 4, 4, 8, 8, 1, 1, 2, 2, 4, 4, 8, 8));
+
+            // U_q holds U_q for this quad
+            // flags has e_k, e_1, and rho such that e_k is sitting in the
+            // 0x8000, e_1 in 0x800, and rho in 0x80
+
+            // next e_k and m_n
+            __m256i m_n;
+            __m256i w0 = _mm256_srli_epi32(flags, 15); // e_k
+            m_n = _mm256_sub_epi32(U_q, w0);
+            m_n = _mm256_andnot_si256(insig, m_n);
+
+            // find cumulative sums
+            // to find at which bit in ms_vec the sample starts
+            __m256i inc_sum = m_n; // inclusive scan
+            inc_sum = _mm256_add_epi32(inc_sum, _mm256_bslli_epi128(inc_sum, 4));
+            inc_sum = _mm256_add_epi32(inc_sum, _mm256_bslli_epi128(inc_sum, 8));
+            ui32 total_mn1 = (ui32)_mm256_extract_epi16(inc_sum, 6);
+            ui32 total_mn2 = (ui32)_mm256_extract_epi16(inc_sum, 14);
+
+            __m128i ms_vec0 = dfetch(dbuf, limit, pos);
+            __m128i ms_vec1 = dfetch(dbuf, limit, pos + total_mn1);
+            pos += total_mn1 + total_mn2;
+
+            __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
+
+            __m256i ex_sum = _mm256_bslli_epi128(inc_sum, 4); // exclusive scan
+
+            // find the starting byte and starting bit
+            __m256i byte_idx = _mm256_srli_epi32(ex_sum, 3);
+            __m256i bit_idx = _mm256_and_si256(ex_sum, _mm256_set1_epi32(7));
+            byte_idx = _mm256_shuffle_epi8(byte_idx,
+                _mm256_set_epi32(0x0C0C0C0C, 0x08080808, 0x04040404, 0x00000000, 0x0C0C0C0C, 0x08080808, 0x04040404, 0x00000000));
+            byte_idx = _mm256_add_epi32(byte_idx, _mm256_set1_epi32(0x03020100));
+            __m256i d0 = _mm256_shuffle_epi8(ms_vec, byte_idx);
+            byte_idx = _mm256_add_epi32(byte_idx, _mm256_set1_epi32(0x01010101));
+            __m256i d1 = _mm256_shuffle_epi8(ms_vec, byte_idx);
+
+            // shift samples values to correct location
+            bit_idx = _mm256_or_si256(bit_idx, _mm256_slli_epi32(bit_idx, 16));
+
+            __m128i a = _mm_set_epi8(1, 3, 7, 15, 31, 63, 127, -1, 1, 3, 7, 15, 31, 63, 127, -1);
+            __m256i aa = _mm256_inserti128_si256(_mm256_castsi128_si256(a), a, 0x1);
+
+            __m256i bit_shift = _mm256_shuffle_epi8(aa, bit_idx);
+            bit_shift = _mm256_add_epi16(bit_shift, _mm256_set1_epi16(0x0101));
+            d0 = _mm256_mullo_epi16(d0, bit_shift);
+            d0 = _mm256_srli_epi16(d0, 8); // we should have 8 bits in the LSB
+            d1 = _mm256_mullo_epi16(d1, bit_shift);
+            d1 = _mm256_and_si256(d1, _mm256_set1_epi32((si32)0xFF00FF00)); // 8 in MSB
+            d0 = _mm256_or_si256(d0, d1);
+
+            // find location of e_k and mask
+            __m256i shift;
+            __m256i ones = _mm256_set1_epi32(1);
+            __m256i twos = _mm256_set1_epi32(2);
+            __m256i U_q_m1 = _mm256_sub_epi32(U_q, ones);
+            U_q_m1 = _mm256_and_si256(U_q_m1, _mm256_set_epi32(0, 0, 0, 0x1F, 0, 0, 0, 0x1F));
+            U_q_m1 = _mm256_shuffle_epi32(U_q_m1, 0);
+            w0 = _mm256_sub_epi32(twos, w0);
+            shift = _mm256_sllv_epi32(w0, U_q_m1); // U_q_m1 must be no more than 31
+            ms_vec = _mm256_and_si256(d0, _mm256_sub_epi32(shift, ones));
+
+            // next e_1
+            w0 = _mm256_and_si256(flags, _mm256_set1_epi32(0x800));
+            w0 = _mm256_cmpeq_epi32(w0, _mm256_setzero_si256());
+            w0 = _mm256_andnot_si256(w0, shift);  // e_1 in correct position
+            ms_vec = _mm256_or_si256(ms_vec, w0); // e_1
+            w0 = _mm256_slli_epi32(ms_vec, 31);   // sign
+            ms_vec = _mm256_or_si256(ms_vec, ones); // bin center
+            __m256i tvn = ms_vec;
+            ms_vec = _mm256_add_epi32(ms_vec, twos);// + 2
+            ms_vec = _mm256_slli_epi32(ms_vec, (si32)p - 1);
+            ms_vec = _mm256_or_si256(ms_vec, w0); // sign
+            row = _mm256_andnot_si256(insig, ms_vec); // significant only
+
+            ms_vec = _mm256_andnot_si256(insig, tvn); // significant only
+
+            tvn = _mm256_shuffle_epi8(ms_vec, _mm256_set_epi32(-1, 0x0F0E0D0C, 0x07060504, -1, -1, -1, 0x0F0E0D0C, 0x07060504));
+
+            vn = _mm_or_si128(vn, _mm256_castsi256_si128(tvn));
+            vn = _mm_or_si128(vn, _mm256_extracti128_si256(tvn, 0x1));
+        }
+        return row;
+    }
+
+
+   //************************************************************************/
+    /** @brief decodes twos consecutive quads (one octet), using 16 bit data
+     *
+     *  @param inf_u_q  decoded VLC code, with interleaved u values
+     *  @param U_q      U values
+     *  @param magsgn   structure for forward data buffer
+     *  @param p        bitplane at which we are decoding
+     *  @param vn       used for handling E values (stores v_n values)
+     *  @return __m128i decoded quad
+     */
+
+    OJPH_FORCE_INLINE
+    __m256i decode_four_quad16(const __m128i inf_u_q, __m128i U_q,
+                               const ui8* dbuf, ui32 limit, ui32& pos,
+                               ui32 p, __m128i& vn) {
+
+        __m256i w0;     // workers
+        __m256i insig;  // lanes hold FF's if samples are insignificant
+        __m256i flags;  // lanes hold e_k, e_1, and rho
+
+        __m256i row = _mm256_setzero_si256();
+        __m128i ddd = _mm_shuffle_epi8(inf_u_q,
+            _mm_set_epi16(0x0d0c, 0x0d0c, 0x0908, 0x908, 0x0504, 0x0504, 0x0100, 0x0100));
+        w0 = _mm256_permutevar8x32_epi32(_mm256_castsi128_si256(ddd),
+            _mm256_setr_epi32(0, 0, 1, 1, 2, 2, 3, 3));
+        // we keeps e_k, e_1, and rho in w2
+        flags = _mm256_and_si256(w0,
+            _mm256_set_epi16((si16)0x8880, 0x4440, 0x2220, 0x1110,
+                             (si16)0x8880, 0x4440, 0x2220, 0x1110,
+                             (si16)0x8880, 0x4440, 0x2220, 0x1110,
+                             (si16)0x8880, 0x4440, 0x2220, 0x1110));
+        insig = _mm256_cmpeq_epi16(flags, _mm256_setzero_si256());
+        if ((uint32_t)_mm256_movemask_epi8(insig) != (uint32_t)0xFFFFFFFF) //are all insignificant?
+        {
+            ddd = _mm_or_si128(_mm_bslli_si128(U_q, 2), U_q);
+            __m256i U_q_avx = _mm256_permutevar8x32_epi32(_mm256_castsi128_si256(ddd),
+                _mm256_setr_epi32(0, 0, 1, 1, 2, 2, 3, 3));
+            flags = _mm256_mullo_epi16(flags, _mm256_set_epi16(1, 2, 4, 8, 1, 2, 4, 8, 1, 2, 4, 8, 1, 2, 4, 8));
+
+            // U_q holds U_q for this quad
+            // flags has e_k, e_1, and rho such that e_k is sitting in the
+            // 0x8000, e_1 in 0x800, and rho in 0x80
+
+            // next e_k and m_n
+            __m256i m_n;
+            w0 = _mm256_srli_epi16(flags, 15); // e_k
+            m_n = _mm256_sub_epi16(U_q_avx, w0);
+            m_n = _mm256_andnot_si256(insig, m_n);
+
+            // find cumulative sums
+            // to find at which bit in ms_vec the sample starts
+            __m256i inc_sum = m_n; // inclusive scan
+            inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 2));
+            inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 4));
+            inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 8));
+            ui32 total_mn1 = (ui32)_mm256_extract_epi16(inc_sum, 7);
+            ui32 total_mn2 = (ui32)_mm256_extract_epi16(inc_sum, 15);
+            __m256i ex_sum = _mm256_bslli_epi128(inc_sum, 2); // exclusive scan
+
+            __m128i ms_vec0 = dfetch(dbuf, limit, pos);
+            __m128i ms_vec1 = dfetch(dbuf, limit, pos + total_mn1);
+            pos += total_mn1 + total_mn2;
+
+            __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
+
+            // find the starting byte and starting bit
+            __m256i byte_idx = _mm256_srli_epi16(ex_sum, 3);
+            __m256i bit_idx = _mm256_and_si256(ex_sum, _mm256_set1_epi16(7));
+            byte_idx = _mm256_shuffle_epi8(byte_idx,
+                _mm256_set_epi16(0x0E0E, 0x0C0C, 0x0A0A, 0x0808,
+                    0x0606, 0x0404, 0x0202, 0x0000, 0x0E0E, 0x0C0C, 0x0A0A, 0x0808,
+                    0x0606, 0x0404, 0x0202, 0x0000));
+            byte_idx = _mm256_add_epi16(byte_idx, _mm256_set1_epi16(0x0100));
+            __m256i d0 = _mm256_shuffle_epi8(ms_vec, byte_idx);
+            byte_idx = _mm256_add_epi16(byte_idx, _mm256_set1_epi16(0x0101));
+            __m256i d1 = _mm256_shuffle_epi8(ms_vec, byte_idx);
+
+            // shift samples values to correct location
+            __m256i bit_shift = _mm256_shuffle_epi8(
+                _mm256_set_epi8(1, 3, 7, 15, 31, 63, 127, -1,
+                    1, 3, 7, 15, 31, 63, 127, -1, 1, 3, 7, 15, 31, 63, 127, -1,
+                    1, 3, 7, 15, 31, 63, 127, -1), bit_idx);
+            bit_shift = _mm256_add_epi16(bit_shift, _mm256_set1_epi16(0x0101));
+            d0 = _mm256_mullo_epi16(d0, bit_shift);
+            d0 = _mm256_srli_epi16(d0, 8); // we should have 8 bits in the LSB
+            d1 = _mm256_mullo_epi16(d1, bit_shift);
+            d1 = _mm256_and_si256(d1, _mm256_set1_epi16((si16)0xFF00)); // 8 in MSB
+            d0 = _mm256_or_si256(d0, d1);
+
+            // find location of e_k and mask
+            __m256i shift;
+            __m256i ones = _mm256_set1_epi16(1);
+            __m256i twos = _mm256_set1_epi16(2);
+            // shift = (2 - e_k) << (U_q - 1); AVX2 has no _mm256_sllv_epi16,
+            // so the variable shift is emulated with a pshufb power-of-two
+            // lookup and a 16-bit multiply.  U_q - 1 <= 14 in this path;
+            // for U_q == 0 the lookup indices have their MSB set, so pshufb
+            // returns 0, the same shift value the former uniform 16-bit
+            // shift emulation produced (it shifted by 31)
+            __m256i kq = _mm256_sub_epi16(U_q_avx, ones);
+            __m256i idx = _mm256_or_si256(kq,
+                _mm256_slli_epi16(_mm256_sub_epi16(kq,
+                                            _mm256_set1_epi16(8)), 8));
+            const __m256i pow2_tbl = _mm256_setr_epi8(
+                1, 2, 4, 8, 16, 32, 64, (char)128, 0, 0, 0, 0, 0, 0, 0, 0,
+                1, 2, 4, 8, 16, 32, 64, (char)128, 0, 0, 0, 0, 0, 0, 0, 0);
+            __m256i pow2 = _mm256_shuffle_epi8(pow2_tbl, idx);
+            w0 = _mm256_sub_epi16(twos, w0);
+            shift = _mm256_mullo_epi16(w0, pow2);
+            ms_vec = _mm256_and_si256(d0, _mm256_sub_epi16(shift, ones));
+
+            // next e_1
+            w0 = _mm256_and_si256(flags, _mm256_set1_epi16(0x800));
+            w0 = _mm256_cmpeq_epi16(w0, _mm256_setzero_si256());
+            w0 = _mm256_andnot_si256(w0, shift);  // e_1 in correct position
+            ms_vec = _mm256_or_si256(ms_vec, w0); // e_1
+            w0 = _mm256_slli_epi16(ms_vec, 15);   // sign
+            ms_vec = _mm256_or_si256(ms_vec, ones); // bin center
+            __m256i tvn = ms_vec;
+            ms_vec = _mm256_add_epi16(ms_vec, twos);// + 2
+            ms_vec = _mm256_slli_epi16(ms_vec, (si32)p - 1);
+            ms_vec = _mm256_or_si256(ms_vec, w0); // sign
+            row = _mm256_andnot_si256(insig, ms_vec); // significant only
+
+            ms_vec = _mm256_andnot_si256(insig, tvn); // significant only
+
+            __m256i ms_vec_shuffle1 = _mm256_shuffle_epi8(ms_vec,
+                _mm256_set_epi16(-1, -1, -1, -1, 0x0706, 0x0302, -1, -1,
+                                 -1, -1, -1, -1, -1, -1, 0x0706, 0x0302));
+            __m256i ms_vec_shuffle2 = _mm256_shuffle_epi8(ms_vec,
+                _mm256_set_epi16(-1, -1, -1, 0x0F0E, 0x0B0A, -1, -1, -1,
+                                 -1, -1, -1, -1, -1, 0x0F0E, 0x0B0A, -1));
+            ms_vec = _mm256_or_si256(ms_vec_shuffle1, ms_vec_shuffle2);
+
+            vn = _mm_or_si128(vn, _mm256_castsi256_si128(ms_vec));
+            vn = _mm_or_si128(vn, _mm256_extracti128_si256(ms_vec, 0x1));
+        }
+        return row;
+    }
+
+    // https://stackoverflow.com/a/58827596
+    inline __m256i avx2_lzcnt_epi32(__m256i v) {
+        // prevent value from being rounded up to the next power of two
+        v = _mm256_andnot_si256(_mm256_srli_epi32(v, 8), v);  // keep 8 MSB
+
+        v = _mm256_castps_si256(_mm256_cvtepi32_ps(v));    // convert an integer to float
+        v = _mm256_srli_epi32(v, 23);                   // shift down the exponent
+        v = _mm256_subs_epu16(_mm256_set1_epi32(158), v);  // undo bias
+        v = _mm256_min_epi16(v, _mm256_set1_epi32(32));    // clamp at 32
+
+        return v;
+    }
+
+    //************************************************************************/
+    /** @brief Decodes one codeblock, processing the cleanup, siginificance
+     *         propagation, and magnitude refinement pass
+     *
+     *  @param [in]   coded_data is a pointer to bitstream
+     *  @param [in]   decoded_data is a pointer to decoded codeblock data buf.
+     *  @param [in]   missing_msbs is the number of missing MSBs
+     *  @param [in]   num_passes is the number of passes: 1 if CUP only,
+     *                2 for CUP+SPP, and 3 for CUP+SPP+MRP
+     *  @param [in]   lengths1 is the length of cleanup pass
+     *  @param [in]   lengths2 is the length of refinement passes (either SPP
+     *                only or SPP+MRP)
+     *  @param [in]   width is the decoded codeblock width
+     *  @param [in]   height is the decoded codeblock height
+     *  @param [in]   stride is the decoded codeblock buffer stride
+     *  @param [in]   stripe_causal is true for stripe causal mode
+     */
+    //************************************************************************/
+    /** @brief Step-2 MagSgn decode for the 16-bit (4-quad) path.
+     *
+     *  Outlined into its own function so that decode_four_quad16 can be
+     *  force-inlined here without inflating register pressure in the
+     *  much larger ojph_decode_codeblock_avx2 (which also hosts the
+     *  mutually-exclusive 32-bit step-2 path). Returns false on a
+     *  precision-overflow error, true otherwise.
+     */
+    OJPH_NO_INLINE
+    bool decode_cb_step2_16bit(ui16* scratch, ui32* decoded_data,
+                               ui8* coded_data, ui32 width, ui32 height,
+                               ui32 stride, ui32 sstr, ui32 p, ui32 mmsbp2,
+                               int lcup, int scup)
+    {
+        // reduce bitplane by 16 because we now have 16 bits instead of 32
+        p -= 16;
+
+        const int v_n_size = 512 + 16;
+#ifdef __MINGW64__
+        ui16 v_n_scratch[v_n_size] = {0};
+        ui32 v_n_scratch_32[v_n_size] = {0};
+#else
+        ui16 v_n_scratch[v_n_size];
+        memset(v_n_scratch + (width >> 1) + 4, 0, 8 * sizeof(ui16));
+        ui32 v_n_scratch_32[v_n_size];
+#endif
+
+        // maximum consumable MagSgn bits: 4096 samples x (mmsbp2 < 16) bits
+        const ui32 dbuf_cap = 4096 * 15 / 8;
+        ui8 dbuf[dbuf_cap + 72];
+        ui32 limit = destuff_frwd<0xFF>(coded_data, lcup - scup, dbuf, dbuf_cap);
+        ui32 pos = 0;
+
+        {
+          ui16 *sp = scratch;
+          ui16 *vp = v_n_scratch;
+          ui32 *dp = decoded_data;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8) {
+              ////process four quads
+              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
+              __m128i U_q = _mm_srli_epi32(inf_u_q, 16);
+              __m128i w = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
+              if (!_mm_testz_si128(w, w)) {
+                  return false;
+              }
+
+              __m128i vn = _mm_set1_epi16(2);
+              __m256i row = decode_four_quad16(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+
+              w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
+              _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
+
+              __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
+              __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
+
+              _mm256_storeu_si256((__m256i*)dp, w0);
+              _mm256_storeu_si256((__m256i*)(dp + stride), w1);
+          }
+        }
+
+        for (ui32 y = 2; y < height; y += 2) {
+          {
+            // perform 15 - count_leading_zeros(*vp) here
+            ui16 *vp = v_n_scratch;
+            ui32 *vp_32 = v_n_scratch_32;
+
+            ui16* sp = scratch + (y >> 1) * sstr;
+            const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
+            const __m256i avx_31 = _mm256_set1_epi32(31);
+            const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
+            const __m256i avx_1 = _mm256_set1_epi32(1);
+            const __m256i avx_0 = _mm256_setzero_si256();
+
+            for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16, vp_32 += 8) {
+              __m128i v = _mm_loadu_si128((__m128i*)vp);
+              __m128i v_p1 = _mm_loadu_si128((__m128i*)(vp + 1));
+              v = _mm_or_si128(v, v_p1);
+
+              __m256i v_avx = _mm256_cvtepu16_epi32(v);
+              v_avx = avx2_lzcnt_epi32(v_avx);
+              v_avx = _mm256_sub_epi32(avx_31, v_avx);
+
+              __m256i inf_u_q = _mm256_loadu_si256((__m256i*)sp);
+              __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
+              __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
+              gamma = _mm256_and_si256(gamma, w0);
+              gamma = _mm256_cmpeq_epi32(gamma, avx_0);
+
+              v_avx = _mm256_andnot_si256(gamma, v_avx);
+              v_avx = _mm256_max_epi32(v_avx, avx_1);
+
+              inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
+              v_avx = _mm256_add_epi32(inf_u_q, v_avx);
+
+              w0 = _mm256_cmpgt_epi32(v_avx, avx_mmsbp2);
+              if (!_mm256_testz_si256(w0, w0)) {
+                  return false;
+              }
+
+              _mm256_storeu_si256((__m256i*)vp_32, v_avx);
+            }
+          }
+
+          ui16 *vp = v_n_scratch;
+          ui32* vp_32 = v_n_scratch_32;
+          ui16 *sp = scratch + (y >> 1) * sstr;
+          ui32 *dp = decoded_data + y * stride;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8, vp_32 += 4) {
+            ////process four quads
+              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
+              __m128i U_q = _mm_loadu_si128((__m128i*)vp_32);
+
+            __m128i vn = _mm_set1_epi16(2);
+            __m256i row = decode_four_quad16(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+
+            __m128i w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
+            _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
+
+            __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
+            __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
+
+            _mm256_storeu_si256((__m256i*)dp, w0);
+            _mm256_storeu_si256((__m256i*)(dp + stride), w1);
+          }
+        }
+        return true;
+    }
+
+    //************************************************************************/
+    /** @brief Step-2 MagSgn decode for the 32-bit (2-quad) path.
+     *
+     *  Outlined for the same reason as decode_cb_step2_16bit: it keeps the
+     *  always-inlined decode_two_quad32_avx2 kernel in its own register
+     *  allocation scope, isolated from step-1 and from the 16-bit path.
+     *  Returns false on a precision-overflow error, true otherwise.
+     */
+    OJPH_NO_INLINE
+    bool decode_cb_step2_32bit(ui16* scratch, ui32* decoded_data,
+                               ui8* coded_data, ui32 width, ui32 height,
+                               ui32 stride, ui32 sstr, ui32 p, ui32 mmsbp2,
+                               int lcup, int scup)
+    {
+        const int v_n_size = 512 + 16;
+#ifdef __MINGW64__
+        ui32 v_n_scratch[2 * v_n_size] = {0};
+#else
+        ui32 v_n_scratch[2 * v_n_size];
+        memset(v_n_scratch + (width >> 1) + 2, 0, 14 * sizeof(ui32));
+#endif
+
+        // maximum consumable MagSgn bits: 4096 samples x (mmsbp2 <= 32) bits
+        const ui32 dbuf_cap = 4096 * 32 / 8;
+        ui8 dbuf[dbuf_cap + 72];
+        ui32 limit = destuff_frwd<0xFF>(coded_data, lcup - scup, dbuf, dbuf_cap);
+        ui32 pos = 0;
+
+        const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
+
+        {
+          ui16 *sp = scratch;
+          ui32 *vp = v_n_scratch;
+          ui32 *dp = decoded_data;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
+          {
+            __m128i vn = _mm_set1_epi32(2);
+
+            __m256i inf_u_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)sp));
+            inf_u_q = _mm256_permutevar8x32_epi32(inf_u_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
+
+            __m256i U_q = _mm256_srli_epi32(inf_u_q, 16);
+            __m256i w = _mm256_cmpgt_epi32(U_q, avx_mmsbp2);
+            if (!_mm256_testz_si256(w, w)) {
+                return false;
+            }
+
+            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+            row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            _mm_store_si128((__m128i*)dp, _mm256_castsi256_si128(row));
+            _mm_store_si128((__m128i*)(dp + stride), _mm256_extracti128_si256(row, 0x1));
+
+            __m128i w0 = _mm_cvtsi32_si128(*(int const*)vp);
+            w0 = _mm_or_si128(w0, vn);
+            _mm_storeu_si128((__m128i*)vp, w0);
+          }
+        }
+
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          {
+            // perform 31 - count_leading_zeros(*vp) here
+            ui32 *vp = v_n_scratch;
+            ui16* sp = scratch + (y >> 1) * sstr;
+
+            const __m256i avx_31 = _mm256_set1_epi32(31);
+            const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
+            const __m256i avx_1 = _mm256_set1_epi32(1);
+            const __m256i avx_0 = _mm256_setzero_si256();
+
+            for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16) {
+              __m256i v = _mm256_loadu_si256((__m256i*)vp);
+              __m256i v_p1 = _mm256_loadu_si256((__m256i*)(vp + 1));
+              v = _mm256_or_si256(v, v_p1);
+              v = avx2_lzcnt_epi32(v);
+              v = _mm256_sub_epi32(avx_31, v);
+
+              __m256i inf_u_q = _mm256_loadu_si256((__m256i*)sp);
+              __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
+              __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
+              gamma = _mm256_and_si256(gamma, w0);
+              gamma = _mm256_cmpeq_epi32(gamma, avx_0);
+
+              v = _mm256_andnot_si256(gamma, v);
+              v = _mm256_max_epi32(v, avx_1);
+
+              inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
+              v = _mm256_add_epi32(inf_u_q, v);
+
+              w0 = _mm256_cmpgt_epi32(v, avx_mmsbp2);
+              if (!_mm256_testz_si256(w0, w0)) {
+                  return false;
+              }
+
+              _mm256_storeu_si256((__m256i*)(vp + v_n_size), v);
+            }
+          }
+
+          ui32 *vp = v_n_scratch;
+          ui16 *sp = scratch + (y >> 1) * sstr;
+          ui32 *dp = decoded_data + y * stride;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4) {
+            //process two quads
+            __m128i vn = _mm_set1_epi32(2);
+
+            __m256i inf_u_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)sp));
+            inf_u_q = _mm256_permutevar8x32_epi32(inf_u_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
+
+            __m256i U_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)(vp + v_n_size)));
+            U_q = _mm256_permutevar8x32_epi32(U_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
+
+            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+            row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            _mm_store_si128((__m128i*)dp, _mm256_castsi256_si128(row));
+            _mm_store_si128((__m128i*)(dp + stride), _mm256_extracti128_si256(row, 0x1));
+
+            __m128i w0 = _mm_cvtsi32_si128(*(int const*)vp);
+            w0 = _mm_or_si128(w0, vn);
+            _mm_storeu_si128((__m128i*)vp, w0);
+          }
+        }
+        return true;
+    }
+
+    //************************************************************************/
+    /** @brief Significance-Propagation and Magnitude-Refinement passes.
+     *
+     *  Outlined from ojph_decode_codeblock_avx2 so the (lossless cleanup-only)
+     *  common path does not pay the register-allocation cost of this ~375-line
+     *  block. Only runs when num_passes > 1.
+     */
+    OJPH_NO_INLINE
+    void decode_cb_spp_mrp(ui16* scratch, ui32* decoded_data, ui8* coded_data,
+                           ui32 width, ui32 height, ui32 stride, ui32 sstr,
+                           ui32 p, ui32 num_passes, ui32 lengths1,
+                           ui32 lengths2, bool stripe_causal)
+    {
+        // We use scratch again, we can divide it into multiple regions
+        // sigma holds all the significant samples, and it cannot
+        // be modified after it is set.  it will be used during the
+        // Magnitude Refinement Pass
+        ui16* const sigma = scratch;
+
+        ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
+                                         // ui16 contains 4 columns
+        mstr = ((mstr + 2u) + 7u) & ~7u; // multiples of 8
+
+        // We re-arrange quad significance, where each 4 consecutive
+        // bits represent one quad, into column significance, where,
+        // each 4 consequtive bits represent one column of 4 rows
+        {
+          ui32 y;
+
+          const __m128i mask_3 = _mm_set1_epi32(0x30);
+          const __m128i mask_C = _mm_set1_epi32(0xC0);
+          const __m128i shuffle_mask = _mm_set_epi32(-1, -1, -1, 0x0C080400);
+          for (y = 0; y < height; y += 4)
+          {
+            ui16* sp = scratch + (y >> 1) * sstr;
+            ui16* dp = sigma + (y >> 2) * mstr;
+            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2)
             {
+              __m128i s0, s1, u3, uC, t0, t1;
+
+              s0 = _mm_loadu_si128((__m128i*)(sp));
+              u3 = _mm_and_si128(s0, mask_3);
+              u3 = _mm_srli_epi32(u3, 4);
+              uC = _mm_and_si128(s0, mask_C);
+              uC = _mm_srli_epi32(uC, 2);
+              t0 = _mm_or_si128(u3, uC);
+
+              s1 = _mm_loadu_si128((__m128i*)(sp + sstr));
+              u3 = _mm_and_si128(s1, mask_3);
+              u3 = _mm_srli_epi32(u3, 2);
+              uC = _mm_and_si128(s1, mask_C);
+              t1 = _mm_or_si128(u3, uC);
+
+              __m128i r = _mm_or_si128(t0, t1);
+              r = _mm_shuffle_epi8(r, shuffle_mask);
+
+              ui32 t = (ui32)_mm_extract_epi32(r, 0);
+              memcpy(dp, &t, 4);
             }
-            // data decoding machinery
-            ui8 *data;    //!< the address of data (or bitstream)
-            ui64 tmp;     //!< temporary buffer for read data
-            int bits;     //!< number of bits stored in tmp
-            int size;     //!< number of bytes in MEL code
-            bool unstuff; //!< true if the next bit needs to be unstuffed
-            int k;        //!< state of MEL decoder
+            dp[0] = 0; // set an extra entry on the right with 0
+          }
+          {
+            // reset one row after the codeblock
+            ui16* dp = sigma + (y >> 2) * mstr;
+            __m128i zero = _mm_setzero_si128();
+            for (ui32 x = 0; x < width; x += 32, dp += 8)
+              _mm_storeu_si128((__m128i*)dp, zero);
+            dp[0] = 0; // set an extra entry on the right with 0
+          }
+        }
 
-            // queue of decoded runs
-            int num_runs; //!< number of decoded runs left in runs (maximum 8)
-            ui64 runs;    //!< runs of decoded MEL codewords (7 bits/run)
-        };
-
-        //************************************************************************/
-        /** @brief Reads and unstuffs the MEL bitstream
-         *
-         *  This design needs more bytes in the codeblock buffer than the length
-         *  of the cleanup pass by up to 2 bytes.
-         *
-         *  Unstuffing removes the MSB of the byte following a byte whose
-         *  value is 0xFF; this prevents sequences larger than 0xFF7F in value
-         *  from appearing the bitstream.
-         *
-         *  @param [in]  melp is a pointer to dec_mel_st structure
-         */
-        static inline void mel_read(dec_mel_st *melp)
+        // We perform Significance Propagation Pass here
         {
-            if (melp->bits > 32) // there are enough bits in the tmp variable
-                return;          // return without reading new data
+          // This stores significance information of the previous
+          // 4 rows.  Significance information in this array includes
+          // all signicant samples in bitplane p - 1; that is,
+          // significant samples for bitplane p (discovered during the
+          // cleanup pass and stored in sigma) and samples that have recently
+          // became significant (during the SPP) in bitplane p-1.
+          // We store enough for the widest row, containing 1024 columns,
+          // which is equivalent to 256 of ui16, since each stores 4 columns.
+          // We add an extra 8 entries, just in case we need more
+          ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
 
-            ui32 val = 0xFFFFFFFF; // feed in 0xFF if buffer is exhausted
-            if (melp->size > 4)
-            {                              // if there is data in the MEL segment
-                val = *(ui32 *)melp->data; // read 32 bits from MEL data
-                melp->data += 4;           // advance pointer
-                melp->size -= 4;           // reduce counter
+          // maximum consumable SPP bits: 4096 samples x 2 bits (one
+          // significance bit and one sign bit per sample)
+          const ui32 spp_cap = 4096 * 2 / 8;
+          ui8 spp_buf[spp_cap + 72];
+          ui32 spp_limit = destuff_frwd<0>(coded_data + lengths1,
+                                           (int)lengths2, spp_buf, spp_cap);
+          ui32 spp_pos = 0;
+
+          for (ui32 y = 0; y < height; y += 4)
+          {
+            ui32 pattern = 0xFFFFu; // a pattern needed samples
+            if (height - y < 4) {
+              pattern = 0x7777u;
+              if (height - y < 3) {
+                pattern = 0x3333u;
+                if (height - y < 2)
+                  pattern = 0x1111u;
+              }
             }
-            else if (melp->size > 0)
-            { // 4 or less
-                int i = 0;
-                while (melp->size > 1)
+
+            // prev holds sign. info. for the previous quad, together
+            // with the rows on top of it and below it.
+            ui32 prev = 0;
+            ui16 *prev_sig = prev_row_sig;
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
+            ui32 *dpp = decoded_data + y * stride;
+            for (ui32 x = 0; x < width; x += 4, dpp += 4, ++cur_sig, ++prev_sig)
+            {
+              // only rows and columns inside the stripe are included
+              si32 s = (si32)x + 4 - (si32)width;
+              s = ojph_max(s, 0);
+              pattern = pattern >> (s * 4);
+
+              // We first find locations that need to be tested (potential
+              // SPP members); these location will end up in mbr
+              // In each iteration, we produce 16 bits because cwd can have
+              // up to 16 bits of significance information, followed by the
+              // corresponding 16 bits of sign information; therefore, it is
+              // sufficient to fetch 32 bit data per loop.
+
+              // Althougth we are interested in 16 bits only, we load 32 bits.
+              // For the 16 bits we are producing, we need the next 4 bits --
+              // We need data for at least 5 columns out of 8.
+              // Therefore loading 32 bits is easier than loading 16 bits
+              // twice.
+              ui32 ps, ns, cs;
+              memcpy(&ps, prev_sig, 4);
+              memcpy(&ns, cur_sig + mstr, 4);
+              ui32 u = (ps & 0x88888888) >> 3; // the row on top
+              if (!stripe_causal)
+                u |= (ns & 0x11111111) << 3;   // the row below
+
+              memcpy(&cs, cur_sig, 4);
+              // vertical integration
+              ui32 mbr =  cs;                // this sig. info.
+              mbr |= (cs & 0x77777777) << 1; //above neighbors
+              mbr |= (cs & 0xEEEEEEEE) >> 1; //below neighbors
+              mbr |= u;
+              // horizontal integration
+              ui32 t = mbr;
+              mbr |= t << 4;      // neighbors on the left
+              mbr |= t >> 4;      // neighbors on the right
+              mbr |= prev >> 12;  // significance of previous group
+
+              // remove outside samples, and already significant samples
+              mbr &= pattern;
+              mbr &= ~cs;
+
+              // find samples that become significant during the SPP
+              ui32 new_sig = mbr;
+              if (new_sig)
+              {
+                ui64 cwd = dfetch64(spp_buf, spp_limit, spp_pos);
+
+                ui32 cnt = 0;
+                ui32 col_mask = 0xFu;
+                ui32 inv_sig = ~cs & pattern;
+                for (int i = 0; i < 16; i += 4, col_mask <<= 4)
                 {
-                    ui32 v = *melp->data++;     // read one byte at a time
-                    ui32 m = ~(0xFFu << i);     // mask of location
-                    val = (val & m) | (v << i); // put one byte in its correct location
-                    --melp->size;
-                    i += 8;
+                  if ((col_mask & new_sig) == 0)
+                    continue;
+
+                  //scan one column
+                  ui32 sample_mask = 0x1111u & col_mask;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0x33u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0x76u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0xECu << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0xC8u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
                 }
-                // size equal to 1
-                ui32 v = *melp->data++; // the one before the last is different
-                v |= 0xF;               // MEL and VLC segments can overlap
-                ui32 m = ~(0xFFu << i);
-                val = (val & m) | (v << i);
-                --melp->size;
-            }
 
-            // next we unstuff them before adding them to the buffer
-            int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
-                                           // the previously read byte requires
-                                           // unstuffing
-
-            // data is unstuffed and accumulated in t
-            // bits has the number of bits in t
-            ui32 t = val & 0xFF;
-            bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
-            bits -= unstuff;                       // there is one less bit in t if unstuffing is needed
-            t = t << (8 - unstuff);                // move up to make room for the next byte
-
-            // this is a repeat of the above
-            t |= (val >> 8) & 0xFF;
-            unstuff = (((val >> 8) & 0xFF) == 0xFF);
-            bits -= unstuff;
-            t = t << (8 - unstuff);
-
-            t |= (val >> 16) & 0xFF;
-            unstuff = (((val >> 16) & 0xFF) == 0xFF);
-            bits -= unstuff;
-            t = t << (8 - unstuff);
-
-            t |= (val >> 24) & 0xFF;
-            melp->unstuff = (((val >> 24) & 0xFF) == 0xFF);
-
-            // move t to tmp, and push the result all the way up, so we read from
-            // the MSB
-            melp->tmp |= ((ui64)t) << (64 - bits - melp->bits);
-            melp->bits += bits; // increment the number of bits in tmp
-        }
-
-        //************************************************************************/
-        /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
-         *
-         *  Runs are stored in "runs" and the number of runs in "num_runs".
-         *  Each run represents a number of zero events that may or may not
-         *  terminate in a 1 event.
-         *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
-         *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating
-         *  with 1, contain the number of consecutive 0 zero events * 2; for the
-         *  case terminating with 0, they store (number of consecutive 0 zero
-         *  events - 1) * 2.
-         *  A total of 6 bits (made up of 1 + 5) should have been enough.
-         *
-         *  @param [in]  melp is a pointer to dec_mel_st structure
-         */
-        static inline void mel_decode(dec_mel_st *melp)
-        {
-            static const int mel_exp[13] = {// MEL exponents
-                                            0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5};
-
-            if (melp->bits < 6) // if there are less than 6 bits in tmp
-                mel_read(melp); // then read from the MEL bitstream
-                                // 6 bits is the largest decodable MEL cwd
-
-            // repeat so long that there is enough decodable bits in tmp,
-            //  and the runs store is not full (num_runs < 8)
-            while (melp->bits >= 6 && melp->num_runs < 8)
-            {
-                int eval = mel_exp[melp->k]; // number of bits associated with state
-                int run = 0;
-                if (melp->tmp & (1ull << 63)) // The next bit to decode (stored in MSB)
-                {                             // one is found
-                    run = 1 << eval;
-                    run--;                                         // consecutive runs of 0 events - 1
-                    melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12; // increment, max is 12
-                    melp->tmp <<= 1;                               // consume one bit from tmp
-                    melp->bits -= 1;
-                    run = run << 1; // a stretch of zeros not terminating in one
-                }
-                else
-                { // 0 is found
-                    run = (int)(melp->tmp >> (63 - eval)) & ((1 << eval) - 1);
-                    melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; // decrement, min is 0
-                    melp->tmp <<= eval + 1;                      // consume eval + 1 bits (max is 6)
-                    melp->bits -= eval + 1;
-                    run = (run << 1) + 1; // a stretch of zeros terminating with one
-                }
-                eval = melp->num_runs * 7;           // 7 bits per run
-                melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
-                melp->runs |= ((ui64)run) << eval;   // store the value in runs
-                melp->num_runs++;                    // increment count
-            }
-        }
-
-        //************************************************************************/
-        /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
-         *         some bytes in order to get the read address to a multiple
-         *         of 4
-         *
-         *  @param [in]  melp is a pointer to dec_mel_st structure
-         *  @param [in]  bbuf is a pointer to byte buffer
-         *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-         *  @param [in]  scup is the length of MEL+VLC segments
-         */
-        static inline void mel_init(dec_mel_st *melp, ui8 *bbuf, int lcup, int scup)
-        {
-            melp->data = bbuf + lcup - scup; // move the pointer to the start of MEL
-            melp->bits = 0;                  // 0 bits in tmp
-            melp->tmp = 0;                   //
-            melp->unstuff = false;           // no unstuffing
-            melp->size = scup - 1;           // size is the length of MEL+VLC-1
-            melp->k = 0;                     // 0 for state
-            melp->num_runs = 0;              // num_runs is 0
-            melp->runs = 0;                  //
-
-            // This code is borrowed; original is for a different architecture
-            // These few lines take care of the case where data is not at a multiple
-            //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
-            int num = 4 - (int)(intptr_t(melp->data) & 0x3);
-            for (int i = 0; i < num; ++i)
-            { // this code is similar to mel_read
-                assert(melp->unstuff == false || melp->data[0] <= 0x8F);
-                ui64 d = (melp->size > 0) ? *melp->data : 0xFF; // if buffer is consumed
-                                                                // set data to 0xFF
-                if (melp->size == 1)
-                    d |= 0xF; // if this is MEL+VLC-1, set LSBs to 0xF
-                              //  see the standard
-                melp->data += melp->size-- > 0;        // increment if the end is not reached
-                int d_bits = 8 - melp->unstuff;        // if unstuffing is needed, reduce by 1
-                melp->tmp = (melp->tmp << d_bits) | d; // store bits in tmp
-                melp->bits += d_bits;                  // increment tmp by number of bits
-                melp->unstuff = ((d & 0xFF) == 0xFF);  // true of next byte needs
-                                                      // unstuffing
-            }
-            melp->tmp <<= (64 - melp->bits); // push all the way up so the first bit
-                                             //  is the MSB
-        }
-
-        //************************************************************************/
-        /** @brief Retrieves one run from dec_mel_st; if there are no runs stored
-         *         MEL segment is decoded
-         *
-         * @param [in]  melp is a pointer to dec_mel_st structure
-         */
-        static inline int mel_get_run(dec_mel_st *melp)
-        {
-            if (melp->num_runs == 0) // if no runs, decode more bit from MEL segment
-                mel_decode(melp);
-
-            int t = melp->runs & 0x7F; // retrieve one run
-            melp->runs >>= 7;          // remove the retrieved run
-            melp->num_runs--;
-            return t; // return run
-        }
-
-        //************************************************************************/
-        /** @brief A structure for reading and unstuffing a segment that grows
-         *         backward, such as VLC and MRP
-         */
-        struct rev_struct
-        {
-            rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
-            {
-            }
-            // storage
-            ui8 *data;    //!< pointer to where to read data
-            ui64 tmp;     //!< temporary buffer of read data
-            ui32 bits;    //!< number of bits stored in tmp
-            int size;     //!< number of bytes left
-            bool unstuff; //!< true if the last byte is more than 0x8F
-                          //!< then the current byte is unstuffed if it is 0x7F
-        };
-
-        //************************************************************************/
-        /** @brief Read and unstuff data from a backwardly-growing segment
-         *
-         *  This reader can read up to 8 bytes from before the VLC segment.
-         *  Care must be taken not read from unreadable memory, causing a
-         *  segmentation fault.
-         *
-         *  Note that there is another subroutine rev_read_mrp that is slightly
-         *  different.  The other one fills zeros when the buffer is exhausted.
-         *  This one basically does not care if the bytes are consumed, because
-         *  any extra data should not be used in the actual decoding.
-         *
-         *  Unstuffing is needed to prevent sequences more than 0xFF8F from
-         *  appearing in the bits stream; since we are reading backward, we keep
-         *  watch when a value larger than 0x8F appears in the bitstream.
-         *  If the byte following this is 0x7F, we unstuff this byte (ignore the
-         *  MSB of that byte, which should be 0).
-         *
-         *  @param [in]  vlcp is a pointer to rev_struct structure
-         */
-        static inline void rev_read(rev_struct *vlcp)
-        {
-            // process 4 bytes at a time
-            if (vlcp->bits > 32) // if there are more than 32 bits in tmp, then
-                return;          // reading 32 bits can overflow vlcp->tmp
-            ui32 val = 0;
-            // the next line (the if statement) needs to be tested first
-            if (vlcp->size > 3) // if there are more than 3 bytes left in VLC
-            {
-                // (vlcp->data - 3) move pointer back to read 32 bits at once
-                val = *(ui32 *)(vlcp->data - 3); // then read 32 bits
-                vlcp->data -= 4;                 // move data pointer back by 4
-                vlcp->size -= 4;                 // reduce available byte by 4
-            }
-            else if (vlcp->size > 0)
-            { // 4 or less
-                int i = 24;
-                while (vlcp->size > 0)
+                if (new_sig)
                 {
-                    ui32 v = *vlcp->data--; // read one byte at a time
-                    val |= (v << i);        // put byte in its correct location
-                    --vlcp->size;
-                    i -= 8;
+                  // the sign bits sit right after the cnt consumed bits
+                  // of cwd; no reassembly is needed
+
+                  // Spread new_sig, such that each bit is in one byte with a
+                  // value of 0 if new_sig bit is 0, and 0xFF if new_sig is 1
+                  __m128i new_sig_vec = _mm_set1_epi16((si16)new_sig);
+                  new_sig_vec = _mm_shuffle_epi8(new_sig_vec,
+                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                  new_sig_vec = _mm_and_si128(new_sig_vec,
+                    _mm_set1_epi64x((si64)0x8040201008040201));
+                  new_sig_vec = _mm_cmpeq_epi8(new_sig_vec,
+                    _mm_set1_epi64x((si64)0x8040201008040201));
+
+                  // find cumulative sums
+                  // to find which bit in cwd we should extract
+                  __m128i inc_sum = new_sig_vec; // inclusive scan
+                  inc_sum = _mm_abs_epi8(inc_sum); // cvrt to 0 or 1
+                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
+                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
+                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
+                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
+                  cnt += (ui32)_mm_extract_epi16(inc_sum, 7) >> 8;
+                  // exclusive scan
+                  __m128i ex_sum = _mm_bslli_si128(inc_sum, 1);
+
+                  // Spread cwd, such that each bit is in one byte
+                  // with a value of 0 or 1.
+                  __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
+                  cwd_vec = _mm_shuffle_epi8(cwd_vec,
+                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                  cwd_vec = _mm_and_si128(cwd_vec,
+                    _mm_set1_epi64x((si64)0x8040201008040201));
+                  cwd_vec = _mm_cmpeq_epi8(cwd_vec,
+                    _mm_set1_epi64x((si64)0x8040201008040201));
+                  cwd_vec = _mm_abs_epi8(cwd_vec);
+
+                  // Obtain bit from cwd_vec correspondig to ex_sum
+                  // Basically, collect needed bits from cwd_vec
+                  __m128i v = _mm_shuffle_epi8(cwd_vec, ex_sum);
+
+                  // load data and set spp coefficients
+                  __m128i m =
+                    _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
+                  __m128i val = _mm_set1_epi32(3 << (p - 2));
+                  ui32 *dp = dpp;
+                  for (int c = 0; c < 4; ++ c) {
+                    __m128i s0, s0_ns, s0_val;
+                    // load coefficients
+                    s0 = _mm_load_si128((__m128i*)dp);
+
+                    // epi32 is -1 only for coefficient that
+                    // are changed during the SPP
+                    s0_ns = _mm_shuffle_epi8(new_sig_vec, m);
+                    s0_ns = _mm_cmpeq_epi32(s0_ns, _mm_set1_epi32(0xFF));
+
+                    // obtain sign for coefficients in SPP
+                    s0_val = _mm_shuffle_epi8(v, m);
+                    s0_val = _mm_slli_epi32(s0_val, 31);
+                    s0_val = _mm_or_si128(s0_val, val);
+                    s0_val = _mm_and_si128(s0_val, s0_ns);
+
+                    // update vector
+                    s0 = _mm_or_si128(s0, s0_val);
+                    // store coefficients
+                    _mm_store_si128((__m128i*)dp, s0);
+                    // prepare for next row
+                    dp += stride;
+                    m = _mm_add_epi32(m, _mm_set1_epi32(1));
+                  }
                 }
+                spp_pos += cnt;
+              }
+
+              new_sig |= cs;
+              *prev_sig = (ui16)(new_sig);
+
+              // vertical integration for the new sig. info.
+              t = new_sig;
+              new_sig |= (t & 0x7777) << 1; //above neighbors
+              new_sig |= (t & 0xEEEE) >> 1; //below neighbors
+              // add sig. info. from the row on top and below
+              prev = new_sig | u;
+              // we need only the bits in 0xF000
+              prev &= 0xF000;
             }
-
-            __m128i tmp_vec = _mm_set1_epi32((int32_t)val);
-            tmp_vec = _mm_srlv_epi32(tmp_vec, _mm_setr_epi32(24, 16, 8, 0));
-            tmp_vec = _mm_and_si128(tmp_vec, _mm_set1_epi32(0xff));
-
-            __m128i unstuff_vec = _mm_cmpgt_epi32(tmp_vec, _mm_set1_epi32(0x8F));
-            bool unstuff_next = _mm_extract_epi32(unstuff_vec, 3);
-            unstuff_vec = _mm_slli_si128(unstuff_vec, 4);
-            unstuff_vec = _mm_insert_epi32(unstuff_vec, vlcp->unstuff * 0xffffffff, 0);
-
-            __m128i val_7f = _mm_set1_epi32(0x7F);
-            __m128i this_byte_7f = _mm_cmpeq_epi32(_mm_and_si128(tmp_vec, val_7f), val_7f);
-            unstuff_vec = _mm_and_si128(unstuff_vec, this_byte_7f);
-            unstuff_vec = _mm_srli_epi32(unstuff_vec, 31);
-
-            __m128i inc_sum = _mm_sub_epi32(_mm_set1_epi32(8), unstuff_vec);
-            inc_sum = _mm_add_epi32(inc_sum, _mm_bslli_si128(inc_sum, 4));
-            inc_sum = _mm_add_epi32(inc_sum, _mm_bslli_si128(inc_sum, 8));
-            ui32 total_bits = (ui32)_mm_extract_epi32(inc_sum, 3);
-
-            __m128i final_shift = _mm_slli_si128(inc_sum, 4);
-            tmp_vec = _mm_sllv_epi32(tmp_vec, final_shift);
-            tmp_vec = _mm_or_si128(tmp_vec, _mm_bsrli_si128(tmp_vec, 8));
-
-            ui64 tmp = (ui32)_mm_cvtsi128_si32(tmp_vec) | (ui32)_mm_extract_epi32(tmp_vec, 1);
-
-            vlcp->unstuff = unstuff_next;
-            vlcp->tmp |= tmp << vlcp->bits;
-            vlcp->bits += total_bits;
+          }
         }
 
-        //************************************************************************/
-        /** @brief Initiates the rev_struct structure and reads a few bytes to
-         *         move the read address to multiple of 4
-         *
-         *  There is another similar rev_init_mrp subroutine.  The difference is
-         *  that this one, rev_init, discards the first 12 bits (they have the
-         *  sum of the lengths of VLC and MEL segments), and first unstuff depends
-         *  on first 4 bits.
-         *
-         *  @param [in]  vlcp is a pointer to rev_struct structure
-         *  @param [in]  data is a pointer to byte at the start of the cleanup pass
-         *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-         *  @param [in]  scup is the length of MEL+VLC segments
-         */
-        static inline void rev_init(rev_struct *vlcp, ui8 *data, int lcup, int scup)
+        // We perform Magnitude Refinement Pass here
+        if (num_passes > 2)
         {
-            // first byte has only the upper 4 bits
-            vlcp->data = data + lcup - 2;
+          // de-stuff the MRP segment; consumption is at most 1 bit per
+          // sample = 512 bytes, so 1024 bytes always suffice
+          const ui32 mrp_cap = 1024;
+          ui8 mrp_buf[mrp_cap + 72];
+          ui32 mrp_limit = destuff_mrp(coded_data, (int)lengths1,
+                                       (int)lengths2, mrp_buf, mrp_cap);
+          ui32 mrp_pos = 0;
 
-            // size can not be larger than this, in fact it should be smaller
-            vlcp->size = scup - 2;
-
-            ui32 d = *vlcp->data--;                  // read one byte (this is a half byte)
-            vlcp->tmp = d >> 4;                      // both initialize and set
-            vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); // check standard
-            vlcp->unstuff = (d | 0xF) > 0x8F;        // this is useful for the next byte
-
-            // This code is designed for an architecture that read address should
-            //  align to the read size (address multiple of 4 if read size is 4)
-            // These few lines take care of the case where data is not at a multiple
-            //  of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
-            //  To read 32 bits, read from (vlcp->data - 3)
-            int num = 1 + (int)(intptr_t(vlcp->data) & 0x3);
-            int tnum = num < vlcp->size ? num : vlcp->size;
-            for (int i = 0; i < tnum; ++i)
+          for (ui32 y = 0; y < height; y += 4)
+          {
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
+            ui32 *dpp = decoded_data + y * stride;
+            for (ui32 i = 0; i < width; i += 4, dpp += 4)
             {
-                ui64 d;
-                d = *vlcp->data--; // read one byte and move read pointer
-                // check if the last byte was >0x8F (unstuff == true) and this is 0x7F
-                ui32 d_bits = 8 - ((vlcp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-                vlcp->tmp |= d << vlcp->bits; // move data to vlcp->tmp
-                vlcp->bits += d_bits;
-                vlcp->unstuff = d > 0x8F; // for next byte
-            }
-            vlcp->size -= tnum;
-            rev_read(vlcp); // read another 32 buts
-        }
+              //Process one entry from sigma array at a time
+              // Each nibble (4 bits) in the sigma array represents 4 rows,
+              ui64 cwd = dfetch64(mrp_buf, mrp_limit, mrp_pos);
+              ui16 sig = *cur_sig++; // 16 bit that will be processed now
+              int total_bits = 0;
+              if (sig) // if any of the 32 bits are set
+              {
+                // We work on 4 rows, with 4 samples each, since
+                // data is 32 bit (4 bytes)
 
-        //************************************************************************/
-        /** @brief Retrieves 32 bits from the head of a rev_struct structure
-         *
-         *  By the end of this call, vlcp->tmp must have no less than 33 bits
-         *
-         *  @param [in]  vlcp is a pointer to rev_struct structure
-         */
-        static inline ui32 rev_fetch(rev_struct *vlcp)
-        {
-            if (vlcp->bits < 32) // if there are less then 32 bits, read more
-            {
-                rev_read(vlcp);      // read 32 bits, but unstuffing might reduce this
-                if (vlcp->bits < 32) // if there is still space in vlcp->tmp for 32 bits
-                    rev_read(vlcp);  // read another 32
-            }
-            return (ui32)vlcp->tmp; // return the head (bottom-most) of vlcp->tmp
-        }
-
-        //************************************************************************/
-        /** @brief Consumes num_bits from a rev_struct structure
-         *
-         *  @param [in]  vlcp is a pointer to rev_struct structure
-         *  @param [in]  num_bits is the number of bits to be removed
-         */
-        static inline ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
-        {
-            assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
-            vlcp->tmp >>= num_bits;         // remove bits
-            vlcp->bits -= num_bits;         // decrement the number of bits
-            return (ui32)vlcp->tmp;
-        }
-
-        //************************************************************************/
-        /** @brief Reads and unstuffs from rev_struct
-         *
-         *  This is different than rev_read in that this fills in zeros when the
-         *  the available data is consumed.  The other does not care about the
-         *  values when all data is consumed.
-         *
-         *  See rev_read for more information about unstuffing
-         *
-         *  @param [in]  mrp is a pointer to rev_struct structure
-         */
-        static inline void rev_read_mrp(rev_struct *mrp)
-        {
-            // process 4 bytes at a time
-            if (mrp->bits > 32)
-                return;
-            ui32 val = 0;
-            if (mrp->size > 3)                  // If there are 3 byte or more
-            {                                   // (mrp->data - 3) move pointer back to read 32 bits at once
-                val = *(ui32 *)(mrp->data - 3); // read 32 bits
-                mrp->data -= 4;                 // move back pointer
-                mrp->size -= 4;                 // reduce count
-            }
-            else if (mrp->size > 0)
-            {
-                int i = 24;
-                while (mrp->size > 0)
-                {
-                    ui32 v = *mrp->data--; // read one byte at a time
-                    val |= (v << i);       // put byte in its correct location
-                    --mrp->size;
-                    i -= 8;
-                }
-            }
-
-            // accumulate in tmp, and keep count in bits
-            ui32 bits, tmp = val >> 24;
-
-            // test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
-            bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
-            bool unstuff = (val >> 24) > 0x8F;
-
-            // process the next byte
-            tmp |= ((val >> 16) & 0xFF) << bits;
-            bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = ((val >> 16) & 0xFF) > 0x8F;
-
-            tmp |= ((val >> 8) & 0xFF) << bits;
-            bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = ((val >> 8) & 0xFF) > 0x8F;
-
-            tmp |= (val & 0xFF) << bits;
-            bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
-            unstuff = (val & 0xFF) > 0x8F;
-
-            mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
-            mrp->bits += bits;
-            mrp->unstuff = unstuff; // next byte
-        }
-
-        //************************************************************************/
-        /** @brief Initialized rev_struct structure for MRP segment, and reads
-         *         a number of bytes such that the next 32 bits read are from
-         *         an address that is a multiple of 4. Note this is designed for
-         *         an architecture that read size must be compatible with the
-         *         alignment of the read address
-         *
-         *  There is another similar subroutine rev_init.  This subroutine does
-         *  NOT skip the first 12 bits, and starts with unstuff set to true.
-         *
-         *  @param [in]  mrp is a pointer to rev_struct structure
-         *  @param [in]  data is a pointer to byte at the start of the cleanup pass
-         *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
-         *  @param [in]  len2 is the length of SPP+MRP segments
-         */
-        static inline void rev_init_mrp(rev_struct *mrp, ui8 *data, int lcup, int len2)
-        {
-            mrp->data = data + lcup + len2 - 1;
-            mrp->size = len2;
-            mrp->unstuff = true;
-            mrp->bits = 0;
-            mrp->tmp = 0;
-
-            // This code is designed for an architecture that read address should
-            //  align to the read size (address multiple of 4 if read size is 4)
-            // These few lines take care of the case where data is not at a multiple
-            //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
-            int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
-            for (int i = 0; i < num; ++i)
-            {
-                ui64 d;
-                // read a byte, 0 if no more data
-                d = (mrp->size-- > 0) ? *mrp->data-- : 0;
-                // check if unstuffing is needed
-                ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-                mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
-                mrp->bits += d_bits;
-                mrp->unstuff = d > 0x8F; // for next byte
-            }
-            rev_read_mrp(mrp);
-        }
-
-        //************************************************************************/
-        /** @brief Retrieves 32 bits from the head of a rev_struct structure
-         *
-         *  By the end of this call, mrp->tmp must have no less than 33 bits
-         *
-         *  @param [in]  mrp is a pointer to rev_struct structure
-         */
-        static inline ui32 rev_fetch_mrp(rev_struct *mrp)
-        {
-            if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
-            {
-                rev_read_mrp(mrp);     // read 30-32 bits from mrp
-                if (mrp->bits < 32)    // if there is a space of 32 bits
-                    rev_read_mrp(mrp); // read more
-            }
-            return (ui32)mrp->tmp; // return the head of mrp->tmp
-        }
-
-        //************************************************************************/
-        /** @brief Consumes num_bits from a rev_struct structure
-         *
-         *  @param [in]  mrp is a pointer to rev_struct structure
-         *  @param [in]  num_bits is the number of bits to be removed
-         */
-        inline ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
-        {
-            assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
-            mrp->tmp >>= num_bits;         // discard the lowest num_bits bits
-            mrp->bits -= num_bits;
-            return (ui32)mrp->tmp; // return data after consumption
-        }
-
-        //************************************************************************/
-        /** @brief State structure for reading and unstuffing of forward-growing
-         *         bitstreams; these are: MagSgn and SPP bitstreams
-         */
-        struct frwd_struct_avx2
-        {
-            const ui8 *data; //!< pointer to bitstream
-            ui8 tmp[48];     //!< temporary buffer of read data + 16 extra
-            ui32 bits;       //!< number of bits stored in tmp
-            ui32 unstuff;    //!< 1 if a bit needs to be unstuffed from next byte
-            int size;        //!< size of data
-        };
-
-        //************************************************************************/
-        /** @brief Read and unstuffs 16 bytes from forward-growing bitstream
-         *
-         *  A template is used to accommodate a different requirement for
-         *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
-         *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
-         *  X controls this value.
-         *
-         *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
-         *  in the compressed sequence.  So whenever a value of 0xFF is coded, the
-         *  MSB of the next byte is set 0 and must be ignored during decoding.
-         *
-         *  Reading can go beyond the end of buffer by up to 16 bytes.
-         *
-         *  @tparam       X is the value fed in when the bitstream is exhausted
-         *  @param  [in]  msp is a pointer to frwd_struct_avx2 structure
-         *
-         */
-        template <int X>
-        static inline void frwd_read(frwd_struct_avx2 *msp)
-        {
-            assert(msp->bits <= 128);
-
-            __m128i offset, val, validity, all_xff;
-            val = _mm_loadu_si128((__m128i *)msp->data);
-            int bytes = msp->size >= 16 ? 16 : msp->size;
-            validity = _mm_set1_epi8((char)bytes);
-            msp->data += bytes;
-            msp->size -= bytes;
-            int bits = 128;
-            offset = _mm_set_epi64x(0x0F0E0D0C0B0A0908, 0x0706050403020100);
-            validity = _mm_cmpgt_epi8(validity, offset);
-            all_xff = _mm_set1_epi8(-1);
-            if (X == 0xFF) // the compiler should remove this if statement
-            {
-                __m128i t = _mm_xor_si128(validity, all_xff); // complement
-                val = _mm_or_si128(t, val);                   // fill with 0xFF
-            }
-            else if (X == 0)
-                val = _mm_and_si128(validity, val); // fill with zeros
-            else
-                assert(0);
-
-            __m128i ff_bytes;
-            ff_bytes = _mm_cmpeq_epi8(val, all_xff);
-            ff_bytes = _mm_and_si128(ff_bytes, validity);
-            ui32 flags = (ui32)_mm_movemask_epi8(ff_bytes);
-            flags <<= 1; // unstuff following byte
-            ui32 next_unstuff = flags >> 16;
-            flags |= msp->unstuff;
-            flags &= 0xFFFF;
-            while (flags)
-            { // bit unstuffing occurs on average once every 256 bytes
-                // therefore it is not an issue if it is a bit slow
-                // here we process 16 bytes
-                --bits; // consuming one stuffing bit
-
-                ui32 loc = 31 - count_leading_zeros(flags);
-                flags ^= 1 << loc;
-
-                __m128i m, t, c;
-                t = _mm_set1_epi8((char)loc);
-                m = _mm_cmpgt_epi8(offset, t);
-
-                t = _mm_and_si128(m, val); // keep bits at locations larger than loc
-                c = _mm_srli_epi64(t, 1);  // 1 bits left
-                t = _mm_srli_si128(t, 8);  // 8 bytes left
-                t = _mm_slli_epi64(t, 63); // keep the MSB only
-                t = _mm_or_si128(t, c);    // combine the above 3 steps
-
-                val = _mm_or_si128(t, _mm_andnot_si128(m, val));
-            }
-
-            // combine with earlier data
-            assert(msp->bits >= 0 && msp->bits <= 128);
-            int cur_bytes = msp->bits >> 3;
-            int cur_bits = msp->bits & 7;
-            __m128i b1, b2;
-            b1 = _mm_sll_epi64(val, _mm_set1_epi64x(cur_bits));
-            b2 = _mm_slli_si128(val, 8); // 8 bytes right
-            b2 = _mm_srl_epi64(b2, _mm_set1_epi64x(64 - cur_bits));
-            b1 = _mm_or_si128(b1, b2);
-            b2 = _mm_loadu_si128((__m128i *)(msp->tmp + cur_bytes));
-            b2 = _mm_or_si128(b1, b2);
-            _mm_storeu_si128((__m128i *)(msp->tmp + cur_bytes), b2);
-
-            int consumed_bits = bits < 128 - cur_bits ? bits : 128 - cur_bits;
-            cur_bytes = (msp->bits + (ui32)consumed_bits + 7) >> 3; // round up
-            int upper = _mm_extract_epi16(val, 7);
-            upper >>= consumed_bits - 128 + 16;
-            msp->tmp[cur_bytes] = (ui8)upper; // copy byte
-
-            msp->bits += (ui32)bits;
-            msp->unstuff = next_unstuff; // next unstuff
-            assert(msp->unstuff == 0 || msp->unstuff == 1);
-        }
-
-        //************************************************************************/
-        /** @brief Initialize frwd_struct_avx2 struct and reads some bytes
-         *
-         *  @tparam      X is the value fed in when the bitstream is exhausted.
-         *               See frwd_read regarding the template
-         *  @param [in]  msp is a pointer to frwd_struct_avx2
-         *  @param [in]  data is a pointer to the start of data
-         *  @param [in]  size is the number of byte in the bitstream
-         */
-        template <int X>
-        static inline void frwd_init(frwd_struct_avx2 *msp, const ui8 *data, int size)
-        {
-            msp->data = data;
-            _mm_storeu_si128((__m128i *)msp->tmp, _mm_setzero_si128());
-            _mm_storeu_si128((__m128i *)msp->tmp + 1, _mm_setzero_si128());
-            _mm_storeu_si128((__m128i *)msp->tmp + 2, _mm_setzero_si128());
-
-            msp->bits = 0;
-            msp->unstuff = 0;
-            msp->size = size;
-
-            frwd_read<X>(msp); // read 128 bits more
-        }
-
-        //************************************************************************/
-        /** @brief Consume num_bits bits from the bitstream of frwd_struct_avx2
-         *
-         *  @param [in]  msp is a pointer to frwd_struct_avx2
-         *  @param [in]  num_bits is the number of bit to consume
-         */
-        static inline void frwd_advance(frwd_struct_avx2 *msp, ui32 num_bits)
-        {
-            assert(num_bits > 0 && num_bits <= msp->bits && num_bits < 128);
-            msp->bits -= num_bits;
-
-            __m128i *p = (__m128i *)(msp->tmp + ((num_bits >> 3) & 0x18));
-            num_bits &= 63;
-
-            __m128i v0, v1, c0, c1, t;
-            v0 = _mm_loadu_si128(p);
-            v1 = _mm_loadu_si128(p + 1);
-
-            // shift right by num_bits
-            c0 = _mm_srl_epi64(v0, _mm_set1_epi64x(num_bits));
-            t = _mm_srli_si128(v0, 8);
-            t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-            c0 = _mm_or_si128(c0, t);
-            t = _mm_slli_si128(v1, 8);
-            t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-            c0 = _mm_or_si128(c0, t);
-
-            _mm_storeu_si128((__m128i *)msp->tmp, c0);
-
-            c1 = _mm_srl_epi64(v1, _mm_set1_epi64x(num_bits));
-            t = _mm_srli_si128(v1, 8);
-            t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-            c1 = _mm_or_si128(c1, t);
-
-            _mm_storeu_si128((__m128i *)msp->tmp + 1, c1);
-        }
-
-        //************************************************************************/
-        /** @brief Fetches 32 bits from the frwd_struct_avx2 bitstream
-         *
-         *  @tparam      X is the value fed in when the bitstream is exhausted.
-         *               See frwd_read regarding the template
-         *  @param [in]  msp is a pointer to frwd_struct_avx2
-         */
-        template <int X>
-        static inline __m128i frwd_fetch(frwd_struct_avx2 *msp)
-        {
-            if (msp->bits <= 128)
-            {
-                frwd_read<X>(msp);
-                if (msp->bits <= 128) // need to test
-                    frwd_read<X>(msp);
-            }
-            __m128i t = _mm_loadu_si128((__m128i *)msp->tmp);
-            return t;
-        }
-
-        //************************************************************************/
-        /** @brief decodes twos consecutive quads (one octet), using 32 bit data
-         *
-         *  @param inf_u_q  decoded VLC code, with interleaved u values
-         *  @param U_q      U values
-         *  @param magsgn   structure for forward data buffer
-         *  @param p        bitplane at which we are decoding
-         *  @param vn       used for handling E values (stores v_n values)
-         *  @return __m256i decoded two quads
-         */
-        static inline __m256i decode_two_quad32_avx2(__m256i inf_u_q, __m256i U_q, frwd_struct_avx2 *magsgn, ui32 p, __m128i &vn)
-        {
-            __m256i row = _mm256_setzero_si256();
-
-            // we keeps e_k, e_1, and rho in w2
-            __m256i flags = _mm256_and_si256(inf_u_q, _mm256_set_epi32(0x8880, 0x4440, 0x2220, 0x1110, 0x8880, 0x4440, 0x2220, 0x1110));
-            __m256i insig = _mm256_cmpeq_epi32(flags, _mm256_setzero_si256());
-
-            if ((uint32_t)_mm256_movemask_epi8(insig) != (uint32_t)0xFFFFFFFF) // are all insignificant?
-            {
-                flags = _mm256_mullo_epi16(flags, _mm256_set_epi16(1, 1, 2, 2, 4, 4, 8, 8, 1, 1, 2, 2, 4, 4, 8, 8));
-
-                // U_q holds U_q for this quad
-                // flags has e_k, e_1, and rho such that e_k is sitting in the
-                // 0x8000, e_1 in 0x800, and rho in 0x80
-
-                // next e_k and m_n
-                __m256i m_n;
-                __m256i w0 = _mm256_srli_epi32(flags, 15); // e_k
-                m_n = _mm256_sub_epi32(U_q, w0);
-                m_n = _mm256_andnot_si256(insig, m_n);
+                // spread the 16 bits in sig to 0 or 1 bytes in sig_vec
+                __m128i sig_vec = _mm_set1_epi16((si16)sig);
+                sig_vec = _mm_shuffle_epi8(sig_vec,
+                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                sig_vec = _mm_and_si128(sig_vec,
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                sig_vec = _mm_cmpeq_epi8(sig_vec,
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                sig_vec = _mm_abs_epi8(sig_vec);
 
                 // find cumulative sums
-                // to find at which bit in ms_vec the sample starts
-                __m256i inc_sum = m_n; // inclusive scan
-                inc_sum = _mm256_add_epi32(inc_sum, _mm256_bslli_epi128(inc_sum, 4));
-                inc_sum = _mm256_add_epi32(inc_sum, _mm256_bslli_epi128(inc_sum, 8));
-                int total_mn1 = _mm256_extract_epi16(inc_sum, 6);
-                int total_mn2 = _mm256_extract_epi16(inc_sum, 14);
+                // to find which bit in cwd we should extract
+                __m128i inc_sum = sig_vec; // inclusive scan
+                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
+                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
+                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
+                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
+                total_bits = _mm_extract_epi16(inc_sum, 7) >> 8;
+                __m128i ex_sum = _mm_bslli_si128(inc_sum, 1); // exclusive scan
 
-                __m128i ms_vec0 = _mm_setzero_si128();
-                __m128i ms_vec1 = _mm_setzero_si128();
-                if (total_mn1)
-                {
-                    ms_vec0 = frwd_fetch<0xFF>(magsgn);
-                    frwd_advance(magsgn, (ui32)total_mn1);
+                // Spread the 16 bits in cwd to inverted 0 or 1 bytes in
+                // cwd_vec. Then, convert these to a form suitable
+                // for coefficient modifications; in particular, a value
+                // of 0 is presented as binary 11, and a value of 1 is
+                // represented as binary 01
+                __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
+                cwd_vec = _mm_shuffle_epi8(cwd_vec,
+                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                cwd_vec = _mm_and_si128(cwd_vec,
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                cwd_vec = _mm_cmpeq_epi8(cwd_vec,
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                cwd_vec = _mm_add_epi8(cwd_vec, _mm_set1_epi8(1));
+                cwd_vec = _mm_add_epi8(cwd_vec, cwd_vec);
+                cwd_vec = _mm_or_si128(cwd_vec, _mm_set1_epi8(1));
+
+                // load data and insert the mrp bit
+                __m128i m =
+                  _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
+                ui32 *dp = dpp;
+                for (int c = 0; c < 4; ++c) {
+                  __m128i s0, s0_sig, s0_idx, s0_val;
+                  // load coefficients
+                  s0 = _mm_load_si128((__m128i*)dp);
+                  // find significant samples in this row
+                  s0_sig = _mm_shuffle_epi8(sig_vec, m);
+                  s0_sig = _mm_cmpeq_epi8(s0_sig, _mm_setzero_si128());
+                  // get MRP bit index, and MRP pattern
+                  s0_idx = _mm_shuffle_epi8(ex_sum, m);
+                  s0_val = _mm_shuffle_epi8(cwd_vec, s0_idx);
+                  // keep data from significant samples only
+                  s0_val = _mm_andnot_si128(s0_sig, s0_val);
+                  // move mrp bits to correct position, and employ
+                  s0_val = _mm_slli_epi32(s0_val, (si32)p - 2);
+                  s0 = _mm_xor_si128(s0, s0_val);
+                  // store coefficients
+                  _mm_store_si128((__m128i*)dp, s0);
+                  // prepare for next row
+                  dp += stride;
+                  m = _mm_add_epi32(m, _mm_set1_epi32(1));
                 }
-                if (total_mn2)
-                {
-                    ms_vec1 = frwd_fetch<0xFF>(magsgn);
-                    frwd_advance(magsgn, (ui32)total_mn2);
-                }
-
-                __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
-
-                __m256i ex_sum = _mm256_bslli_epi128(inc_sum, 4); // exclusive scan
-
-                // find the starting byte and starting bit
-                __m256i byte_idx = _mm256_srli_epi32(ex_sum, 3);
-                __m256i bit_idx = _mm256_and_si256(ex_sum, _mm256_set1_epi32(7));
-                byte_idx = _mm256_shuffle_epi8(byte_idx,
-                                               _mm256_set_epi32(0x0C0C0C0C, 0x08080808, 0x04040404, 0x00000000, 0x0C0C0C0C, 0x08080808, 0x04040404, 0x00000000));
-                byte_idx = _mm256_add_epi32(byte_idx, _mm256_set1_epi32(0x03020100));
-                __m256i d0 = _mm256_shuffle_epi8(ms_vec, byte_idx);
-                byte_idx = _mm256_add_epi32(byte_idx, _mm256_set1_epi32(0x01010101));
-                __m256i d1 = _mm256_shuffle_epi8(ms_vec, byte_idx);
-
-                // shift samples values to correct location
-                bit_idx = _mm256_or_si256(bit_idx, _mm256_slli_epi32(bit_idx, 16));
-
-                __m128i a = _mm_set_epi8(1, 3, 7, 15, 31, 63, 127, -1, 1, 3, 7, 15, 31, 63, 127, -1);
-                __m256i aa = _mm256_inserti128_si256(_mm256_castsi128_si256(a), a, 0x1);
-
-                __m256i bit_shift = _mm256_shuffle_epi8(aa, bit_idx);
-                bit_shift = _mm256_add_epi16(bit_shift, _mm256_set1_epi16(0x0101));
-                d0 = _mm256_mullo_epi16(d0, bit_shift);
-                d0 = _mm256_srli_epi16(d0, 8); // we should have 8 bits in the LSB
-                d1 = _mm256_mullo_epi16(d1, bit_shift);
-                d1 = _mm256_and_si256(d1, _mm256_set1_epi32((si32)0xFF00FF00)); // 8 in MSB
-                d0 = _mm256_or_si256(d0, d1);
-
-                // find location of e_k and mask
-                __m256i shift;
-                __m256i ones = _mm256_set1_epi32(1);
-                __m256i twos = _mm256_set1_epi32(2);
-                __m256i U_q_m1 = _mm256_sub_epi32(U_q, ones);
-                U_q_m1 = _mm256_and_si256(U_q_m1, _mm256_set_epi32(0, 0, 0, 0x1F, 0, 0, 0, 0x1F));
-                U_q_m1 = _mm256_shuffle_epi32(U_q_m1, 0);
-                w0 = _mm256_sub_epi32(twos, w0);
-                shift = _mm256_sllv_epi32(w0, U_q_m1); // U_q_m1 must be no more than 31
-                ms_vec = _mm256_and_si256(d0, _mm256_sub_epi32(shift, ones));
-
-                // next e_1
-                w0 = _mm256_and_si256(flags, _mm256_set1_epi32(0x800));
-                w0 = _mm256_cmpeq_epi32(w0, _mm256_setzero_si256());
-                w0 = _mm256_andnot_si256(w0, shift);    // e_1 in correct position
-                ms_vec = _mm256_or_si256(ms_vec, w0);   // e_1
-                w0 = _mm256_slli_epi32(ms_vec, 31);     // sign
-                ms_vec = _mm256_or_si256(ms_vec, ones); // bin center
-                __m256i tvn = ms_vec;
-                ms_vec = _mm256_add_epi32(ms_vec, twos); // + 2
-                ms_vec = _mm256_slli_epi32(ms_vec, (si32)p - 1);
-                ms_vec = _mm256_or_si256(ms_vec, w0);     // sign
-                row = _mm256_andnot_si256(insig, ms_vec); // significant only
-
-                ms_vec = _mm256_andnot_si256(insig, tvn); // significant only
-
-                tvn = _mm256_shuffle_epi8(ms_vec, _mm256_set_epi32(-1, 0x0F0E0D0C, 0x07060504, -1, -1, -1, 0x0F0E0D0C, 0x07060504));
-
-                vn = _mm_or_si128(vn, _mm256_castsi256_si128(tvn));
-                vn = _mm_or_si128(vn, _mm256_extracti128_si256(tvn, 0x1));
+              }
+              // consume data according to the number of bits set
+              mrp_pos += (ui32)total_bits;
             }
-            return row;
-        }
-
-        //************************************************************************/
-        /** @brief decodes twos consecutive quads (one octet), using 16 bit data
-         *
-         *  @param inf_u_q  decoded VLC code, with interleaved u values
-         *  @param U_q      U values
-         *  @param magsgn   structure for forward data buffer
-         *  @param p        bitplane at which we are decoding
-         *  @param vn       used for handling E values (stores v_n values)
-         *  @return __m128i decoded quad
-         */
-
-        static inline __m256i decode_four_quad16(const __m128i inf_u_q, __m128i U_q, frwd_struct_avx2 *magsgn, ui32 p, __m128i &vn)
-        {
-
-            __m256i w0;    // workers
-            __m256i insig; // lanes hold FF's if samples are insignificant
-            __m256i flags; // lanes hold e_k, e_1, and rho
-
-            __m256i row = _mm256_setzero_si256();
-            __m128i ddd = _mm_shuffle_epi8(inf_u_q,
-                                           _mm_set_epi16(0x0d0c, 0x0d0c, 0x0908, 0x908, 0x0504, 0x0504, 0x0100, 0x0100));
-            w0 = _mm256_permutevar8x32_epi32(_mm256_castsi128_si256(ddd),
-                                             _mm256_setr_epi32(0, 0, 1, 1, 2, 2, 3, 3));
-            // we keeps e_k, e_1, and rho in w2
-            flags = _mm256_and_si256(w0,
-                                     _mm256_set_epi16((si16)0x8880, 0x4440, 0x2220, 0x1110,
-                                                      (si16)0x8880, 0x4440, 0x2220, 0x1110,
-                                                      (si16)0x8880, 0x4440, 0x2220, 0x1110,
-                                                      (si16)0x8880, 0x4440, 0x2220, 0x1110));
-            insig = _mm256_cmpeq_epi16(flags, _mm256_setzero_si256());
-            if ((uint32_t)_mm256_movemask_epi8(insig) != (uint32_t)0xFFFFFFFF) // are all insignificant?
-            {
-                ddd = _mm_or_si128(_mm_bslli_si128(U_q, 2), U_q);
-                __m256i U_q_avx = _mm256_permutevar8x32_epi32(_mm256_castsi128_si256(ddd),
-                                                              _mm256_setr_epi32(0, 0, 1, 1, 2, 2, 3, 3));
-                flags = _mm256_mullo_epi16(flags, _mm256_set_epi16(1, 2, 4, 8, 1, 2, 4, 8, 1, 2, 4, 8, 1, 2, 4, 8));
-
-                // U_q holds U_q for this quad
-                // flags has e_k, e_1, and rho such that e_k is sitting in the
-                // 0x8000, e_1 in 0x800, and rho in 0x80
-
-                // next e_k and m_n
-                __m256i m_n;
-                w0 = _mm256_srli_epi16(flags, 15); // e_k
-                m_n = _mm256_sub_epi16(U_q_avx, w0);
-                m_n = _mm256_andnot_si256(insig, m_n);
-
-                // find cumulative sums
-                // to find at which bit in ms_vec the sample starts
-                __m256i inc_sum = m_n; // inclusive scan
-                inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 2));
-                inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 4));
-                inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 8));
-                int total_mn1 = _mm256_extract_epi16(inc_sum, 7);
-                int total_mn2 = _mm256_extract_epi16(inc_sum, 15);
-                __m256i ex_sum = _mm256_bslli_epi128(inc_sum, 2); // exclusive scan
-
-                __m128i ms_vec0 = _mm_setzero_si128();
-                __m128i ms_vec1 = _mm_setzero_si128();
-                if (total_mn1)
-                {
-                    ms_vec0 = frwd_fetch<0xFF>(magsgn);
-                    frwd_advance(magsgn, (ui32)total_mn1);
-                }
-                if (total_mn2)
-                {
-                    ms_vec1 = frwd_fetch<0xFF>(magsgn);
-                    frwd_advance(magsgn, (ui32)total_mn2);
-                }
-
-                __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
-
-                // find the starting byte and starting bit
-                __m256i byte_idx = _mm256_srli_epi16(ex_sum, 3);
-                __m256i bit_idx = _mm256_and_si256(ex_sum, _mm256_set1_epi16(7));
-                byte_idx = _mm256_shuffle_epi8(byte_idx,
-                                               _mm256_set_epi16(0x0E0E, 0x0C0C, 0x0A0A, 0x0808,
-                                                                0x0606, 0x0404, 0x0202, 0x0000, 0x0E0E, 0x0C0C, 0x0A0A, 0x0808,
-                                                                0x0606, 0x0404, 0x0202, 0x0000));
-                byte_idx = _mm256_add_epi16(byte_idx, _mm256_set1_epi16(0x0100));
-                __m256i d0 = _mm256_shuffle_epi8(ms_vec, byte_idx);
-                byte_idx = _mm256_add_epi16(byte_idx, _mm256_set1_epi16(0x0101));
-                __m256i d1 = _mm256_shuffle_epi8(ms_vec, byte_idx);
-
-                // shift samples values to correct location
-                __m256i bit_shift = _mm256_shuffle_epi8(
-                    _mm256_set_epi8(1, 3, 7, 15, 31, 63, 127, -1,
-                                    1, 3, 7, 15, 31, 63, 127, -1, 1, 3, 7, 15, 31, 63, 127, -1,
-                                    1, 3, 7, 15, 31, 63, 127, -1),
-                    bit_idx);
-                bit_shift = _mm256_add_epi16(bit_shift, _mm256_set1_epi16(0x0101));
-                d0 = _mm256_mullo_epi16(d0, bit_shift);
-                d0 = _mm256_srli_epi16(d0, 8); // we should have 8 bits in the LSB
-                d1 = _mm256_mullo_epi16(d1, bit_shift);
-                d1 = _mm256_and_si256(d1, _mm256_set1_epi16((si16)0xFF00)); // 8 in MSB
-                d0 = _mm256_or_si256(d0, d1);
-
-                // find location of e_k and mask
-                __m256i shift, t0, t1, Uq0, Uq1;
-                __m256i ones = _mm256_set1_epi16(1);
-                __m256i twos = _mm256_set1_epi16(2);
-                __m256i U_q_m1 = _mm256_sub_epi32(U_q_avx, ones);
-                Uq0 = _mm256_and_si256(U_q_m1, _mm256_set_epi32(0, 0, 0, 0x1F, 0, 0, 0, 0x1F));
-                Uq1 = _mm256_bsrli_epi128(U_q_m1, 14);
-                w0 = _mm256_sub_epi16(twos, w0);
-                t0 = _mm256_and_si256(w0, _mm256_set_epi64x(0, -1, 0, -1));
-                t1 = _mm256_and_si256(w0, _mm256_set_epi64x(-1, 0, -1, 0));
-                { // no _mm256_sllv_epi16 in avx2
-                    __m128i t_0_sse = _mm256_castsi256_si128(t0);
-                    t_0_sse = _mm_sll_epi16(t_0_sse, _mm256_castsi256_si128(Uq0));
-                    __m128i t_1_sse = _mm256_extracti128_si256(t0, 0x1);
-                    t_1_sse = _mm_sll_epi16(t_1_sse, _mm256_extracti128_si256(Uq0, 0x1));
-                    t0 = _mm256_inserti128_si256(_mm256_castsi128_si256(t_0_sse), t_1_sse, 0x1);
-
-                    t_0_sse = _mm256_castsi256_si128(t1);
-                    t_0_sse = _mm_sll_epi16(t_0_sse, _mm256_castsi256_si128(Uq1));
-                    t_1_sse = _mm256_extracti128_si256(t1, 0x1);
-                    t_1_sse = _mm_sll_epi16(t_1_sse, _mm256_extracti128_si256(Uq1, 0x1));
-                    t1 = _mm256_inserti128_si256(_mm256_castsi128_si256(t_0_sse), t_1_sse, 0x1);
-                }
-                shift = _mm256_or_si256(t0, t1);
-                ms_vec = _mm256_and_si256(d0, _mm256_sub_epi16(shift, ones));
-
-                // next e_1
-                w0 = _mm256_and_si256(flags, _mm256_set1_epi16(0x800));
-                w0 = _mm256_cmpeq_epi16(w0, _mm256_setzero_si256());
-                w0 = _mm256_andnot_si256(w0, shift);    // e_1 in correct position
-                ms_vec = _mm256_or_si256(ms_vec, w0);   // e_1
-                w0 = _mm256_slli_epi16(ms_vec, 15);     // sign
-                ms_vec = _mm256_or_si256(ms_vec, ones); // bin center
-                __m256i tvn = ms_vec;
-                ms_vec = _mm256_add_epi16(ms_vec, twos); // + 2
-                ms_vec = _mm256_slli_epi16(ms_vec, (si32)p - 1);
-                ms_vec = _mm256_or_si256(ms_vec, w0);     // sign
-                row = _mm256_andnot_si256(insig, ms_vec); // significant only
-
-                ms_vec = _mm256_andnot_si256(insig, tvn); // significant only
-
-                __m256i ms_vec_shuffle1 = _mm256_shuffle_epi8(ms_vec,
-                                                              _mm256_set_epi16(-1, -1, -1, -1, 0x0706, 0x0302, -1, -1,
-                                                                               -1, -1, -1, -1, -1, -1, 0x0706, 0x0302));
-                __m256i ms_vec_shuffle2 = _mm256_shuffle_epi8(ms_vec,
-                                                              _mm256_set_epi16(-1, -1, -1, 0x0F0E, 0x0B0A, -1, -1, -1,
-                                                                               -1, -1, -1, -1, -1, 0x0F0E, 0x0B0A, -1));
-                ms_vec = _mm256_or_si256(ms_vec_shuffle1, ms_vec_shuffle2);
-
-                vn = _mm_or_si128(vn, _mm256_castsi256_si128(ms_vec));
-                vn = _mm_or_si128(vn, _mm256_extracti128_si256(ms_vec, 0x1));
-            }
-            return row;
-        }
-
-        // https://stackoverflow.com/a/58827596
-        inline __m256i avx2_lzcnt_epi32(__m256i v)
-        {
-            // prevent value from being rounded up to the next power of two
-            v = _mm256_andnot_si256(_mm256_srli_epi32(v, 8), v); // keep 8 MSB
-
-            v = _mm256_castps_si256(_mm256_cvtepi32_ps(v));   // convert an integer to float
-            v = _mm256_srli_epi32(v, 23);                     // shift down the exponent
-            v = _mm256_subs_epu16(_mm256_set1_epi32(158), v); // undo bias
-            v = _mm256_min_epi16(v, _mm256_set1_epi32(32));   // clamp at 32
-
-            return v;
-        }
-
-        //************************************************************************/
-        /** @brief Decodes one codeblock, processing the cleanup, siginificance
-         *         propagation, and magnitude refinement pass
-         *
-         *  @param [in]   coded_data is a pointer to bitstream
-         *  @param [in]   decoded_data is a pointer to decoded codeblock data buf.
-         *  @param [in]   missing_msbs is the number of missing MSBs
-         *  @param [in]   num_passes is the number of passes: 1 if CUP only,
-         *                2 for CUP+SPP, and 3 for CUP+SPP+MRP
-         *  @param [in]   lengths1 is the length of cleanup pass
-         *  @param [in]   lengths2 is the length of refinement passes (either SPP
-         *                only or SPP+MRP)
-         *  @param [in]   width is the decoded codeblock width
-         *  @param [in]   height is the decoded codeblock height
-         *  @param [in]   stride is the decoded codeblock buffer stride
-         *  @param [in]   stripe_causal is true for stripe causal mode
-         */
-        bool ojph_decode_codeblock_avx2(ui8 *coded_data, ui32 *decoded_data,
-                                        ui32 missing_msbs, ui32 num_passes,
-                                        ui32 lengths1, ui32 lengths2,
-                                        ui32 width, ui32 height, ui32 stride,
-                                        bool stripe_causal)
-        {
-            static bool insufficient_precision = false;
-            static bool modify_code = false;
-            static bool truncate_spp_mrp = false;
-
-            if (num_passes > 1 && lengths2 == 0)
-            {
-                OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
-                                      "one coding pass, but zero length for "
-                                      "2nd and potential 3rd pass.");
-                num_passes = 1;
-            }
-
-            if (num_passes > 3)
-            {
-                OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
-                                      "This codeblocks has %d passes.",
-                          num_passes);
-                return false;
-            }
-
-            if (missing_msbs > 30) // p < 0
-            {
-                if (insufficient_precision == false)
-                {
-                    insufficient_precision = true;
-                    OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
-                                          "codeblock. This message will not be "
-                                          "displayed again.");
-                }
-                return false;
-            }
-            else if (missing_msbs == 30) // p == 0
-            {                            // not enough precision to decode and set the bin center to 1
-                if (modify_code == false)
-                {
-                    modify_code = true;
-                    OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
-                                          "pass. The code can be modified to support "
-                                          "this case. This message will not be "
-                                          "displayed again.");
-                }
-                return false; // 32 bits are not enough to decode this
-            }
-            else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
-            {
-                if (num_passes > 1)
-                {
-                    num_passes = 1;
-                    if (truncate_spp_mrp == false)
-                    {
-                        truncate_spp_mrp = true;
-                        OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
-                                              "nor MagRef passes; both will be skipped. "
-                                              "This message will not be displayed "
-                                              "again.");
-                    }
-                }
-            }
-            ui32 p = 30 - missing_msbs; // The least significant bitplane for CUP
-            // There is a way to handle the case of p == 0, but a different path
-            // is required
-
-            if (lengths1 < 2)
-            {
-                OJPH_WARN(0x00010006, "Wrong codeblock length.");
-                return false;
-            }
-
-            // read scup and fix the bytes there
-            int lcup, scup;
-            lcup = (int)lengths1; // length of CUP
-            // scup is the length of MEL + VLC
-            scup = (((int)coded_data[lcup - 1]) << 4) + (coded_data[lcup - 2] & 0xF);
-            if (scup < 2 || scup > lcup || scup > 4079) // something is wrong
-                return false;
-
-            // The temporary storage scratch holds two types of data in an
-            // interleaved fashion. The interleaving allows us to use one
-            // memory pointer.
-            // We have one entry for a decoded VLC code, and one entry for UVLC.
-            // Entries are 16 bits each, corresponding to one quad,
-            // but since we want to use XMM registers of the SSE family
-            // of SIMD; we allocated 16 bytes or more per quad row; that is,
-            // the width is no smaller than 16 bytes (or 8 entries), and the
-            // height is 512 quads
-            // Each VLC entry contains, in the following order, starting
-            // from MSB
-            // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
-            // Each entry in UVLC contains u_q
-            // One extra row to handle the case of SPP propagating downwards
-            // when codeblock width is 4
-            ui16 scratch[8 * 513] = {0}; // 8+ kB
-
-            // We need an extra two entries (one inf and one u_q) beyond
-            // the last column.
-            // If the block width is 4 (2 quads), then we use sstr of 8
-            // (enough for 4 quads). If width is 8 (4 quads) we use
-            // sstr is 16 (enough for 8 quads). For a width of 16 (8
-            // quads), we use 24 (enough for 12 quads).
-            ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
-
-            assert((stride & 0x3) == 0);
-
-            ui32 mmsbp2 = missing_msbs + 2;
-
-            // The cleanup pass is decoded in two steps; in step one,
-            // the VLC and MEL segments are decoded, generating a record that
-            // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
-            // This information should be sufficient for the next step.
-            // In step 2, we decode the MagSgn segment.
-
-            // step 1 decoding VLC and MEL segments
-            {
-                // init structures
-                dec_mel_st mel;
-                mel_init(&mel, coded_data, lcup, scup);
-                rev_struct vlc;
-                rev_init(&vlc, coded_data, lcup, scup);
-
-                int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
-                                             // data represented as runs of 0 events
-                                             // See mel_decode description
-
-                ui32 vlc_val;
-                ui32 c_q = 0;
-                ui16 *sp = scratch;
-                // initial quad row
-                for (ui32 x = 0; x < width; sp += 4)
-                {
-                    // decode VLC
-                    /////////////
-
-                    // first quad
-                    vlc_val = rev_fetch(&vlc);
-
-                    // decode VLC using the context c_q and the head of VLC bitstream
-                    ui16 t0 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
-
-                    // if context is zero, use one MEL event
-                    if (c_q == 0) // zero context
-                    {
-                        run -= 2; // subtract 2, since events number if multiplied by 2
-
-                        // Is the run terminated in 1? if so, use decoded VLC code,
-                        // otherwise, discard decoded data, since we will decoded again
-                        // using a different context
-                        t0 = (run == -1) ? t0 : 0;
-
-                        // is run -1 or -2? this means a run has been consumed
-                        if (run < 0)
-                            run = mel_get_run(&mel); // get another run
-                    }
-                    // run -= (c_q == 0) ? 2 : 0;
-                    // t0 = (c_q != 0 || run == -1) ? t0 : 0;
-                    // if (run < 0)
-                    //   run = mel_get_run(&mel);  // get another run
-                    sp[0] = t0;
-                    x += 2;
-
-                    // prepare context for the next quad; eqn. 1 in ITU T.814
-                    c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
-
-                    // remove data from vlc stream (0 bits are removed if vlc is not used)
-                    vlc_val = rev_advance(&vlc, t0 & 0x7);
-
-                    // second quad
-                    ui16 t1 = 0;
-
-                    // decode VLC using the context c_q and the head of VLC bitstream
-                    t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
-
-                    // if context is zero, use one MEL event
-                    if (c_q == 0 && x < width) // zero context
-                    {
-                        run -= 2; // subtract 2, since events number if multiplied by 2
-
-                        // if event is 0, discard decoded t1
-                        t1 = (run == -1) ? t1 : 0;
-
-                        if (run < 0)                 // have we consumed all events in a run
-                            run = mel_get_run(&mel); // if yes, then get another run
-                    }
-                    t1 = x < width ? t1 : 0;
-                    // run -= (c_q == 0 && x < width) ? 2 : 0;
-                    // t1 = (c_q != 0 || run == -1) ? t1 : 0;
-                    // if (run < 0)
-                    //   run = mel_get_run(&mel);  // get another run
-                    sp[2] = t1;
-                    x += 2;
-
-                    // prepare context for the next quad, eqn. 1 in ITU T.814
-                    c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
-
-                    // remove data from vlc stream, if qinf is not used, cwdlen is 0
-                    vlc_val = rev_advance(&vlc, t1 & 0x7);
-
-                    // decode u
-                    /////////////
-                    // uvlc_mode is made up of u_offset bits from the quad pair
-                    ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-                    if (uvlc_mode == 0xc0) // if both u_offset are set, get an event from
-                    {                      // the MEL run of events
-                        run -= 2;          // subtract 2, since events number if multiplied by 2
-
-                        uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
-                                                             // is 0x40
-
-                        if (run < 0) // if run is consumed (run is -1 or -2), get another run
-                            run = mel_get_run(&mel);
-                    }
-                    // run -= (uvlc_mode == 0xc0) ? 2 : 0;
-                    // uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
-                    // if (run < 0)
-                    //   run = mel_get_run(&mel);  // get another run
-
-                    // decode uvlc_mode to get u for both quads
-                    ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
-                    // remove total prefix length
-                    vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-                    uvlc_entry >>= 3;
-                    // extract suffixes for quad 0 and 1
-                    ui32 len = uvlc_entry & 0xF;           // suffix length for 2 quads
-                    ui32 tmp = vlc_val & ((1 << len) - 1); // suffix value for 2 quads
-                    vlc_val = rev_advance(&vlc, len);
-                    ojph_unused(vlc_val); // static code analysis: unused value
-                    uvlc_entry >>= 4;
-                    // quad 0 length
-                    len = uvlc_entry & 0x7; // quad 0 suffix length
-                    uvlc_entry >>= 3;
-                    ui16 u_q = (ui16)(1 + (uvlc_entry & 7) + (tmp & ~(0xFFU << len))); // kap. 1
-                    sp[1] = u_q;
-                    u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len)); // kappa == 1
-                    sp[3] = u_q;
-                }
-                sp[0] = sp[1] = 0;
-
-                // non initial quad rows
-                for (ui32 y = 2; y < height; y += 2)
-                {
-                    c_q = 0;                              // context
-                    ui16 *sp = scratch + (y >> 1) * sstr; // this row of quads
-
-                    for (ui32 x = 0; x < width; sp += 4)
-                    {
-                        // decode VLC
-                        /////////////
-
-                        // sigma_q (n, ne, nf)
-                        c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
-                        c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
-
-                        // first quad
-                        vlc_val = rev_fetch(&vlc);
-
-                        // decode VLC using the context c_q and the head of VLC bitstream
-                        ui16 t0 = vlc_tbl1[c_q + (vlc_val & 0x7F)];
-
-                        // if context is zero, use one MEL event
-                        if (c_q == 0) // zero context
-                        {
-                            run -= 2; // subtract 2, since events number is multiplied by 2
-
-                            // Is the run terminated in 1? if so, use decoded VLC code,
-                            // otherwise, discard decoded data, since we will decoded again
-                            // using a different context
-                            t0 = (run == -1) ? t0 : 0;
-
-                            // is run -1 or -2? this means a run has been consumed
-                            if (run < 0)
-                                run = mel_get_run(&mel); // get another run
-                        }
-                        // run -= (c_q == 0) ? 2 : 0;
-                        // t0 = (c_q != 0 || run == -1) ? t0 : 0;
-                        // if (run < 0)
-                        //   run = mel_get_run(&mel);  // get another run
-                        sp[0] = t0;
-                        x += 2;
-
-                        // prepare context for the next quad; eqn. 2 in ITU T.814
-                        // sigma_q (w, sw)
-                        c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
-                        // sigma_q (nw)
-                        c_q |= sp[0 - (si32)sstr] & 0x80;
-                        // sigma_q (n, ne, nf)
-                        c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
-                        c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
-
-                        // remove data from vlc stream (0 bits are removed if vlc is unused)
-                        vlc_val = rev_advance(&vlc, t0 & 0x7);
-
-                        // second quad
-                        ui16 t1 = 0;
-
-                        // decode VLC using the context c_q and the head of VLC bitstream
-                        t1 = vlc_tbl1[c_q + (vlc_val & 0x7F)];
-
-                        // if context is zero, use one MEL event
-                        if (c_q == 0 && x < width) // zero context
-                        {
-                            run -= 2; // subtract 2, since events number if multiplied by 2
-
-                            // if event is 0, discard decoded t1
-                            t1 = (run == -1) ? t1 : 0;
-
-                            if (run < 0)                 // have we consumed all events in a run
-                                run = mel_get_run(&mel); // if yes, then get another run
-                        }
-                        t1 = x < width ? t1 : 0;
-                        // run -= (c_q == 0 && x < width) ? 2 : 0;
-                        // t1 = (c_q != 0 || run == -1) ? t1 : 0;
-                        // if (run < 0)
-                        //   run = mel_get_run(&mel);  // get another run
-                        sp[2] = t1;
-                        x += 2;
-
-                        // partial c_q, will be completed when we process the next quad
-                        // sigma_q (w, sw)
-                        c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
-                        // sigma_q (nw)
-                        c_q |= sp[2 - (si32)sstr] & 0x80;
-
-                        // remove data from vlc stream, if qinf is not used, cwdlen is 0
-                        vlc_val = rev_advance(&vlc, t1 & 0x7);
-
-                        // decode u
-                        /////////////
-                        // uvlc_mode is made up of u_offset bits from the quad pair
-                        ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-                        ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
-                        // remove total prefix length
-                        vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-                        uvlc_entry >>= 3;
-                        // extract suffixes for quad 0 and 1
-                        ui32 len = uvlc_entry & 0xF;           // suffix length for 2 quads
-                        ui32 tmp = vlc_val & ((1 << len) - 1); // suffix value for 2 quads
-                        vlc_val = rev_advance(&vlc, len);
-                        ojph_unused(vlc_val); // static code analysis: unused value
-                        uvlc_entry >>= 4;
-                        // quad 0 length
-                        len = uvlc_entry & 0x7; // quad 0 suffix length
-                        uvlc_entry >>= 3;
-                        ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
-                        sp[1] = u_q;
-                        u_q = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
-                        sp[3] = u_q;
-                    }
-                    sp[0] = sp[1] = 0;
-                }
-            }
-
-            // step2 we decode magsgn
-            // mmsbp2 equals K_max + 1 (we decode up to K_max bits + 1 sign bit)
-            // The 32 bit path decode 16 bits data, for which one would think
-            // 16 bits are enough, because we want to put in the center of the
-            // bin.
-            // If you have mmsbp2 equals 16 bit, and reversible coding, and
-            // no bitplanes are missing, then we can decoding using the 16 bit
-            // path, but we are not doing this here.
-            if (mmsbp2 >= 16)
-            {
-                // We allocate a scratch row for storing v_n values.
-                // We have 512 quads horizontally.
-                // We may go beyond the last entry by up to 4 entries.
-                // Here we allocate additional 8 entries.
-                // There are two rows in this structure, the bottom
-                // row is used to store processed entries.
-                const int v_n_size = 512 + 16;
-                ui32 v_n_scratch[2 * v_n_size] = {0}; // 4+ kB
-
-                frwd_struct_avx2 magsgn;
-                frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
-
-                const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
-
-                {
-                    ui16 *sp = scratch;
-                    ui32 *vp = v_n_scratch;
-                    ui32 *dp = decoded_data;
-                    vp[0] = 2; // for easy calculation of emax
-
-                    for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
-                    {
-                        __m128i vn = _mm_set1_epi32(2);
-
-                        __m256i inf_u_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i *)sp));
-                        inf_u_q = _mm256_permutevar8x32_epi32(inf_u_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
-
-                        __m256i U_q = _mm256_srli_epi32(inf_u_q, 16);
-                        __m256i w = _mm256_cmpgt_epi32(U_q, avx_mmsbp2);
-                        if (!_mm256_testz_si256(w, w))
-                        {
-                            return false;
-                        }
-
-                        __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, &magsgn, p, vn);
-                        row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
-                        _mm_store_si128((__m128i *)dp, _mm256_castsi256_si128(row));
-                        _mm_store_si128((__m128i *)(dp + stride), _mm256_extracti128_si256(row, 0x1));
-
-                        __m128i w0 = _mm_cvtsi32_si128(*(int const *)vp);
-                        w0 = _mm_or_si128(w0, vn);
-                        _mm_storeu_si128((__m128i *)vp, w0);
-                    }
-                }
-
-                for (ui32 y = 2; y < height; y += 2)
-                {
-                    {
-                        // perform 31 - count_leading_zeros(*vp) here
-                        ui32 *vp = v_n_scratch;
-                        ui16 *sp = scratch + (y >> 1) * sstr;
-
-                        const __m256i avx_31 = _mm256_set1_epi32(31);
-                        const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
-                        const __m256i avx_1 = _mm256_set1_epi32(1);
-                        const __m256i avx_0 = _mm256_setzero_si256();
-
-                        for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16)
-                        {
-                            __m256i v = _mm256_loadu_si256((__m256i *)vp);
-                            __m256i v_p1 = _mm256_loadu_si256((__m256i *)(vp + 1));
-                            v = _mm256_or_si256(v, v_p1);
-                            v = avx2_lzcnt_epi32(v);
-                            v = _mm256_sub_epi32(avx_31, v);
-
-                            __m256i inf_u_q = _mm256_loadu_si256((__m256i *)sp);
-                            __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
-                            __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
-                            gamma = _mm256_and_si256(gamma, w0);
-                            gamma = _mm256_cmpeq_epi32(gamma, avx_0);
-
-                            v = _mm256_andnot_si256(gamma, v);
-                            v = _mm256_max_epi32(v, avx_1);
-
-                            inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
-                            v = _mm256_add_epi32(inf_u_q, v);
-
-                            w0 = _mm256_cmpgt_epi32(v, avx_mmsbp2);
-                            if (!_mm256_testz_si256(w0, w0))
-                            {
-                                return false;
-                            }
-
-                            _mm256_storeu_si256((__m256i *)(vp + v_n_size), v);
-                        }
-                    }
-
-                    ui32 *vp = v_n_scratch;
-                    ui16 *sp = scratch + (y >> 1) * sstr;
-                    ui32 *dp = decoded_data + y * stride;
-                    vp[0] = 2; // for easy calculation of emax
-
-                    for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
-                    {
-                        // process two quads
-                        __m128i vn = _mm_set1_epi32(2);
-
-                        __m256i inf_u_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i *)sp));
-                        inf_u_q = _mm256_permutevar8x32_epi32(inf_u_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
-
-                        __m256i U_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i *)(vp + v_n_size)));
-                        U_q = _mm256_permutevar8x32_epi32(U_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
-
-                        __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, &magsgn, p, vn);
-                        row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
-                        _mm_store_si128((__m128i *)dp, _mm256_castsi256_si128(row));
-                        _mm_store_si128((__m128i *)(dp + stride), _mm256_extracti128_si256(row, 0x1));
-
-                        __m128i w0 = _mm_cvtsi32_si128(*(int const *)vp);
-                        w0 = _mm_or_si128(w0, vn);
-                        _mm_storeu_si128((__m128i *)vp, w0);
-                    }
-                }
-            }
-            else
-            {
-
-                // reduce bitplane by 16 because we now have 16 bits instead of 32
-                p -= 16;
-
-                // We allocate a scratch row for storing v_n values.
-                // We have 512 quads horizontally.
-                // We may go beyond the last entry by up to 8 entries.
-                // Therefore we allocate additional 8 entries.
-                // There are two rows in this structure, the bottom
-                // row is used to store processed entries.
-                const int v_n_size = 512 + 16;
-                ui16 v_n_scratch[v_n_size] = {0};    // 1+ kB
-                ui32 v_n_scratch_32[v_n_size] = {0}; // 2+ kB
-
-                frwd_struct_avx2 magsgn;
-                frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
-
-                {
-                    ui16 *sp = scratch;
-                    ui16 *vp = v_n_scratch;
-                    ui32 *dp = decoded_data;
-                    vp[0] = 2; // for easy calculation of emax
-
-                    for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8)
-                    {
-                        ////process four quads
-                        __m128i inf_u_q = _mm_loadu_si128((__m128i *)sp);
-                        __m128i U_q = _mm_srli_epi32(inf_u_q, 16);
-                        __m128i w = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
-                        if (!_mm_testz_si128(w, w))
-                        {
-                            return false;
-                        }
-
-                        __m128i vn = _mm_set1_epi16(2);
-                        __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
-
-                        w = _mm_cvtsi32_si128(*(unsigned short const *)(vp));
-                        _mm_storeu_si128((__m128i *)vp, _mm_or_si128(w, vn));
-
-                        __m256i w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
-                        __m256i w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
-
-                        _mm256_storeu_si256((__m256i *)dp, w0);
-                        _mm256_storeu_si256((__m256i *)(dp + stride), w1);
-                    }
-                }
-
-                for (ui32 y = 2; y < height; y += 2)
-                {
-                    {
-                        // perform 15 - count_leading_zeros(*vp) here
-                        ui16 *vp = v_n_scratch;
-                        ui32 *vp_32 = v_n_scratch_32;
-
-                        ui16 *sp = scratch + (y >> 1) * sstr;
-                        const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
-                        const __m256i avx_31 = _mm256_set1_epi32(31);
-                        const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
-                        const __m256i avx_1 = _mm256_set1_epi32(1);
-                        const __m256i avx_0 = _mm256_setzero_si256();
-
-                        for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16, vp_32 += 8)
-                        {
-                            __m128i v = _mm_loadu_si128((__m128i *)vp);
-                            __m128i v_p1 = _mm_loadu_si128((__m128i *)(vp + 1));
-                            v = _mm_or_si128(v, v_p1);
-
-                            __m256i v_avx = _mm256_cvtepu16_epi32(v);
-                            v_avx = avx2_lzcnt_epi32(v_avx);
-                            v_avx = _mm256_sub_epi32(avx_31, v_avx);
-
-                            __m256i inf_u_q = _mm256_loadu_si256((__m256i *)sp);
-                            __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
-                            __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
-                            gamma = _mm256_and_si256(gamma, w0);
-                            gamma = _mm256_cmpeq_epi32(gamma, avx_0);
-
-                            v_avx = _mm256_andnot_si256(gamma, v_avx);
-                            v_avx = _mm256_max_epi32(v_avx, avx_1);
-
-                            inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
-                            v_avx = _mm256_add_epi32(inf_u_q, v_avx);
-
-                            w0 = _mm256_cmpgt_epi32(v_avx, avx_mmsbp2);
-                            if (!_mm256_testz_si256(w0, w0))
-                            {
-                                return false;
-                            }
-
-                            _mm256_storeu_si256((__m256i *)vp_32, v_avx);
-                        }
-                    }
-
-                    ui16 *vp = v_n_scratch;
-                    ui32 *vp_32 = v_n_scratch_32;
-                    ui16 *sp = scratch + (y >> 1) * sstr;
-                    ui32 *dp = decoded_data + y * stride;
-                    vp[0] = 2; // for easy calculation of emax
-
-                    for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8, vp_32 += 4)
-                    {
-                        ////process four quads
-                        __m128i inf_u_q = _mm_loadu_si128((__m128i *)sp);
-                        __m128i U_q = _mm_loadu_si128((__m128i *)vp_32);
-
-                        __m128i vn = _mm_set1_epi16(2);
-                        __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
-
-                        __m128i w = _mm_cvtsi32_si128(*(unsigned short const *)(vp));
-                        _mm_storeu_si128((__m128i *)vp, _mm_or_si128(w, vn));
-
-                        __m256i w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
-                        __m256i w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
-
-                        _mm256_storeu_si256((__m256i *)dp, w0);
-                        _mm256_storeu_si256((__m256i *)(dp + stride), w1);
-                    }
-                }
-
-                // increase bitplane back by 16 because we need to process 32 bits
-                p += 16;
-            }
-
-            if (num_passes > 1)
-            {
-                // We use scratch again, we can divide it into multiple regions
-                // sigma holds all the significant samples, and it cannot
-                // be modified after it is set.  it will be used during the
-                // Magnitude Refinement Pass
-                ui16 *const sigma = scratch;
-
-                ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
-                                                 // ui16 contains 4 columns
-                mstr = ((mstr + 2u) + 7u) & ~7u; // multiples of 8
-
-                // We re-arrange quad significance, where each 4 consecutive
-                // bits represent one quad, into column significance, where,
-                // each 4 consequtive bits represent one column of 4 rows
-                {
-                    ui32 y;
-
-                    const __m128i mask_3 = _mm_set1_epi32(0x30);
-                    const __m128i mask_C = _mm_set1_epi32(0xC0);
-                    const __m128i shuffle_mask = _mm_set_epi32(-1, -1, -1, 0x0C080400);
-                    for (y = 0; y < height; y += 4)
-                    {
-                        ui16 *sp = scratch + (y >> 1) * sstr;
-                        ui16 *dp = sigma + (y >> 2) * mstr;
-                        for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2)
-                        {
-                            __m128i s0, s1, u3, uC, t0, t1;
-
-                            s0 = _mm_loadu_si128((__m128i *)(sp));
-                            u3 = _mm_and_si128(s0, mask_3);
-                            u3 = _mm_srli_epi32(u3, 4);
-                            uC = _mm_and_si128(s0, mask_C);
-                            uC = _mm_srli_epi32(uC, 2);
-                            t0 = _mm_or_si128(u3, uC);
-
-                            s1 = _mm_loadu_si128((__m128i *)(sp + sstr));
-                            u3 = _mm_and_si128(s1, mask_3);
-                            u3 = _mm_srli_epi32(u3, 2);
-                            uC = _mm_and_si128(s1, mask_C);
-                            t1 = _mm_or_si128(u3, uC);
-
-                            __m128i r = _mm_or_si128(t0, t1);
-                            r = _mm_shuffle_epi8(r, shuffle_mask);
-
-                            *(ui32 *)dp = (ui32)_mm_extract_epi32(r, 0);
-                        }
-                        dp[0] = 0; // set an extra entry on the right with 0
-                    }
-                    {
-                        // reset one row after the codeblock
-                        ui16 *dp = sigma + (y >> 2) * mstr;
-                        __m128i zero = _mm_setzero_si128();
-                        for (ui32 x = 0; x < width; x += 32, dp += 8)
-                            _mm_storeu_si128((__m128i *)dp, zero);
-                        dp[0] = 0; // set an extra entry on the right with 0
-                    }
-                }
-
-                // We perform Significance Propagation Pass here
-                {
-                    // This stores significance information of the previous
-                    // 4 rows.  Significance information in this array includes
-                    // all signicant samples in bitplane p - 1; that is,
-                    // significant samples for bitplane p (discovered during the
-                    // cleanup pass and stored in sigma) and samples that have recently
-                    // became significant (during the SPP) in bitplane p-1.
-                    // We store enough for the widest row, containing 1024 columns,
-                    // which is equivalent to 256 of ui16, since each stores 4 columns.
-                    // We add an extra 8 entries, just in case we need more
-                    ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
-
-                    frwd_struct_avx2 sigprop;
-                    frwd_init<0>(&sigprop, coded_data + lengths1, (int)lengths2);
-
-                    for (ui32 y = 0; y < height; y += 4)
-                    {
-                        ui32 pattern = 0xFFFFu; // a pattern needed samples
-                        if (height - y < 4)
-                        {
-                            pattern = 0x7777u;
-                            if (height - y < 3)
-                            {
-                                pattern = 0x3333u;
-                                if (height - y < 2)
-                                    pattern = 0x1111u;
-                            }
-                        }
-
-                        // prev holds sign. info. for the previous quad, together
-                        // with the rows on top of it and below it.
-                        ui32 prev = 0;
-                        ui16 *prev_sig = prev_row_sig;
-                        ui16 *cur_sig = sigma + (y >> 2) * mstr;
-                        ui32 *dpp = decoded_data + y * stride;
-                        for (ui32 x = 0; x < width; x += 4, dpp += 4, ++cur_sig, ++prev_sig)
-                        {
-                            // only rows and columns inside the stripe are included
-                            si32 s = (si32)x + 4 - (si32)width;
-                            s = ojph_max(s, 0);
-                            pattern = pattern >> (s * 4);
-
-                            // We first find locations that need to be tested (potential
-                            // SPP members); these location will end up in mbr
-                            // In each iteration, we produce 16 bits because cwd can have
-                            // up to 16 bits of significance information, followed by the
-                            // corresponding 16 bits of sign information; therefore, it is
-                            // sufficient to fetch 32 bit data per loop.
-
-                            // Althougth we are interested in 16 bits only, we load 32 bits.
-                            // For the 16 bits we are producing, we need the next 4 bits --
-                            // We need data for at least 5 columns out of 8.
-                            // Therefore loading 32 bits is easier than loading 16 bits
-                            // twice.
-                            ui32 ps = *(ui32 *)prev_sig;
-                            ui32 ns = *(ui32 *)(cur_sig + mstr);
-                            ui32 u = (ps & 0x88888888) >> 3; // the row on top
-                            if (!stripe_causal)
-                                u |= (ns & 0x11111111) << 3; // the row below
-
-                            ui32 cs = *(ui32 *)cur_sig;
-                            // vertical integration
-                            ui32 mbr = cs;                 // this sig. info.
-                            mbr |= (cs & 0x77777777) << 1; // above neighbors
-                            mbr |= (cs & 0xEEEEEEEE) >> 1; // below neighbors
-                            mbr |= u;
-                            // horizontal integration
-                            ui32 t = mbr;
-                            mbr |= t << 4;     // neighbors on the left
-                            mbr |= t >> 4;     // neighbors on the right
-                            mbr |= prev >> 12; // significance of previous group
-
-                            // remove outside samples, and already significant samples
-                            mbr &= pattern;
-                            mbr &= ~cs;
-
-                            // find samples that become significant during the SPP
-                            ui32 new_sig = mbr;
-                            if (new_sig)
-                            {
-                                __m128i cwd_vec = frwd_fetch<0>(&sigprop);
-                                ui32 cwd = (ui32)_mm_extract_epi16(cwd_vec, 0);
-
-                                ui32 cnt = 0;
-                                ui32 col_mask = 0xFu;
-                                ui32 inv_sig = ~cs & pattern;
-                                for (int i = 0; i < 16; i += 4, col_mask <<= 4)
-                                {
-                                    if ((col_mask & new_sig) == 0)
-                                        continue;
-
-                                    // scan one column
-                                    ui32 sample_mask = 0x1111u & col_mask;
-                                    if (new_sig & sample_mask)
-                                    {
-                                        new_sig &= ~sample_mask;
-                                        if (cwd & 1)
-                                        {
-                                            ui32 t = 0x33u << i;
-                                            new_sig |= t & inv_sig;
-                                        }
-                                        cwd >>= 1;
-                                        ++cnt;
-                                    }
-
-                                    sample_mask <<= 1;
-                                    if (new_sig & sample_mask)
-                                    {
-                                        new_sig &= ~sample_mask;
-                                        if (cwd & 1)
-                                        {
-                                            ui32 t = 0x76u << i;
-                                            new_sig |= t & inv_sig;
-                                        }
-                                        cwd >>= 1;
-                                        ++cnt;
-                                    }
-
-                                    sample_mask <<= 1;
-                                    if (new_sig & sample_mask)
-                                    {
-                                        new_sig &= ~sample_mask;
-                                        if (cwd & 1)
-                                        {
-                                            ui32 t = 0xECu << i;
-                                            new_sig |= t & inv_sig;
-                                        }
-                                        cwd >>= 1;
-                                        ++cnt;
-                                    }
-
-                                    sample_mask <<= 1;
-                                    if (new_sig & sample_mask)
-                                    {
-                                        new_sig &= ~sample_mask;
-                                        if (cwd & 1)
-                                        {
-                                            ui32 t = 0xC8u << i;
-                                            new_sig |= t & inv_sig;
-                                        }
-                                        cwd >>= 1;
-                                        ++cnt;
-                                    }
-                                }
-
-                                if (new_sig)
-                                {
-                                    cwd |= (ui32)_mm_extract_epi16(cwd_vec, 1) << (16 - cnt);
-
-                                    // Spread new_sig, such that each bit is in one byte with a
-                                    // value of 0 if new_sig bit is 0, and 0xFF if new_sig is 1
-                                    __m128i new_sig_vec = _mm_set1_epi16((si16)new_sig);
-                                    new_sig_vec = _mm_shuffle_epi8(new_sig_vec,
-                                                                   _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0));
-                                    new_sig_vec = _mm_and_si128(new_sig_vec,
-                                                                _mm_set1_epi64x((si64)0x8040201008040201));
-                                    new_sig_vec = _mm_cmpeq_epi8(new_sig_vec,
-                                                                 _mm_set1_epi64x((si64)0x8040201008040201));
-
-                                    // find cumulative sums
-                                    // to find which bit in cwd we should extract
-                                    __m128i inc_sum = new_sig_vec;   // inclusive scan
-                                    inc_sum = _mm_abs_epi8(inc_sum); // cvrt to 0 or 1
-                                    inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
-                                    inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
-                                    inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
-                                    inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
-                                    cnt += (ui32)_mm_extract_epi16(inc_sum, 7) >> 8;
-                                    // exclusive scan
-                                    __m128i ex_sum = _mm_bslli_si128(inc_sum, 1);
-
-                                    // Spread cwd, such that each bit is in one byte
-                                    // with a value of 0 or 1.
-                                    cwd_vec = _mm_set1_epi16((si16)cwd);
-                                    cwd_vec = _mm_shuffle_epi8(cwd_vec,
-                                                               _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0));
-                                    cwd_vec = _mm_and_si128(cwd_vec,
-                                                            _mm_set1_epi64x((si64)0x8040201008040201));
-                                    cwd_vec = _mm_cmpeq_epi8(cwd_vec,
-                                                             _mm_set1_epi64x((si64)0x8040201008040201));
-                                    cwd_vec = _mm_abs_epi8(cwd_vec);
-
-                                    // Obtain bit from cwd_vec correspondig to ex_sum
-                                    // Basically, collect needed bits from cwd_vec
-                                    __m128i v = _mm_shuffle_epi8(cwd_vec, ex_sum);
-
-                                    // load data and set spp coefficients
-                                    __m128i m =
-                                        _mm_set_epi8(-1, -1, -1, 12, -1, -1, -1, 8, -1, -1, -1, 4, -1, -1, -1, 0);
-                                    __m128i val = _mm_set1_epi32(3 << (p - 2));
-                                    ui32 *dp = dpp;
-                                    for (int c = 0; c < 4; ++c)
-                                    {
-                                        __m128i s0, s0_ns, s0_val;
-                                        // load coefficients
-                                        s0 = _mm_load_si128((__m128i *)dp);
-
-                                        // epi32 is -1 only for coefficient that
-                                        // are changed during the SPP
-                                        s0_ns = _mm_shuffle_epi8(new_sig_vec, m);
-                                        s0_ns = _mm_cmpeq_epi32(s0_ns, _mm_set1_epi32(0xFF));
-
-                                        // obtain sign for coefficients in SPP
-                                        s0_val = _mm_shuffle_epi8(v, m);
-                                        s0_val = _mm_slli_epi32(s0_val, 31);
-                                        s0_val = _mm_or_si128(s0_val, val);
-                                        s0_val = _mm_and_si128(s0_val, s0_ns);
-
-                                        // update vector
-                                        s0 = _mm_or_si128(s0, s0_val);
-                                        // store coefficients
-                                        _mm_store_si128((__m128i *)dp, s0);
-                                        // prepare for next row
-                                        dp += stride;
-                                        m = _mm_add_epi32(m, _mm_set1_epi32(1));
-                                    }
-                                }
-                                frwd_advance(&sigprop, cnt);
-                            }
-
-                            new_sig |= cs;
-                            *prev_sig = (ui16)(new_sig);
-
-                            // vertical integration for the new sig. info.
-                            t = new_sig;
-                            new_sig |= (t & 0x7777) << 1; // above neighbors
-                            new_sig |= (t & 0xEEEE) >> 1; // below neighbors
-                            // add sig. info. from the row on top and below
-                            prev = new_sig | u;
-                            // we need only the bits in 0xF000
-                            prev &= 0xF000;
-                        }
-                    }
-                }
-
-                // We perform Magnitude Refinement Pass here
-                if (num_passes > 2)
-                {
-                    rev_struct magref;
-                    rev_init_mrp(&magref, coded_data, (int)lengths1, (int)lengths2);
-
-                    for (ui32 y = 0; y < height; y += 4)
-                    {
-                        ui16 *cur_sig = sigma + (y >> 2) * mstr;
-                        ui32 *dpp = decoded_data + y * stride;
-                        for (ui32 i = 0; i < width; i += 4, dpp += 4)
-                        {
-                            // Process one entry from sigma array at a time
-                            //  Each nibble (4 bits) in the sigma array represents 4 rows,
-                            ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
-                            ui16 sig = *cur_sig++;             // 16 bit that will be processed now
-                            int total_bits = 0;
-                            if (sig) // if any of the 32 bits are set
-                            {
-                                // We work on 4 rows, with 4 samples each, since
-                                // data is 32 bit (4 bytes)
-
-                                // spread the 16 bits in sig to 0 or 1 bytes in sig_vec
-                                __m128i sig_vec = _mm_set1_epi16((si16)sig);
-                                sig_vec = _mm_shuffle_epi8(sig_vec,
-                                                           _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0));
-                                sig_vec = _mm_and_si128(sig_vec,
-                                                        _mm_set1_epi64x((si64)0x8040201008040201));
-                                sig_vec = _mm_cmpeq_epi8(sig_vec,
-                                                         _mm_set1_epi64x((si64)0x8040201008040201));
-                                sig_vec = _mm_abs_epi8(sig_vec);
-
-                                // find cumulative sums
-                                // to find which bit in cwd we should extract
-                                __m128i inc_sum = sig_vec; // inclusive scan
-                                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
-                                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
-                                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
-                                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
-                                total_bits = _mm_extract_epi16(inc_sum, 7) >> 8;
-                                __m128i ex_sum = _mm_bslli_si128(inc_sum, 1); // exclusive scan
-
-                                // Spread the 16 bits in cwd to inverted 0 or 1 bytes in
-                                // cwd_vec. Then, convert these to a form suitable
-                                // for coefficient modifications; in particular, a value
-                                // of 0 is presented as binary 11, and a value of 1 is
-                                // represented as binary 01
-                                __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
-                                cwd_vec = _mm_shuffle_epi8(cwd_vec,
-                                                           _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0));
-                                cwd_vec = _mm_and_si128(cwd_vec,
-                                                        _mm_set1_epi64x((si64)0x8040201008040201));
-                                cwd_vec = _mm_cmpeq_epi8(cwd_vec,
-                                                         _mm_set1_epi64x((si64)0x8040201008040201));
-                                cwd_vec = _mm_add_epi8(cwd_vec, _mm_set1_epi8(1));
-                                cwd_vec = _mm_add_epi8(cwd_vec, cwd_vec);
-                                cwd_vec = _mm_or_si128(cwd_vec, _mm_set1_epi8(1));
-
-                                // load data and insert the mrp bit
-                                __m128i m =
-                                    _mm_set_epi8(-1, -1, -1, 12, -1, -1, -1, 8, -1, -1, -1, 4, -1, -1, -1, 0);
-                                ui32 *dp = dpp;
-                                for (int c = 0; c < 4; ++c)
-                                {
-                                    __m128i s0, s0_sig, s0_idx, s0_val;
-                                    // load coefficients
-                                    s0 = _mm_load_si128((__m128i *)dp);
-                                    // find significant samples in this row
-                                    s0_sig = _mm_shuffle_epi8(sig_vec, m);
-                                    s0_sig = _mm_cmpeq_epi8(s0_sig, _mm_setzero_si128());
-                                    // get MRP bit index, and MRP pattern
-                                    s0_idx = _mm_shuffle_epi8(ex_sum, m);
-                                    s0_val = _mm_shuffle_epi8(cwd_vec, s0_idx);
-                                    // keep data from significant samples only
-                                    s0_val = _mm_andnot_si128(s0_sig, s0_val);
-                                    // move mrp bits to correct position, and employ
-                                    s0_val = _mm_slli_epi32(s0_val, (si32)p - 2);
-                                    s0 = _mm_xor_si128(s0, s0_val);
-                                    // store coefficients
-                                    _mm_store_si128((__m128i *)dp, s0);
-                                    // prepare for next row
-                                    dp += stride;
-                                    m = _mm_add_epi32(m, _mm_set1_epi32(1));
-                                }
-                            }
-                            // consume data according to the number of bits set
-                            rev_advance_mrp(&magref, (ui32)total_bits);
-                        }
-                    }
-                }
-            }
-
-            return true;
+          }
         }
     }
+
+    //************************************************************************/
+    /** @brief Step-1: decode the VLC and MEL segments into the scratch buffer.
+     *
+     *  Outlined so the serial scalar VLC/MEL chain gets its own register
+     *  allocation, isolated from the step-2 / SPP-MRP code paths.
+     */
+    OJPH_NO_INLINE
+    void decode_cb_step1_vlc(ui16* scratch, ui8* coded_data, int lcup,
+                             int scup, ui32 width, ui32 height, ui32 sstr)
+    {
+        // init structures
+        dec_mel_st mel;
+        mel_init(&mel, coded_data, lcup, scup);
+
+        // de-stuff the VLC segment; its size is at most scup - 1 < 4095
+        // bytes (scup is a 12-bit value), and consumption per quad pair is
+        // at most 7 + 7 + 30 bits, so 4096 bytes always suffice
+        const ui32 vlc_cap = 4096;
+        ui8 vlc_buf[vlc_cap + 72];
+        ui32 vlc_limit = destuff_vlc(coded_data, lcup, scup,
+                                     vlc_buf, vlc_cap);
+        ui32 vlc_off = 0;
+        ui32 vlc_bits = 0;
+
+        int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
+                                     // data represented as runs of 0 events
+                                     // See mel_decode description
+
+        ui64 vlc_val = 0;
+        ui32 c_q = 0;
+        ui16 *sp = scratch;
+        //initial quad row
+        for (ui32 x = 0; x < width; sp += 4)
+        {
+          // decode VLC
+          /////////////
+
+          // first quad
+          drefill(vlc_val, vlc_bits, vlc_off, vlc_buf, vlc_limit);
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
+
+          // if context is zero, use one MEL event
+          if (c_q == 0) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // Is the run terminated in 1? if so, use decoded VLC code,
+            // otherwise, discard decoded data, since we will decoded again
+            // using a different context
+            t0 = (run == -1) ? t0 : 0;
+
+            // is run -1 or -2? this means a run has been consumed
+            if (run < 0)
+              run = mel_get_run(&mel);  // get another run
+          }
+          //run -= (c_q == 0) ? 2 : 0;
+          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[0] = t0;
+          x += 2;
+
+          // prepare context for the next quad; eqn. 1 in ITU T.814
+          c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
+
+          //remove data from vlc stream (0 bits are removed if vlc is not used)
+          dconsume(vlc_val, vlc_bits, t0 & 0x7u);
+
+          //second quad
+          ui16 t1 = 0;
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
+
+          // if context is zero, use one MEL event
+          if (c_q == 0 && x < width) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // if event is 0, discard decoded t1
+            t1 = (run == -1) ? t1 : 0;
+
+            if (run < 0) // have we consumed all events in a run
+              run = mel_get_run(&mel); // if yes, then get another run
+          }
+          t1 = x < width ? t1 : 0;
+          //run -= (c_q == 0 && x < width) ? 2 : 0;
+          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[2] = t1;
+          x += 2;
+
+          //prepare context for the next quad, eqn. 1 in ITU T.814
+          c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
+
+          //remove data from vlc stream, if qinf is not used, cwdlen is 0
+          dconsume(vlc_val, vlc_bits, t1 & 0x7u);
+
+          // decode u
+          /////////////
+          // uvlc_mode is made up of u_offset bits from the quad pair
+          ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
+          {                     // the MEL run of events
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
+                                                 // is 0x40
+
+            if (run < 0)//if run is consumed (run is -1 or -2), get another run
+              run = mel_get_run(&mel);
+          }
+          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
+          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+
+          //decode uvlc_mode to get u for both quads
+          ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
+          //remove total prefix length
+          dconsume(vlc_val, vlc_bits, uvlc_entry & 0x7u);
+          uvlc_entry >>= 3;
+          //extract suffixes for quad 0 and 1
+          ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+          ui32 tmp = (ui32)vlc_val & ((1u << len) - 1); //suffix value, 2 quads
+          dconsume(vlc_val, vlc_bits, len);
+          uvlc_entry >>= 4;
+          // quad 0 length
+          len = uvlc_entry & 0x7; // quad 0 suffix length
+          uvlc_entry >>= 3;
+          ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len))); //kap. 1
+          sp[1] = u_q;
+          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
+          sp[3] = u_q;
+        }
+        sp[0] = sp[1] = 0;
+
+        //non initial quad rows
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          c_q = 0;                                // context
+          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
+
+          for (ui32 x = 0; x < width; sp += 4)
+          {
+            // decode VLC
+            /////////////
+
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
+
+            // first quad
+            drefill(vlc_val, vlc_bits, vlc_off, vlc_buf, vlc_limit);
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
+
+            // if context is zero, use one MEL event
+            if (c_q == 0) //zero context
+            {
+              run -= 2; //subtract 2, since events number is multiplied by 2
+
+              // Is the run terminated in 1? if so, use decoded VLC code,
+              // otherwise, discard decoded data, since we will decoded again
+              // using a different context
+              t0 = (run == -1) ? t0 : 0;
+
+              // is run -1 or -2? this means a run has been consumed
+              if (run < 0)
+                run = mel_get_run(&mel);  // get another run
+            }
+            //run -= (c_q == 0) ? 2 : 0;
+            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[0] = t0;
+            x += 2;
+
+            // prepare context for the next quad; eqn. 2 in ITU T.814
+            // sigma_q (w, sw)
+            c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[0 - (si32)sstr] & 0x80;
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
+
+            //remove data from vlc stream (0 bits are removed if vlc is unused)
+            dconsume(vlc_val, vlc_bits, t0 & 0x7u);
+
+            //second quad
+            ui16 t1 = 0;
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)];
+
+            // if context is zero, use one MEL event
+            if (c_q == 0 && x < width) //zero context
+            {
+              run -= 2; //subtract 2, since events number if multiplied by 2
+
+              // if event is 0, discard decoded t1
+              t1 = (run == -1) ? t1 : 0;
+
+              if (run < 0) // have we consumed all events in a run
+                run = mel_get_run(&mel); // if yes, then get another run
+            }
+            t1 = x < width ? t1 : 0;
+            //run -= (c_q == 0 && x < width) ? 2 : 0;
+            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[2] = t1;
+            x += 2;
+
+            // partial c_q, will be completed when we process the next quad
+            // sigma_q (w, sw)
+            c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[2 - (si32)sstr] & 0x80;
+
+            //remove data from vlc stream, if qinf is not used, cwdlen is 0
+            dconsume(vlc_val, vlc_bits, t1 & 0x7u);
+
+            // decode u using wide UVLC table
+            /////////////
+            ui32 uvlc_mode = (((t0 >> 3) & 1u) | (((t1 >> 3) & 1u) << 1));
+            ui32 uvlc_entry =
+              uvlc_tbl1_wide[(uvlc_mode << 10) | (vlc_val & 0x3FF)];
+            ui32 total_bits = uvlc_entry & 0x1F;
+            if (total_bits < 0x1F) {
+              sp[1] = (ui16)((uvlc_entry >> 5) & 0xFF);
+              sp[3] = (ui16)((uvlc_entry >> 13) & 0xFF);
+              dconsume(vlc_val, vlc_bits, total_bits);
+            } else {
+              uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+              uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
+              dconsume(vlc_val, vlc_bits, uvlc_entry & 0x7u);
+              uvlc_entry >>= 3;
+              ui32 len = uvlc_entry & 0xF;
+              ui32 tmp = (ui32)vlc_val & ((1u << len) - 1);
+              dconsume(vlc_val, vlc_bits, len);
+              uvlc_entry >>= 4;
+              len = uvlc_entry & 0x7;
+              uvlc_entry >>= 3;
+              sp[1] = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
+              sp[3] = (ui16)((uvlc_entry >> 3) + (tmp >> len));
+            }
+          }
+          sp[0] = sp[1] = 0;
+        }
+    }
+
+    bool ojph_decode_codeblock_avx2(ui8* coded_data, ui32* decoded_data,
+                                    ui32 missing_msbs, ui32 num_passes,
+                                    ui32 lengths1, ui32 lengths2,
+                                    ui32 width, ui32 height, ui32 stride,
+                                    bool stripe_causal)
+    {
+      static bool insufficient_precision = false;
+      static bool modify_code = false;
+      static bool truncate_spp_mrp = false;
+
+      if (num_passes > 1 && lengths2 == 0)
+      {
+        OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
+                              "one coding pass, but zero length for "
+                              "2nd and potential 3rd pass.");
+        num_passes = 1;
+      }
+
+      if (num_passes > 3)
+      {
+        OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
+                              "This codeblocks has %d passes.",
+                              num_passes);
+        return false;
+      }
+
+      if (missing_msbs > 30) // p < 0
+      {
+        if (insufficient_precision == false)
+        {
+          insufficient_precision = true;
+          OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
+                                "codeblock. This message will not be "
+                                "displayed again.");
+        }
+        return false;
+      }
+      else if (missing_msbs == 30) // p == 0
+      { // not enough precision to decode and set the bin center to 1
+        if (modify_code == false) {
+          modify_code = true;
+          OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
+                                "pass. The code can be modified to support "
+                                "this case. This message will not be "
+                                "displayed again.");
+        }
+         return false;         // 32 bits are not enough to decode this
+       }
+      else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
+      {
+        if (num_passes > 1) {
+          num_passes = 1;
+          if (truncate_spp_mrp == false) {
+            truncate_spp_mrp = true;
+            OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
+                                  "nor MagRef passes; both will be skipped. "
+                                  "This message will not be displayed "
+                                  "again.");
+          }
+        }
+      }
+      ui32 p = 30 - missing_msbs; // The least significant bitplane for CUP
+      // There is a way to handle the case of p == 0, but a different path
+      // is required
+
+      if (lengths1 < 2)
+      {
+        OJPH_WARN(0x00010006, "Wrong codeblock length.");
+        return false;
+      }
+
+      // read scup and fix the bytes there
+      int lcup, scup;
+      lcup = (int)lengths1;  // length of CUP
+      //scup is the length of MEL + VLC
+      scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
+      if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
+        return false;
+
+      // The temporary storage scratch holds two types of data in an
+      // interleaved fashion. The interleaving allows us to use one
+      // memory pointer.
+      // We have one entry for a decoded VLC code, and one entry for UVLC.
+      // Entries are 16 bits each, corresponding to one quad,
+      // but since we want to use XMM registers of the SSE family
+      // of SIMD; we allocated 16 bytes or more per quad row; that is,
+      // the width is no smaller than 16 bytes (or 8 entries), and the
+      // height is 512 quads
+      // Each VLC entry contains, in the following order, starting
+      // from MSB
+      // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
+      // Each entry in UVLC contains u_q
+      // One extra row to handle the case of SPP propagating downwards
+      // when codeblock width is 4
+      // We need an extra two entries (one inf and one u_q) beyond
+      // the last column.
+      // If the block width is 4 (2 quads), then we use sstr of 8
+      // (enough for 4 quads). If width is 8 (4 quads) we use
+      // sstr is 16 (enough for 8 quads). For a width of 16 (8
+      // quads), we use 24 (enough for 12 quads).
+      ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
+
+#ifdef __MINGW64__
+      ui16 scratch[8 * 513] = {0};
+#else
+      ui16 scratch[8 * 513];
+      ui32 quad_rows = (height + 1u) >> 1;
+      size_t scratch_zero = (size_t)(quad_rows + 1) * sstr;
+      if (scratch_zero > 8 * 513) scratch_zero = 8 * 513;
+      memset(scratch, 0, scratch_zero * sizeof(ui16));
+#endif
+
+      assert((stride & 0x3) == 0);
+
+      ui32 mmsbp2 = missing_msbs + 2;
+
+      // The cleanup pass is decoded in two steps; in step one,
+      // the VLC and MEL segments are decoded, generating a record that
+      // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
+      // This information should be sufficient for the next step.
+      // In step 2, we decode the MagSgn segment.
+
+      // step 1: decode VLC and MEL segments into scratch
+      decode_cb_step1_vlc(scratch, coded_data, lcup, scup, width, height, sstr);
+
+      // step2 we decode magsgn
+      // mmsbp2 equals K_max + 1 (we decode up to K_max bits + 1 sign bit)
+      // The 32 bit path decode 16 bits data, for which one would think
+      // 16 bits are enough, because we want to put in the center of the
+      // bin.
+      // If you have mmsbp2 equals 16 bit, and reversible coding, and
+      // no bitplanes are missing, then we can decoding using the 16 bit
+      // path, but we are not doing this here.
+      if (mmsbp2 >= 16)
+      {
+        if (!decode_cb_step2_32bit(scratch, decoded_data, coded_data,
+                                   width, height, stride, sstr, p, mmsbp2,
+                                   lcup, scup))
+          return false;
+      }
+      else {
+        if (!decode_cb_step2_16bit(scratch, decoded_data, coded_data,
+                                   width, height, stride, sstr, p, mmsbp2,
+                                   lcup, scup))
+          return false;
+      }
+
+      if (num_passes > 1)
+        decode_cb_spp_mrp(scratch, decoded_data, coded_data, width, height,
+                          stride, sstr, p, num_passes, lengths1, lengths2,
+                          stripe_causal);
+
+      return true;
+    }
+  }
 }
 
 #endif

--- a/Native/Common/OpenJPH/coding/ojph_block_decoder_ssse3.cpp
+++ b/Native/Common/OpenJPH/coding/ojph_block_decoder_ssse3.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -54,10 +54,8 @@
 
 #include <immintrin.h>
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //************************************************************************/
     /** @brief MEL state structure for reading and decoding the MEL bitstream
@@ -65,29 +63,27 @@ namespace ojph
      *  A number of events is decoded from the MEL bitstream ahead of time
      *  and stored in run/num_runs.
      *  Each run represents the number of zero events before a one event.
-     */
-    struct dec_mel_st
-    {
+     */ 
+    struct dec_mel_st {
       dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
-                     k(0), num_runs(0), runs(0)
-      {
-      }
+        k(0), num_runs(0), runs(0)
+      {}
       // data decoding machinery
-      ui8 *data;    //!< the address of data (or bitstream)
-      ui64 tmp;     //!< temporary buffer for read data
-      int bits;     //!< number of bits stored in tmp
-      int size;     //!< number of bytes in MEL code
-      bool unstuff; //!< true if the next bit needs to be unstuffed
-      int k;        //!< state of MEL decoder
+      ui8* data;    //!<the address of data (or bitstream)
+      ui64 tmp;     //!<temporary buffer for read data
+      int bits;     //!<number of bits stored in tmp
+      int size;     //!<number of bytes in MEL code
+      bool unstuff; //!<true if the next bit needs to be unstuffed
+      int k;        //!<state of MEL decoder
 
       // queue of decoded runs
-      int num_runs; //!< number of decoded runs left in runs (maximum 8)
-      ui64 runs;    //!< runs of decoded MEL codewords (7 bits/run)
+      int num_runs; //!<number of decoded runs left in runs (maximum 8)
+      ui64 runs;    //!<runs of decoded MEL codewords (7 bits/run)
     };
 
     //************************************************************************/
     /** @brief Reads and unstuffs the MEL bitstream
-     *
+     * 
      *  This design needs more bytes in the codeblock buffer than the length
      *  of the cleanup pass by up to 2 bytes.
      *
@@ -97,165 +93,165 @@ namespace ojph
      *
      *  @param [in]  melp is a pointer to dec_mel_st structure
      */
-    static inline void mel_read(dec_mel_st *melp)
+    static inline
+    void mel_read(dec_mel_st *melp)
     {
-      if (melp->bits > 32) // there are enough bits in the tmp variable
-        return;            // return without reading new data
+      if (melp->bits > 32)  //there are enough bits in the tmp variable
+        return;             // return without reading new data
 
-      ui32 val = 0xFFFFFFFF; // feed in 0xFF if buffer is exhausted
-      if (melp->size > 4)
-      {                            // if there is data in the MEL segment
-        val = *(ui32 *)melp->data; // read 32 bits from MEL data
+      ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
+      if (melp->size > 4) {        // if there is data in the MEL segment
+        val = *(ui32*)melp->data;  // read 32 bits from MEL data
         melp->data += 4;           // advance pointer
         melp->size -= 4;           // reduce counter
       }
       else if (melp->size > 0)
       { // 4 or less
         int i = 0;
-        while (melp->size > 1)
-        {
-          ui32 v = *melp->data++;     // read one byte at a time
-          ui32 m = ~(0xFFu << i);     // mask of location
-          val = (val & m) | (v << i); // put one byte in its correct location
+        while (melp->size > 1) {   
+          ui32 v = *melp->data++;    // read one byte at a time
+          ui32 m = ~(0xFFu << i);    // mask of location
+          val = (val & m) | (v << i);// put one byte in its correct location
           --melp->size;
           i += 8;
         }
         // size equal to 1
-        ui32 v = *melp->data++; // the one before the last is different
-        v |= 0xF;               // MEL and VLC segments can overlap
+        ui32 v = *melp->data++;    // the one before the last is different 
+        v |= 0xF;                  // MEL and VLC segments can overlap
         ui32 m = ~(0xFFu << i);
         val = (val & m) | (v << i);
         --melp->size;
       }
-
+      
       // next we unstuff them before adding them to the buffer
       int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
-                                     // the previously read byte requires
+                                     // the previously read byte requires 
                                      // unstuffing
 
       // data is unstuffed and accumulated in t
       // bits has the number of bits in t
-      ui32 t = val & 0xFF;
+      ui32 t = val & 0xFF; 
       bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
-      bits -= unstuff;                       // there is one less bit in t if unstuffing is needed
-      t = t << (8 - unstuff);                // move up to make room for the next byte
+      bits -= unstuff; // there is one less bit in t if unstuffing is needed
+      t = t << (8 - unstuff); // move up to make room for the next byte
 
-      // this is a repeat of the above
-      t |= (val >> 8) & 0xFF;
+      //this is a repeat of the above
+      t |= (val>>8) & 0xFF;
       unstuff = (((val >> 8) & 0xFF) == 0xFF);
       bits -= unstuff;
       t = t << (8 - unstuff);
 
-      t |= (val >> 16) & 0xFF;
+      t |= (val>>16) & 0xFF;
       unstuff = (((val >> 16) & 0xFF) == 0xFF);
       bits -= unstuff;
       t = t << (8 - unstuff);
 
-      t |= (val >> 24) & 0xFF;
+      t |= (val>>24) & 0xFF;
       melp->unstuff = (((val >> 24) & 0xFF) == 0xFF);
 
       // move t to tmp, and push the result all the way up, so we read from
       // the MSB
       melp->tmp |= ((ui64)t) << (64 - bits - melp->bits);
-      melp->bits += bits; // increment the number of bits in tmp
+      melp->bits += bits; //increment the number of bits in tmp
     }
 
     //************************************************************************/
     /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
-     *
+     * 
      *  Runs are stored in "runs" and the number of runs in "num_runs".
-     *  Each run represents a number of zero events that may or may not
+     *  Each run represents a number of zero events that may or may not 
      *  terminate in a 1 event.
      *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
-     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating
-     *  with 1, contain the number of consecutive 0 zero events * 2; for the
-     *  case terminating with 0, they store (number of consecutive 0 zero
+     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating 
+     *  with 1, contain the number of consecutive 0 zero events * 2; for the 
+     *  case terminating with 0, they store (number of consecutive 0 zero 
      *  events - 1) * 2.
      *  A total of 6 bits (made up of 1 + 5) should have been enough.
      *
      *  @param [in]  melp is a pointer to dec_mel_st structure
      */
-    static inline void mel_decode(dec_mel_st *melp)
+    static inline
+    void mel_decode(dec_mel_st *melp)
     {
-      static const int mel_exp[13] = {// MEL exponents
-                                      0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5};
+      static const int mel_exp[13] = { //MEL exponents
+        0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5
+      };
 
       if (melp->bits < 6) // if there are less than 6 bits in tmp
         mel_read(melp);   // then read from the MEL bitstream
                           // 6 bits is the largest decodable MEL cwd
 
-      // repeat so long that there is enough decodable bits in tmp,
-      //  and the runs store is not full (num_runs < 8)
+      //repeat so long that there is enough decodable bits in tmp,
+      // and the runs store is not full (num_runs < 8)
       while (melp->bits >= 6 && melp->num_runs < 8)
       {
         int eval = mel_exp[melp->k]; // number of bits associated with state
         int run = 0;
-        if (melp->tmp & (1ull << 63)) // The next bit to decode (stored in MSB)
-        {                             // one is found
-          run = 1 << eval;
-          run--;                                         // consecutive runs of 0 events - 1
-          melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12; // increment, max is 12
-          melp->tmp <<= 1;                               // consume one bit from tmp
+        if (melp->tmp & (1ull<<63)) //The next bit to decode (stored in MSB)
+        { //one is found
+          run = 1 << eval;  
+          run--; // consecutive runs of 0 events - 1
+          melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12;//increment, max is 12
+          melp->tmp <<= 1; // consume one bit from tmp
           melp->bits -= 1;
           run = run << 1; // a stretch of zeros not terminating in one
         }
         else
-        { // 0 is found
+        { //0 is found
           run = (int)(melp->tmp >> (63 - eval)) & ((1 << eval) - 1);
-          melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; // decrement, min is 0
-          melp->tmp <<= eval + 1;                      // consume eval + 1 bits (max is 6)
+          melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; //decrement, min is 0
+          melp->tmp <<= eval + 1; //consume eval + 1 bits (max is 6)
           melp->bits -= eval + 1;
           run = (run << 1) + 1; // a stretch of zeros terminating with one
         }
         eval = melp->num_runs * 7;           // 7 bits per run
         melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
         melp->runs |= ((ui64)run) << eval;   // store the value in runs
-        melp->num_runs++;                    // increment count
+        melp->num_runs++;                    // increment count  
       }
     }
 
     //************************************************************************/
     /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
      *         some bytes in order to get the read address to a multiple
-     *         of 4
+     *         of 4 
      *
      *  @param [in]  melp is a pointer to dec_mel_st structure
      *  @param [in]  bbuf is a pointer to byte buffer
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  scup is the length of MEL+VLC segments
      */
-    static inline void mel_init(dec_mel_st *melp, ui8 *bbuf, int lcup, int scup)
+    static inline
+    void mel_init(dec_mel_st *melp, ui8* bbuf, int lcup, int scup)
     {
       melp->data = bbuf + lcup - scup; // move the pointer to the start of MEL
       melp->bits = 0;                  // 0 bits in tmp
       melp->tmp = 0;                   //
       melp->unstuff = false;           // no unstuffing
       melp->size = scup - 1;           // size is the length of MEL+VLC-1
-      melp->k = 0;                     // 0 for state
+      melp->k = 0;                     // 0 for state 
       melp->num_runs = 0;              // num_runs is 0
       melp->runs = 0;                  //
 
-      // This code is borrowed; original is for a different architecture
-      // These few lines take care of the case where data is not at a multiple
-      //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
+      //This code is borrowed; original is for a different architecture
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
       int num = 4 - (int)(intptr_t(melp->data) & 0x3);
-      for (int i = 0; i < num; ++i)
-      { // this code is similar to mel_read
+      for (int i = 0; i < num; ++i) { // this code is similar to mel_read
         assert(melp->unstuff == false || melp->data[0] <= 0x8F);
-        ui64 d = (melp->size > 0) ? *melp->data : 0xFF; // if buffer is consumed
-                                                        // set data to 0xFF
-        if (melp->size == 1)
-          d |= 0xF; // if this is MEL+VLC-1, set LSBs to 0xF
-                    //  see the standard
-        melp->data += melp->size-- > 0;        // increment if the end is not reached
-        int d_bits = 8 - melp->unstuff;        // if unstuffing is needed, reduce by 1
-        melp->tmp = (melp->tmp << d_bits) | d; // store bits in tmp
-        melp->bits += d_bits;                  // increment tmp by number of bits
-        melp->unstuff = ((d & 0xFF) == 0xFF);  // true of next byte needs
-                                              // unstuffing
+        ui64 d = (melp->size > 0) ? *melp->data : 0xFF;//if buffer is consumed
+                                                       //set data to 0xFF
+        if (melp->size == 1) d |= 0xF; //if this is MEL+VLC-1, set LSBs to 0xF
+                                       // see the standard
+        melp->data += melp->size-- > 0; //increment if the end is not reached
+        int d_bits = 8 - melp->unstuff; //if unstuffing is needed, reduce by 1
+        melp->tmp = (melp->tmp << d_bits) | d; //store bits in tmp
+        melp->bits += d_bits;  //increment tmp by number of bits
+        melp->unstuff = ((d & 0xFF) == 0xFF); //true of next byte needs 
+                                              //unstuffing
       }
-      melp->tmp <<= (64 - melp->bits); // push all the way up so the first bit
-                                       //  is the MSB
+      melp->tmp <<= (64 - melp->bits); //push all the way up so the first bit
+                                       // is the MSB
     }
 
     //************************************************************************/
@@ -263,14 +259,15 @@ namespace ojph
      *         MEL segment is decoded
      *
      * @param [in]  melp is a pointer to dec_mel_st structure
-     */
-    static inline int mel_get_run(dec_mel_st *melp)
+     */    
+    static inline
+    int mel_get_run(dec_mel_st *melp)
     {
-      if (melp->num_runs == 0) // if no runs, decode more bit from MEL segment
+      if (melp->num_runs == 0)  //if no runs, decode more bit from MEL segment
         mel_decode(melp);
 
-      int t = melp->runs & 0x7F; // retrieve one run
-      melp->runs >>= 7;          // remove the retrieved run
+      int t = melp->runs & 0x7F; //retrieve one run
+      melp->runs >>= 7;  // remove the retrieved run
       melp->num_runs--;
       return t; // return run
     }
@@ -278,60 +275,58 @@ namespace ojph
     //************************************************************************/
     /** @brief A structure for reading and unstuffing a segment that grows
      *         backward, such as VLC and MRP
-     */
-    struct rev_struct
-    {
+     */ 
+    struct rev_struct {
       rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
-      {
-      }
-      // storage
-      ui8 *data;    //!< pointer to where to read data
-      ui64 tmp;     //!< temporary buffer of read data
-      ui32 bits;    //!< number of bits stored in tmp
-      int size;     //!< number of bytes left
-      bool unstuff; //!< true if the last byte is more than 0x8F
-                    //!< then the current byte is unstuffed if it is 0x7F
+      {}
+      //storage
+      ui8* data;     //!<pointer to where to read data
+      ui64 tmp;	     //!<temporary buffer of read data
+      ui32 bits;     //!<number of bits stored in tmp
+      int size;      //!<number of bytes left
+      bool unstuff;  //!<true if the last byte is more than 0x8F
+                     //!<then the current byte is unstuffed if it is 0x7F
     };
 
     //************************************************************************/
     /** @brief Read and unstuff data from a backwardly-growing segment
      *
      *  This reader can read up to 8 bytes from before the VLC segment.
-     *  Care must be taken not read from unreadable memory, causing a
+     *  Care must be taken not read from unreadable memory, causing a 
      *  segmentation fault.
-     *
+     * 
      *  Note that there is another subroutine rev_read_mrp that is slightly
      *  different.  The other one fills zeros when the buffer is exhausted.
      *  This one basically does not care if the bytes are consumed, because
      *  any extra data should not be used in the actual decoding.
      *
-     *  Unstuffing is needed to prevent sequences more than 0xFF8F from
+     *  Unstuffing is needed to prevent sequences more than 0xFF8F from 
      *  appearing in the bits stream; since we are reading backward, we keep
-     *  watch when a value larger than 0x8F appears in the bitstream.
-     *  If the byte following this is 0x7F, we unstuff this byte (ignore the
+     *  watch when a value larger than 0x8F appears in the bitstream. 
+     *  If the byte following this is 0x7F, we unstuff this byte (ignore the 
      *  MSB of that byte, which should be 0).
      *
      *  @param [in]  vlcp is a pointer to rev_struct structure
      */
-    static inline void rev_read(rev_struct *vlcp)
+    static inline 
+    void rev_read(rev_struct *vlcp)
     {
-      // process 4 bytes at a time
-      if (vlcp->bits > 32) // if there are more than 32 bits in tmp, then
-        return;            // reading 32 bits can overflow vlcp->tmp
+      //process 4 bytes at a time
+      if (vlcp->bits > 32)  // if there are more than 32 bits in tmp, then 
+        return;             // reading 32 bits can overflow vlcp->tmp
       ui32 val = 0;
-      // the next line (the if statement) needs to be tested first
-      if (vlcp->size > 3) // if there are more than 3 bytes left in VLC
+      //the next line (the if statement) needs to be tested first
+      if (vlcp->size > 3)  // if there are more than 3 bytes left in VLC
       {
         // (vlcp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32 *)(vlcp->data - 3); // then read 32 bits
-        vlcp->data -= 4;                 // move data pointer back by 4
-        vlcp->size -= 4;                 // reduce available byte by 4
+        val = *(ui32*)(vlcp->data - 3); // then read 32 bits
+        vlcp->data -= 4;          // move data pointer back by 4
+        vlcp->size -= 4;          // reduce available byte by 4
       }
       else if (vlcp->size > 0)
       { // 4 or less
         int i = 24;
-        while (vlcp->size > 0)
-        {
+        while (vlcp->size > 0) {   
           ui32 v = *vlcp->data--; // read one byte at a time
           val |= (v << i);        // put byte in its correct location
           --vlcp->size;
@@ -339,15 +334,15 @@ namespace ojph
         }
       }
 
-      // accumulate in tmp, number of bits in tmp are stored in bits
-      ui32 tmp = val >> 24; // start with the MSB byte
+      //accumulate in tmp, number of bits in tmp are stored in bits
+      ui32 tmp = val >> 24;  //start with the MSB byte
       ui32 bits;
 
       // test unstuff (previous byte is >0x8F), and this byte is 0x7F
       bits = 8 - ((vlcp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
-      bool unstuff = (val >> 24) > 0x8F; // this is for the next byte
+      bool unstuff = (val >> 24) > 0x8F; //this is for the next byte
 
-      tmp |= ((val >> 16) & 0xFF) << bits; // process the next byte
+      tmp |= ((val >> 16) & 0xFF) << bits; //process the next byte
       bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
       unstuff = ((val >> 16) & 0xFF) > 0x8F;
 
@@ -366,7 +361,7 @@ namespace ojph
     }
 
     //************************************************************************/
-    /** @brief Initiates the rev_struct structure and reads a few bytes to
+    /** @brief Initiates the rev_struct structure and reads a few bytes to 
      *         move the read address to multiple of 4
      *
      *  There is another similar rev_init_mrp subroutine.  The difference is
@@ -379,54 +374,55 @@ namespace ojph
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  scup is the length of MEL+VLC segments
      */
-    static inline void rev_init(rev_struct *vlcp, ui8 *data, int lcup, int scup)
+    static inline 
+    void rev_init(rev_struct *vlcp, ui8* data, int lcup, int scup)
     {
-      // first byte has only the upper 4 bits
+      //first byte has only the upper 4 bits
       vlcp->data = data + lcup - 2;
 
-      // size can not be larger than this, in fact it should be smaller
+      //size can not be larger than this, in fact it should be smaller
       vlcp->size = scup - 2;
 
-      ui32 d = *vlcp->data--;                  // read one byte (this is a half byte)
-      vlcp->tmp = d >> 4;                      // both initialize and set
-      vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); // check standard
-      vlcp->unstuff = (d | 0xF) > 0x8F;        // this is useful for the next byte
+      ui32 d = *vlcp->data--; // read one byte (this is a half byte)
+      vlcp->tmp = d >> 4;    // both initialize and set
+      vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); //check standard
+      vlcp->unstuff = (d | 0xF) > 0x8F; //this is useful for the next byte
 
-      // This code is designed for an architecture that read address should
-      //  align to the read size (address multiple of 4 if read size is 4)
-      // These few lines take care of the case where data is not at a multiple
-      //  of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
-      //  To read 32 bits, read from (vlcp->data - 3)
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
+      // To read 32 bits, read from (vlcp->data - 3)
       int num = 1 + (int)(intptr_t(vlcp->data) & 0x3);
       int tnum = num < vlcp->size ? num : vlcp->size;
-      for (int i = 0; i < tnum; ++i)
-      {
+      for (int i = 0; i < tnum; ++i) {
         ui64 d;
-        d = *vlcp->data--; // read one byte and move read pointer
-        // check if the last byte was >0x8F (unstuff == true) and this is 0x7F
+        d = *vlcp->data--;  // read one byte and move read pointer
+        //check if the last byte was >0x8F (unstuff == true) and this is 0x7F
         ui32 d_bits = 8 - ((vlcp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
         vlcp->tmp |= d << vlcp->bits; // move data to vlcp->tmp
         vlcp->bits += d_bits;
         vlcp->unstuff = d > 0x8F; // for next byte
       }
       vlcp->size -= tnum;
-      rev_read(vlcp); // read another 32 buts
+      rev_read(vlcp);  // read another 32 buts
     }
 
     //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
      *
      *  By the end of this call, vlcp->tmp must have no less than 33 bits
      *
      *  @param [in]  vlcp is a pointer to rev_struct structure
      */
-    static inline ui32 rev_fetch(rev_struct *vlcp)
+    static inline 
+    ui32 rev_fetch(rev_struct *vlcp)
     {
-      if (vlcp->bits < 32) // if there are less then 32 bits, read more
+      if (vlcp->bits < 32)  // if there are less then 32 bits, read more
       {
-        rev_read(vlcp);      // read 32 bits, but unstuffing might reduce this
-        if (vlcp->bits < 32) // if there is still space in vlcp->tmp for 32 bits
-          rev_read(vlcp);    // read another 32
+        rev_read(vlcp);     // read 32 bits, but unstuffing might reduce this
+        if (vlcp->bits < 32)// if there is still space in vlcp->tmp for 32 bits
+          rev_read(vlcp);   // read another 32
       }
       return (ui32)vlcp->tmp; // return the head (bottom-most) of vlcp->tmp
     }
@@ -437,7 +433,8 @@ namespace ojph
      *  @param [in]  vlcp is a pointer to rev_struct structure
      *  @param [in]  num_bits is the number of bits to be removed
      */
-    static inline ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
+    static inline 
+    ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
     {
       assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
       vlcp->tmp >>= num_bits;         // remove bits
@@ -456,23 +453,23 @@ namespace ojph
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
      */
-    static inline void rev_read_mrp(rev_struct *mrp)
+    static inline 
+    void rev_read_mrp(rev_struct *mrp)
     {
-      // process 4 bytes at a time
+      //process 4 bytes at a time
       if (mrp->bits > 32)
         return;
       ui32 val = 0;
-      if (mrp->size > 3)                // If there are 3 byte or more
-      {                                 // (mrp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32 *)(mrp->data - 3); // read 32 bits
-        mrp->data -= 4;                 // move back pointer
-        mrp->size -= 4;                 // reduce count
+      if (mrp->size > 3) // If there are 3 byte or more
+      { // (mrp->data - 3) move pointer back to read 32 bits at once
+        val = *(ui32*)(mrp->data - 3); // read 32 bits
+        mrp->data -= 4;                // move back pointer
+        mrp->size -= 4;                // reduce count
       }
       else if (mrp->size > 0)
       {
         int i = 24;
-        while (mrp->size > 0)
-        {
+        while (mrp->size > 0) {   
           ui32 v = *mrp->data--; // read one byte at a time
           val |= (v << i);       // put byte in its correct location
           --mrp->size;
@@ -480,14 +477,14 @@ namespace ojph
         }
       }
 
-      // accumulate in tmp, and keep count in bits
+      //accumulate in tmp, and keep count in bits
       ui32 bits, tmp = val >> 24;
 
-      // test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
+      //test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
       bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
       bool unstuff = (val >> 24) > 0x8F;
 
-      // process the next byte
+      //process the next byte
       tmp |= ((val >> 16) & 0xFF) << bits;
       bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
       unstuff = ((val >> 16) & 0xFF) > 0x8F;
@@ -502,7 +499,7 @@ namespace ojph
 
       mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
       mrp->bits += bits;
-      mrp->unstuff = unstuff; // next byte
+      mrp->unstuff = unstuff;             // next byte
     }
 
     //************************************************************************/
@@ -512,7 +509,7 @@ namespace ojph
      *         an architecture that read size must be compatible with the
      *         alignment of the read address
      *
-     *  There is another similar subroutine rev_init.  This subroutine does
+     *  There is another similar subroutine rev_init.  This subroutine does 
      *  NOT skip the first 12 bits, and starts with unstuff set to true.
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
@@ -520,7 +517,8 @@ namespace ojph
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  len2 is the length of SPP+MRP segments
      */
-    static inline void rev_init_mrp(rev_struct *mrp, ui8 *data, int lcup, int len2)
+    static inline 
+    void rev_init_mrp(rev_struct *mrp, ui8* data, int lcup, int len2)
     {
       mrp->data = data + lcup + len2 - 1;
       mrp->size = len2;
@@ -528,17 +526,16 @@ namespace ojph
       mrp->bits = 0;
       mrp->tmp = 0;
 
-      // This code is designed for an architecture that read address should
-      //  align to the read size (address multiple of 4 if read size is 4)
-      // These few lines take care of the case where data is not at a multiple
-      //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
       int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
-      for (int i = 0; i < num; ++i)
-      {
+      for (int i = 0; i < num; ++i) {
         ui64 d;
-        // read a byte, 0 if no more data
-        d = (mrp->size-- > 0) ? *mrp->data-- : 0;
-        // check if unstuffing is needed
+        //read a byte, 0 if no more data
+        d = (mrp->size-- > 0) ? *mrp->data-- : 0; 
+        //check if unstuffing is needed
         ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
         mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
         mrp->bits += d_bits;
@@ -548,21 +545,22 @@ namespace ojph
     }
 
     //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
      *
      *  By the end of this call, mrp->tmp must have no less than 33 bits
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
      */
-    static inline ui32 rev_fetch_mrp(rev_struct *mrp)
+    static inline 
+    ui32 rev_fetch_mrp(rev_struct *mrp)
     {
       if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
       {
-        rev_read_mrp(mrp);   // read 30-32 bits from mrp
-        if (mrp->bits < 32)  // if there is a space of 32 bits
-          rev_read_mrp(mrp); // read more
+        rev_read_mrp(mrp);    // read 30-32 bits from mrp
+        if (mrp->bits < 32)   // if there is a space of 32 bits
+          rev_read_mrp(mrp);  // read more
       }
-      return (ui32)mrp->tmp; // return the head of mrp->tmp
+      return (ui32)mrp->tmp;  // return the head of mrp->tmp
     }
 
     //************************************************************************/
@@ -574,27 +572,26 @@ namespace ojph
     inline ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
     {
       assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
-      mrp->tmp >>= num_bits;         // discard the lowest num_bits bits
+      mrp->tmp >>= num_bits;  // discard the lowest num_bits bits
       mrp->bits -= num_bits;
-      return (ui32)mrp->tmp; // return data after consumption
+      return (ui32)mrp->tmp;  // return data after consumption
     }
 
     //************************************************************************/
-    /** @brief State structure for reading and unstuffing of forward-growing
+    /** @brief State structure for reading and unstuffing of forward-growing 
      *         bitstreams; these are: MagSgn and SPP bitstreams
      */
-    struct frwd_struct_ssse3
-    {
-      const ui8 *data; //!< pointer to bitstream
-      ui8 tmp[48];     //!< temporary buffer of read data + 16 extra
-      ui32 bits;       //!< number of bits stored in tmp
-      ui32 unstuff;    //!< 1 if a bit needs to be unstuffed from next byte
-      int size;        //!< size of data
+    struct frwd_struct_ssse3 {
+      const ui8* data;  //!<pointer to bitstream
+      ui8 tmp[48];      //!<temporary buffer of read data + 16 extra
+      ui32 bits;        //!<number of bits stored in tmp
+      ui32 unstuff;     //!<1 if a bit needs to be unstuffed from next byte
+      int size;         //!<size of data
     };
 
     //************************************************************************/
     /** @brief Read and unstuffs 16 bytes from forward-growing bitstream
-     *
+     *  
      *  A template is used to accommodate a different requirement for
      *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
      *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
@@ -610,40 +607,41 @@ namespace ojph
      *  @param  [in]  msp is a pointer to frwd_struct_ssse3 structure
      *
      */
-    template <int X>
-    static inline void frwd_read(frwd_struct_ssse3 *msp)
+    template<int X>
+    static inline 
+    void frwd_read(frwd_struct_ssse3 *msp)
     {
       assert(msp->bits <= 128);
 
       __m128i offset, val, validity, all_xff;
-      val = _mm_loadu_si128((__m128i *)msp->data);
+      val = _mm_loadu_si128((__m128i*)msp->data);
       int bytes = msp->size >= 16 ? 16 : msp->size;
       validity = _mm_set1_epi8((char)bytes);
       msp->data += bytes;
       msp->size -= bytes;
       int bits = 128;
-      offset = _mm_set_epi64x(0x0F0E0D0C0B0A0908, 0x0706050403020100);
+      offset = _mm_set_epi64x(0x0F0E0D0C0B0A0908,0x0706050403020100);
       validity = _mm_cmpgt_epi8(validity, offset);
       all_xff = _mm_set1_epi8(-1);
       if (X == 0xFF) // the compiler should remove this if statement
       {
         __m128i t = _mm_xor_si128(validity, all_xff); // complement
-        val = _mm_or_si128(t, val);                   // fill with 0xFF
+        val = _mm_or_si128(t, val); // fill with 0xFF
       }
       else if (X == 0)
-        val = _mm_and_si128(validity, val); // fill with zeros
+        val = _mm_and_si128(validity, val); // fill with zeros 
       else
         assert(0);
 
       __m128i ff_bytes;
       ff_bytes = _mm_cmpeq_epi8(val, all_xff);
       ff_bytes = _mm_and_si128(ff_bytes, validity);
-      ui32 flags = (ui32)_mm_movemask_epi8(ff_bytes);
+      ui32 flags = (ui32)_mm_movemask_epi8(ff_bytes); 
       flags <<= 1; // unstuff following byte
       ui32 next_unstuff = flags >> 16;
       flags |= msp->unstuff;
       flags &= 0xFFFF;
-      while (flags)
+      while (flags) 
       { // bit unstuffing occurs on average once every 256 bytes
         // therefore it is not an issue if it is a bit slow
         // here we process 16 bytes
@@ -656,12 +654,12 @@ namespace ojph
         t = _mm_set1_epi8((char)loc);
         m = _mm_cmpgt_epi8(offset, t);
 
-        t = _mm_and_si128(m, val); // keep bits at locations larger than loc
-        c = _mm_srli_epi64(t, 1);  // 1 bits left
-        t = _mm_srli_si128(t, 8);  // 8 bytes left
-        t = _mm_slli_epi64(t, 63); // keep the MSB only
-        t = _mm_or_si128(t, c);    // combine the above 3 steps
-
+        t = _mm_and_si128(m, val);  // keep bits at locations larger than loc
+        c = _mm_srli_epi64(t, 1);   // 1 bits left
+        t = _mm_srli_si128(t, 8);   // 8 bytes left
+        t = _mm_slli_epi64(t, 63);  // keep the MSB only
+        t = _mm_or_si128(t, c);     // combine the above 3 steps
+                                    
         val = _mm_or_si128(t, _mm_andnot_si128(m, val));
       }
 
@@ -671,12 +669,12 @@ namespace ojph
       int cur_bits = msp->bits & 7;
       __m128i b1, b2;
       b1 = _mm_sll_epi64(val, _mm_set1_epi64x(cur_bits));
-      b2 = _mm_slli_si128(val, 8); // 8 bytes right
-      b2 = _mm_srl_epi64(b2, _mm_set1_epi64x(64 - cur_bits));
+      b2 = _mm_slli_si128(val, 8);  // 8 bytes right
+      b2 = _mm_srl_epi64(b2, _mm_set1_epi64x(64-cur_bits));
       b1 = _mm_or_si128(b1, b2);
-      b2 = _mm_loadu_si128((__m128i *)(msp->tmp + cur_bytes));
+      b2 = _mm_loadu_si128((__m128i*)(msp->tmp + cur_bytes));
       b2 = _mm_or_si128(b1, b2);
-      _mm_storeu_si128((__m128i *)(msp->tmp + cur_bytes), b2);
+      _mm_storeu_si128((__m128i*)(msp->tmp + cur_bytes), b2);
 
       int consumed_bits = bits < 128 - cur_bits ? bits : 128 - cur_bits;
       cur_bytes = (msp->bits + (ui32)consumed_bits + 7) >> 3; // round up
@@ -685,21 +683,22 @@ namespace ojph
       msp->tmp[cur_bytes] = (ui8)upper; // copy byte
 
       msp->bits += (ui32)bits;
-      msp->unstuff = next_unstuff; // next unstuff
+      msp->unstuff = next_unstuff;   // next unstuff
       assert(msp->unstuff == 0 || msp->unstuff == 1);
     }
 
     //************************************************************************/
     /** @brief Initialize frwd_struct_ssse3 struct and reads some bytes
-     *
+     *  
      *  @tparam      X is the value fed in when the bitstream is exhausted.
      *               See frwd_read regarding the template
      *  @param [in]  msp is a pointer to frwd_struct_ssse3
      *  @param [in]  data is a pointer to the start of data
      *  @param [in]  size is the number of byte in the bitstream
      */
-    template <int X>
-    static inline void frwd_init(frwd_struct_ssse3 *msp, const ui8 *data, int size)
+    template<int X>
+    static inline 
+    void frwd_init(frwd_struct_ssse3 *msp, const ui8* data, int size)
     {
       msp->data = data;
       _mm_storeu_si128((__m128i *)msp->tmp, _mm_setzero_si128());
@@ -719,12 +718,13 @@ namespace ojph
      *  @param [in]  msp is a pointer to frwd_struct_ssse3
      *  @param [in]  num_bits is the number of bit to consume
      */
-    static inline void frwd_advance(frwd_struct_ssse3 *msp, ui32 num_bits)
+    static inline 
+    void frwd_advance(frwd_struct_ssse3 *msp, ui32 num_bits)
     {
       assert(num_bits > 0 && num_bits <= msp->bits && num_bits < 128);
       msp->bits -= num_bits;
 
-      __m128i *p = (__m128i *)(msp->tmp + ((num_bits >> 3) & 0x18));
+      __m128i *p = (__m128i*)(msp->tmp + ((num_bits >> 3) & 0x18));
       num_bits &= 63;
 
       __m128i v0, v1, c0, c1, t;
@@ -740,14 +740,14 @@ namespace ojph
       t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
       c0 = _mm_or_si128(c0, t);
 
-      _mm_storeu_si128((__m128i *)msp->tmp, c0);
+      _mm_storeu_si128((__m128i*)msp->tmp, c0);
 
       c1 = _mm_srl_epi64(v1, _mm_set1_epi64x(num_bits));
       t = _mm_srli_si128(v1, 8);
       t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
       c1 = _mm_or_si128(c1, t);
 
-      _mm_storeu_si128((__m128i *)msp->tmp + 1, c1);
+      _mm_storeu_si128((__m128i*)msp->tmp + 1, c1);
     }
 
     //************************************************************************/
@@ -757,16 +757,17 @@ namespace ojph
      *               See frwd_read regarding the template
      *  @param [in]  msp is a pointer to frwd_struct_ssse3
      */
-    template <int X>
-    static inline __m128i frwd_fetch(frwd_struct_ssse3 *msp)
+    template<int X>
+    static inline
+    __m128i frwd_fetch(frwd_struct_ssse3 *msp)
     {
       if (msp->bits <= 128)
       {
         frwd_read<X>(msp);
-        if (msp->bits <= 128) // need to test
+        if (msp->bits <= 128) //need to test
           frwd_read<X>(msp);
       }
-      __m128i t = _mm_loadu_si128((__m128i *)msp->tmp);
+      __m128i t = _mm_loadu_si128((__m128i*)msp->tmp);
       return t;
     }
 
@@ -783,8 +784,9 @@ namespace ojph
      *  @return __m128i decoded quad
      */
     template <int N>
-    static inline __m128i decode_one_quad32(const __m128i inf_u_q, __m128i U_q,
-                                            frwd_struct_ssse3 *magsgn, ui32 p, __m128i &vn)
+    static inline 
+    __m128i decode_one_quad32(const __m128i inf_u_q, __m128i U_q,
+                              frwd_struct_ssse3* magsgn, ui32 p, __m128i& vn)
     {
       __m128i w0;    // workers
       __m128i insig; // lanes hold FF's if samples are insignificant
@@ -796,11 +798,11 @@ namespace ojph
       // we keeps e_k, e_1, and rho in w2
       flags = _mm_and_si128(w0, _mm_set_epi32(0x8880, 0x4440, 0x2220, 0x1110));
       insig = _mm_cmpeq_epi32(flags, _mm_setzero_si128());
-      if (_mm_movemask_epi8(insig) != 0xFFFF) // are all insignificant?
+      if (_mm_movemask_epi8(insig) != 0xFFFF) //are all insignificant?
       {
         U_q = _mm_shuffle_epi32(U_q, _MM_SHUFFLE(N, N, N, N));
-        flags = _mm_mullo_epi16(flags, _mm_set_epi16(1, 1, 2, 2, 4, 4, 8, 8));
-        __m128i ms_vec = frwd_fetch<0xFF>(magsgn);
+        flags = _mm_mullo_epi16(flags, _mm_set_epi16(1,1,2,2,4,4,8,8));
+        __m128i ms_vec = frwd_fetch<0xFF>(magsgn); 
 
         // U_q holds U_q for this quad
         // flags has e_k, e_1, and rho such that e_k is sitting in the
@@ -823,8 +825,8 @@ namespace ojph
         // find the starting byte and starting bit
         __m128i byte_idx = _mm_srli_epi32(ex_sum, 3);
         __m128i bit_idx = _mm_and_si128(ex_sum, _mm_set1_epi32(7));
-        byte_idx = _mm_shuffle_epi8(byte_idx,
-                                    _mm_set_epi32(0x0C0C0C0C, 0x08080808, 0x04040404, 0x00000000));
+        byte_idx = _mm_shuffle_epi8(byte_idx, 
+          _mm_set_epi32(0x0C0C0C0C, 0x08080808, 0x04040404, 0x00000000));
         byte_idx = _mm_add_epi32(byte_idx, _mm_set1_epi32(0x03020100));
         __m128i d0 = _mm_shuffle_epi8(ms_vec, byte_idx);
         byte_idx = _mm_add_epi32(byte_idx, _mm_set1_epi32(0x01010101));
@@ -833,9 +835,8 @@ namespace ojph
         // shift samples values to correct location
         bit_idx = _mm_or_si128(bit_idx, _mm_slli_epi32(bit_idx, 16));
         __m128i bit_shift = _mm_shuffle_epi8(
-            _mm_set_epi8(1, 3, 7, 15, 31, 63, 127, -1,
-                         1, 3, 7, 15, 31, 63, 127, -1),
-            bit_idx);
+          _mm_set_epi8(1, 3, 7, 15, 31, 63, 127, -1,
+                       1, 3, 7, 15, 31, 63, 127, -1), bit_idx);
         bit_shift = _mm_add_epi16(bit_shift, _mm_set1_epi16(0x0101));
         d0 = _mm_mullo_epi16(d0, bit_shift);
         d0 = _mm_srli_epi16(d0, 8); // we should have 8 bits in the LSB
@@ -848,31 +849,31 @@ namespace ojph
         __m128i ones = _mm_set1_epi32(1);
         __m128i twos = _mm_set1_epi32(2);
         __m128i U_q_m1 = _mm_sub_epi32(U_q, ones);
-        U_q_m1 = _mm_and_si128(U_q_m1, _mm_set_epi32(0, 0, 0, 0x1F));
-        w0 = _mm_sub_epi32(twos, w0);
+        U_q_m1 = _mm_and_si128(U_q_m1, _mm_set_epi32(0,0,0,0x1F));
+        w0 = _mm_sub_epi32(twos, w0);        
         shift = _mm_sll_epi32(w0, U_q_m1); // U_q_m1 must be no more than 31
         ms_vec = _mm_and_si128(d0, _mm_sub_epi32(shift, ones));
 
         // next e_1
         w0 = _mm_and_si128(flags, _mm_set1_epi32(0x800));
         w0 = _mm_cmpeq_epi32(w0, _mm_setzero_si128());
-        w0 = _mm_andnot_si128(w0, shift);    // e_1 in correct position
-        ms_vec = _mm_or_si128(ms_vec, w0);   // e_1
-        w0 = _mm_slli_epi32(ms_vec, 31);     // sign
+        w0 = _mm_andnot_si128(w0, shift);  // e_1 in correct position
+        ms_vec = _mm_or_si128(ms_vec, w0); // e_1
+        w0 = _mm_slli_epi32(ms_vec, 31);   // sign
         ms_vec = _mm_or_si128(ms_vec, ones); // bin center
         __m128i tvn = ms_vec;
-        ms_vec = _mm_add_epi32(ms_vec, twos); // + 2
+        ms_vec = _mm_add_epi32(ms_vec, twos);// + 2
         ms_vec = _mm_slli_epi32(ms_vec, (si32)p - 1);
-        ms_vec = _mm_or_si128(ms_vec, w0);     // sign
+        ms_vec = _mm_or_si128(ms_vec, w0); // sign
         row = _mm_andnot_si128(insig, ms_vec); // significant only
 
         ms_vec = _mm_andnot_si128(insig, tvn); // significant only
-        if (N == 0)                            // the compiler should remove one
-          tvn = _mm_shuffle_epi8(ms_vec,
-                                 _mm_set_epi32(-1, -1, 0x0F0E0D0C, 0x07060504));
+        if (N == 0) // the compiler should remove one
+          tvn = _mm_shuffle_epi8(ms_vec, 
+            _mm_set_epi32(-1, -1, 0x0F0E0D0C, 0x07060504));
         else if (N == 1)
-          tvn = _mm_shuffle_epi8(ms_vec,
-                                 _mm_set_epi32(-1, 0x0F0E0D0C, 0x07060504, -1));
+          tvn = _mm_shuffle_epi8(ms_vec, 
+            _mm_set_epi32(-1, 0x0F0E0D0C, 0x07060504, -1));
         else
           assert(0);
         vn = _mm_or_si128(vn, tvn);
@@ -883,7 +884,7 @@ namespace ojph
       return row;
     }
 
-    //************************************************************************/
+   //************************************************************************/
     /** @brief decodes twos consecutive quads (one octet), using 16 bit data
      *
      *  @param inf_u_q  decoded VLC code, with interleaved u values
@@ -893,30 +894,31 @@ namespace ojph
      *  @param vn       used for handling E values (stores v_n values)
      *  @return __m128i decoded quad
      */
-    static inline __m128i decode_two_quad16(const __m128i inf_u_q, __m128i U_q,
-                                            frwd_struct_ssse3 *magsgn, ui32 p, __m128i &vn)
+    static inline 
+    __m128i decode_two_quad16(const __m128i inf_u_q, __m128i U_q, 
+                              frwd_struct_ssse3* magsgn, ui32 p, __m128i& vn)
     {
-      __m128i w0;    // workers
-      __m128i insig; // lanes hold FF's if samples are insignificant
-      __m128i flags; // lanes hold e_k, e_1, and rho
-      __m128i row;   // decoded row
+      __m128i w0;     // workers
+      __m128i insig;  // lanes hold FF's if samples are insignificant
+      __m128i flags;  // lanes hold e_k, e_1, and rho
+      __m128i row;    // decoded row
 
       row = _mm_setzero_si128();
-      w0 = _mm_shuffle_epi8(inf_u_q,
-                            _mm_set_epi16(0x0504, 0x0504, 0x0504, 0x0504,
-                                          0x0100, 0x0100, 0x0100, 0x0100));
+      w0 = _mm_shuffle_epi8(inf_u_q, 
+        _mm_set_epi16(0x0504, 0x0504, 0x0504, 0x0504,
+                      0x0100, 0x0100, 0x0100, 0x0100));
       // we keeps e_k, e_1, and rho in w2
-      flags = _mm_and_si128(w0,
-                            _mm_set_epi16((si16)0x8880, 0x4440, 0x2220, 0x1110,
-                                          (si16)0x8880, 0x4440, 0x2220, 0x1110));
+      flags = _mm_and_si128(w0, 
+        _mm_set_epi16((si16)0x8880, 0x4440, 0x2220, 0x1110,
+                      (si16)0x8880, 0x4440, 0x2220, 0x1110));
       insig = _mm_cmpeq_epi16(flags, _mm_setzero_si128());
-      if (_mm_movemask_epi8(insig) != 0xFFFF) // are all insignificant?
+      if (_mm_movemask_epi8(insig) != 0xFFFF) //are all insignificant?
       {
-        U_q = _mm_shuffle_epi8(U_q,
-                               _mm_set_epi16(0x0504, 0x0504, 0x0504, 0x0504,
-                                             0x0100, 0x0100, 0x0100, 0x0100));
-        flags = _mm_mullo_epi16(flags, _mm_set_epi16(1, 2, 4, 8, 1, 2, 4, 8));
-        __m128i ms_vec = frwd_fetch<0xFF>(magsgn);
+        U_q = _mm_shuffle_epi8(U_q, 
+          _mm_set_epi16(0x0504, 0x0504, 0x0504, 0x0504,
+                        0x0100, 0x0100, 0x0100, 0x0100));
+        flags = _mm_mullo_epi16(flags, _mm_set_epi16(1,2,4,8,1,2,4,8));
+        __m128i ms_vec = frwd_fetch<0xFF>(magsgn); 
 
         // U_q holds U_q for this quad
         // flags has e_k, e_1, and rho such that e_k is sitting in the
@@ -940,9 +942,9 @@ namespace ojph
         // find the starting byte and starting bit
         __m128i byte_idx = _mm_srli_epi16(ex_sum, 3);
         __m128i bit_idx = _mm_and_si128(ex_sum, _mm_set1_epi16(7));
-        byte_idx = _mm_shuffle_epi8(byte_idx,
-                                    _mm_set_epi16(0x0E0E, 0x0C0C, 0x0A0A, 0x0808,
-                                                  0x0606, 0x0404, 0x0202, 0x0000));
+        byte_idx = _mm_shuffle_epi8(byte_idx, 
+          _mm_set_epi16(0x0E0E, 0x0C0C, 0x0A0A, 0x0808, 
+                        0x0606, 0x0404, 0x0202, 0x0000));
         byte_idx = _mm_add_epi16(byte_idx, _mm_set1_epi16(0x0100));
         __m128i d0 = _mm_shuffle_epi8(ms_vec, byte_idx);
         byte_idx = _mm_add_epi16(byte_idx, _mm_set1_epi16(0x0101));
@@ -950,9 +952,8 @@ namespace ojph
 
         // shift samples values to correct location
         __m128i bit_shift = _mm_shuffle_epi8(
-            _mm_set_epi8(1, 3, 7, 15, 31, 63, 127, -1,
-                         1, 3, 7, 15, 31, 63, 127, -1),
-            bit_idx);
+          _mm_set_epi8(1, 3, 7, 15, 31, 63, 127, -1,
+                       1, 3, 7, 15, 31, 63, 127, -1), bit_idx);
         bit_shift = _mm_add_epi16(bit_shift, _mm_set1_epi16(0x0101));
         d0 = _mm_mullo_epi16(d0, bit_shift);
         d0 = _mm_srli_epi16(d0, 8); // we should have 8 bits in the LSB
@@ -965,7 +966,7 @@ namespace ojph
         __m128i ones = _mm_set1_epi16(1);
         __m128i twos = _mm_set1_epi16(2);
         __m128i U_q_m1 = _mm_sub_epi32(U_q, ones);
-        Uq0 = _mm_and_si128(U_q_m1, _mm_set_epi32(0, 0, 0, 0x1F));
+        Uq0 = _mm_and_si128(U_q_m1, _mm_set_epi32(0,0,0,0x1F));
         Uq1 = _mm_bsrli_si128(U_q_m1, 14);
         w0 = _mm_sub_epi16(twos, w0);
         t0 = _mm_and_si128(w0, _mm_set_epi64x(0, -1));
@@ -978,22 +979,22 @@ namespace ojph
         // next e_1
         w0 = _mm_and_si128(flags, _mm_set1_epi16(0x800));
         w0 = _mm_cmpeq_epi16(w0, _mm_setzero_si128());
-        w0 = _mm_andnot_si128(w0, shift);    // e_1 in correct position
-        ms_vec = _mm_or_si128(ms_vec, w0);   // e_1
-        w0 = _mm_slli_epi16(ms_vec, 15);     // sign
+        w0 = _mm_andnot_si128(w0, shift);  // e_1 in correct position
+        ms_vec = _mm_or_si128(ms_vec, w0); // e_1
+        w0 = _mm_slli_epi16(ms_vec, 15);   // sign
         ms_vec = _mm_or_si128(ms_vec, ones); // bin center
         __m128i tvn = ms_vec;
-        ms_vec = _mm_add_epi16(ms_vec, twos); // + 2
+        ms_vec = _mm_add_epi16(ms_vec, twos);// + 2
         ms_vec = _mm_slli_epi16(ms_vec, (si32)p - 1);
-        ms_vec = _mm_or_si128(ms_vec, w0);     // sign
+        ms_vec = _mm_or_si128(ms_vec, w0); // sign
         row = _mm_andnot_si128(insig, ms_vec); // significant only
 
         ms_vec = _mm_andnot_si128(insig, tvn); // significant only
-        w0 = _mm_shuffle_epi8(ms_vec,
-                              _mm_set_epi16(-1, -1, -1, -1, -1, -1, 0x0706, 0x0302));
+        w0 = _mm_shuffle_epi8(ms_vec, 
+          _mm_set_epi16(-1, -1, -1, -1, -1, -1, 0x0706, 0x0302));
         vn = _mm_or_si128(vn, w0);
-        w0 = _mm_shuffle_epi8(ms_vec,
-                              _mm_set_epi16(-1, -1, -1, -1, -1, 0x0F0E, 0x0B0A, -1));
+        w0 = _mm_shuffle_epi8(ms_vec, 
+          _mm_set_epi16(-1, -1, -1, -1, -1, 0x0F0E, 0x0B0A, -1));
         vn = _mm_or_si128(vn, w0);
 
         if (total_mn)
@@ -1001,6 +1002,7 @@ namespace ojph
       }
       return row;
     }
+
 
     //************************************************************************/
     /** @brief Decodes one codeblock, processing the cleanup, siginificance
@@ -1014,12 +1016,12 @@ namespace ojph
      *  @param [in]   lengths1 is the length of cleanup pass
      *  @param [in]   lengths2 is the length of refinement passes (either SPP
      *                only or SPP+MRP)
-     *  @param [in]   width is the decoded codeblock width
+     *  @param [in]   width is the decoded codeblock width 
      *  @param [in]   height is the decoded codeblock height
-     *  @param [in]   stride is the decoded codeblock buffer stride
+     *  @param [in]   stride is the decoded codeblock buffer stride 
      *  @param [in]   stripe_causal is true for stripe causal mode
      */
-    bool ojph_decode_codeblock_ssse3(ui8 *coded_data, ui32 *decoded_data,
+    bool ojph_decode_codeblock_ssse3(ui8* coded_data, ui32* decoded_data,
                                      ui32 missing_msbs, ui32 num_passes,
                                      ui32 lengths1, ui32 lengths2,
                                      ui32 width, ui32 height, ui32 stride,
@@ -1041,13 +1043,13 @@ namespace ojph
       {
         OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
                               "This codeblocks has %d passes.",
-                  num_passes);
+                              num_passes);
         return false;
       }
 
       if (missing_msbs > 30) // p < 0
       {
-        if (insufficient_precision == false)
+        if (insufficient_precision == false) 
         {
           insufficient_precision = true;
           OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
@@ -1055,26 +1057,23 @@ namespace ojph
                                 "displayed again.");
         }
         return false;
-      }
+      }       
       else if (missing_msbs == 30) // p == 0
-      {                            // not enough precision to decode and set the bin center to 1
-        if (modify_code == false)
-        {
+      { // not enough precision to decode and set the bin center to 1
+        if (modify_code == false) {
           modify_code = true;
           OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
                                 "pass. The code can be modified to support "
                                 "this case. This message will not be "
                                 "displayed again.");
         }
-        return false; // 32 bits are not enough to decode this
-      }
+         return false;         // 32 bits are not enough to decode this
+       }
       else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
       {
-        if (num_passes > 1)
-        {
+        if (num_passes > 1) {
           num_passes = 1;
-          if (truncate_spp_mrp == false)
-          {
+          if (truncate_spp_mrp == false) {
             truncate_spp_mrp = true;
             OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
                                   "nor MagRef passes; both will be skipped. "
@@ -1095,34 +1094,34 @@ namespace ojph
 
       // read scup and fix the bytes there
       int lcup, scup;
-      lcup = (int)lengths1; // length of CUP
-      // scup is the length of MEL + VLC
-      scup = (((int)coded_data[lcup - 1]) << 4) + (coded_data[lcup - 2] & 0xF);
-      if (scup < 2 || scup > lcup || scup > 4079) // something is wrong
+      lcup = (int)lengths1;  // length of CUP
+      //scup is the length of MEL + VLC
+      scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
+      if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
         return false;
 
-      // The temporary storage scratch holds two types of data in an
+      // The temporary storage scratch holds two types of data in an 
       // interleaved fashion. The interleaving allows us to use one
       // memory pointer.
       // We have one entry for a decoded VLC code, and one entry for UVLC.
-      // Entries are 16 bits each, corresponding to one quad,
-      // but since we want to use XMM registers of the SSE family
+      // Entries are 16 bits each, corresponding to one quad, 
+      // but since we want to use XMM registers of the SSE family 
       // of SIMD; we allocated 16 bytes or more per quad row; that is,
       // the width is no smaller than 16 bytes (or 8 entries), and the
       // height is 512 quads
-      // Each VLC entry contains, in the following order, starting
+      // Each VLC entry contains, in the following order, starting 
       // from MSB
       // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
       // Each entry in UVLC contains u_q
       // One extra row to handle the case of SPP propagating downwards
       // when codeblock width is 4
-      ui16 scratch[8 * 513] = {0}; // 8+ kB
+      ui16 scratch[8 * 513] = {0};          // 8+ kB
 
       // We need an extra two entries (one inf and one u_q) beyond
-      // the last column.
-      // If the block width is 4 (2 quads), then we use sstr of 8
-      // (enough for 4 quads). If width is 8 (4 quads) we use
-      // sstr is 16 (enough for 8 quads). For a width of 16 (8
+      // the last column. 
+      // If the block width is 4 (2 quads), then we use sstr of 8 
+      // (enough for 4 quads). If width is 8 (4 quads) we use 
+      // sstr is 16 (enough for 8 quads). For a width of 16 (8 
       // quads), we use 24 (enough for 12 quads).
       ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
 
@@ -1131,11 +1130,11 @@ namespace ojph
       ui32 mmsbp2 = missing_msbs + 2;
 
       // The cleanup pass is decoded in two steps; in step one,
-      // the VLC and MEL segments are decoded, generating a record that
+      // the VLC and MEL segments are decoded, generating a record that 
       // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
       // This information should be sufficient for the next step.
       // In step 2, we decode the MagSgn segment.
-
+      
       // step 1 decoding VLC and MEL segments
       {
         // init structures
@@ -1151,7 +1150,7 @@ namespace ojph
         ui32 vlc_val;
         ui32 c_q = 0;
         ui16 *sp = scratch;
-        // initial quad row
+        //initial quad row
         for (ui32 x = 0; x < width; sp += 4)
         {
           // decode VLC
@@ -1160,111 +1159,111 @@ namespace ojph
           // first quad
           vlc_val = rev_fetch(&vlc);
 
-          // decode VLC using the context c_q and the head of VLC bitstream
-          ui16 t0 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
+          //decode VLC using the context c_q and the head of VLC bitstream
+          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
 
           // if context is zero, use one MEL event
-          if (c_q == 0) // zero context
+          if (c_q == 0) //zero context
           {
-            run -= 2; // subtract 2, since events number if multiplied by 2
+            run -= 2; //subtract 2, since events number if multiplied by 2
 
-            // Is the run terminated in 1? if so, use decoded VLC code,
-            // otherwise, discard decoded data, since we will decoded again
+            // Is the run terminated in 1? if so, use decoded VLC code, 
+            // otherwise, discard decoded data, since we will decoded again 
             // using a different context
             t0 = (run == -1) ? t0 : 0;
 
             // is run -1 or -2? this means a run has been consumed
-            if (run < 0)
-              run = mel_get_run(&mel); // get another run
+            if (run < 0) 
+              run = mel_get_run(&mel);  // get another run
           }
-          // run -= (c_q == 0) ? 2 : 0;
-          // t0 = (c_q != 0 || run == -1) ? t0 : 0;
-          // if (run < 0)
-          //   run = mel_get_run(&mel);  // get another run
-          sp[0] = t0;
+          //run -= (c_q == 0) ? 2 : 0;
+          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[0] = t0; 
           x += 2;
 
           // prepare context for the next quad; eqn. 1 in ITU T.814
           c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
 
-          // remove data from vlc stream (0 bits are removed if vlc is not used)
+          //remove data from vlc stream (0 bits are removed if vlc is not used)
           vlc_val = rev_advance(&vlc, t0 & 0x7);
 
-          // second quad
+          //second quad
           ui16 t1 = 0;
 
-          // decode VLC using the context c_q and the head of VLC bitstream
-          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
+          //decode VLC using the context c_q and the head of VLC bitstream
+          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)]; 
 
           // if context is zero, use one MEL event
-          if (c_q == 0 && x < width) // zero context
+          if (c_q == 0 && x < width) //zero context
           {
-            run -= 2; // subtract 2, since events number if multiplied by 2
+            run -= 2; //subtract 2, since events number if multiplied by 2
 
             // if event is 0, discard decoded t1
             t1 = (run == -1) ? t1 : 0;
 
-            if (run < 0)               // have we consumed all events in a run
+            if (run < 0) // have we consumed all events in a run
               run = mel_get_run(&mel); // if yes, then get another run
           }
           t1 = x < width ? t1 : 0;
-          // run -= (c_q == 0 && x < width) ? 2 : 0;
-          // t1 = (c_q != 0 || run == -1) ? t1 : 0;
-          // if (run < 0)
-          //   run = mel_get_run(&mel);  // get another run
+          //run -= (c_q == 0 && x < width) ? 2 : 0;
+          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
           sp[2] = t1;
           x += 2;
 
-          // prepare context for the next quad, eqn. 1 in ITU T.814
+          //prepare context for the next quad, eqn. 1 in ITU T.814
           c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
 
-          // remove data from vlc stream, if qinf is not used, cwdlen is 0
+          //remove data from vlc stream, if qinf is not used, cwdlen is 0
           vlc_val = rev_advance(&vlc, t1 & 0x7);
-
+          
           // decode u
           /////////////
           // uvlc_mode is made up of u_offset bits from the quad pair
           ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-          if (uvlc_mode == 0xc0) // if both u_offset are set, get an event from
-          {                      // the MEL run of events
-            run -= 2;            // subtract 2, since events number if multiplied by 2
+          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
+          {                     // the MEL run of events
+            run -= 2; //subtract 2, since events number if multiplied by 2
 
             uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
                                                  // is 0x40
 
-            if (run < 0) // if run is consumed (run is -1 or -2), get another run
+            if (run < 0)//if run is consumed (run is -1 or -2), get another run
               run = mel_get_run(&mel);
           }
-          // run -= (uvlc_mode == 0xc0) ? 2 : 0;
-          // uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
-          // if (run < 0)
-          //   run = mel_get_run(&mel);  // get another run
+          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
+          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
 
-          // decode uvlc_mode to get u for both quads
+          //decode uvlc_mode to get u for both quads
           ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
-          // remove total prefix length
-          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-          uvlc_entry >>= 3;
-          // extract suffixes for quad 0 and 1
-          ui32 len = uvlc_entry & 0xF;           // suffix length for 2 quads
-          ui32 tmp = vlc_val & ((1 << len) - 1); // suffix value for 2 quads
+          //remove total prefix length
+          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7); 
+          uvlc_entry >>= 3; 
+          //extract suffixes for quad 0 and 1
+          ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+          ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
           vlc_val = rev_advance(&vlc, len);
           uvlc_entry >>= 4;
           // quad 0 length
           len = uvlc_entry & 0x7; // quad 0 suffix length
           uvlc_entry >>= 3;
-          ui16 u_q = (ui16)(1 + (uvlc_entry & 7) + (tmp & ~(0xFFU << len))); // kap. 1
-          sp[1] = u_q;
-          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len)); // kappa == 1
-          sp[3] = u_q;
+          ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len))); //kap. 1
+          sp[1] = u_q; 
+          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
+          sp[3] = u_q; 
         }
         sp[0] = sp[1] = 0;
 
-        // non initial quad rows
+        //non initial quad rows
         for (ui32 y = 2; y < height; y += 2)
         {
-          c_q = 0;                              // context
-          ui16 *sp = scratch + (y >> 1) * sstr; // this row of quads
+          c_q = 0;                                // context
+          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
 
           for (ui32 x = 0; x < width; sp += 4)
           {
@@ -1278,27 +1277,27 @@ namespace ojph
             // first quad
             vlc_val = rev_fetch(&vlc);
 
-            // decode VLC using the context c_q and the head of VLC bitstream
-            ui16 t0 = vlc_tbl1[c_q + (vlc_val & 0x7F)];
+            //decode VLC using the context c_q and the head of VLC bitstream
+            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
 
             // if context is zero, use one MEL event
-            if (c_q == 0) // zero context
+            if (c_q == 0) //zero context
             {
-              run -= 2; // subtract 2, since events number is multiplied by 2
+              run -= 2; //subtract 2, since events number is multiplied by 2
 
-              // Is the run terminated in 1? if so, use decoded VLC code,
-              // otherwise, discard decoded data, since we will decoded again
+              // Is the run terminated in 1? if so, use decoded VLC code, 
+              // otherwise, discard decoded data, since we will decoded again 
               // using a different context
               t0 = (run == -1) ? t0 : 0;
 
               // is run -1 or -2? this means a run has been consumed
-              if (run < 0)
-                run = mel_get_run(&mel); // get another run
+              if (run < 0) 
+                run = mel_get_run(&mel);  // get another run
             }
-            // run -= (c_q == 0) ? 2 : 0;
-            // t0 = (c_q != 0 || run == -1) ? t0 : 0;
-            // if (run < 0)
-            //   run = mel_get_run(&mel);  // get another run
+            //run -= (c_q == 0) ? 2 : 0;
+            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
             sp[0] = t0;
             x += 2;
 
@@ -1311,32 +1310,32 @@ namespace ojph
             c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
             c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
 
-            // remove data from vlc stream (0 bits are removed if vlc is unused)
+            //remove data from vlc stream (0 bits are removed if vlc is unused)
             vlc_val = rev_advance(&vlc, t0 & 0x7);
 
-            // second quad
+            //second quad
             ui16 t1 = 0;
 
-            // decode VLC using the context c_q and the head of VLC bitstream
-            t1 = vlc_tbl1[c_q + (vlc_val & 0x7F)];
+            //decode VLC using the context c_q and the head of VLC bitstream
+            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)]; 
 
             // if context is zero, use one MEL event
-            if (c_q == 0 && x < width) // zero context
+            if (c_q == 0 && x < width) //zero context
             {
-              run -= 2; // subtract 2, since events number if multiplied by 2
+              run -= 2; //subtract 2, since events number if multiplied by 2
 
               // if event is 0, discard decoded t1
               t1 = (run == -1) ? t1 : 0;
 
-              if (run < 0)               // have we consumed all events in a run
+              if (run < 0) // have we consumed all events in a run
                 run = mel_get_run(&mel); // if yes, then get another run
             }
             t1 = x < width ? t1 : 0;
-            // run -= (c_q == 0 && x < width) ? 2 : 0;
-            // t1 = (c_q != 0 || run == -1) ? t1 : 0;
-            // if (run < 0)
-            //   run = mel_get_run(&mel);  // get another run
-            sp[2] = t1;
+            //run -= (c_q == 0 && x < width) ? 2 : 0;
+            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[2] = t1; 
             x += 2;
 
             // partial c_q, will be completed when we process the next quad
@@ -1345,20 +1344,20 @@ namespace ojph
             // sigma_q (nw)
             c_q |= sp[2 - (si32)sstr] & 0x80;
 
-            // remove data from vlc stream, if qinf is not used, cwdlen is 0
+            //remove data from vlc stream, if qinf is not used, cwdlen is 0
             vlc_val = rev_advance(&vlc, t1 & 0x7);
-
+          
             // decode u
             /////////////
             // uvlc_mode is made up of u_offset bits from the quad pair
             ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
             ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
-            // remove total prefix length
+            //remove total prefix length
             vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
             uvlc_entry >>= 3;
-            // extract suffixes for quad 0 and 1
-            ui32 len = uvlc_entry & 0xF;           // suffix length for 2 quads
-            ui32 tmp = vlc_val & ((1 << len) - 1); // suffix value for 2 quads
+            //extract suffixes for quad 0 and 1
+            ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+            ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
             vlc_val = rev_advance(&vlc, len);
             uvlc_entry >>= 4;
             // quad 0 length
@@ -1403,12 +1402,12 @@ namespace ojph
 
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
-            // here we process two quads
+            //here we process two quads
             __m128i w0, w1; // workers
             __m128i inf_u_q, U_q;
             // determine U_q
             {
-              inf_u_q = _mm_loadu_si128((__m128i *)sp);
+              inf_u_q = _mm_loadu_si128((__m128i*)sp);
               U_q = _mm_srli_epi32(inf_u_q, 16);
 
               w0 = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
@@ -1420,18 +1419,18 @@ namespace ojph
             __m128i vn = _mm_set1_epi32(2);
             __m128i row0 = decode_one_quad32<0>(inf_u_q, U_q, &magsgn, p, vn);
             __m128i row1 = decode_one_quad32<1>(inf_u_q, U_q, &magsgn, p, vn);
-            w0 = _mm_loadu_si128((__m128i *)vp);
-            w0 = _mm_and_si128(w0, _mm_set_epi32(0, 0, 0, -1));
+            w0 = _mm_loadu_si128((__m128i*)vp);
+            w0 = _mm_and_si128(w0, _mm_set_epi32(0,0,0,-1));
             w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i *)vp, w0);
+            _mm_storeu_si128((__m128i*)vp, w0);            
 
-            // interleave in ssse3 style
+            //interleave in ssse3 style 
             w0 = _mm_unpacklo_epi32(row0, row1);
             w1 = _mm_unpackhi_epi32(row0, row1);
             row0 = _mm_unpacklo_epi32(w0, w1);
             row1 = _mm_unpackhi_epi32(w0, w1);
-            _mm_store_si128((__m128i *)dp, row0);
-            _mm_store_si128((__m128i *)(dp + stride), row1);
+            _mm_store_si128((__m128i*)dp, row0);
+            _mm_store_si128((__m128i*)(dp + stride), row1);
           }
         }
 
@@ -1441,9 +1440,11 @@ namespace ojph
             // perform 31 - count_leading_zeros(*vp) here
             ui32 *vp = v_n_scratch;
             const __m128i lut_lo = _mm_set_epi8(
-                4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 7, 31);
+              4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 7, 31
+            );
             const __m128i lut_hi = _mm_set_epi8(
-                0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 31);
+              0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 31
+            );
             const __m128i nibble_mask = _mm_set1_epi8(0x0F);
             const __m128i byte_offset8 = _mm_set1_epi16(8);
             const __m128i byte_offset16 = _mm_set1_epi16(16);
@@ -1451,7 +1452,7 @@ namespace ojph
             for (ui32 x = 0; x <= width; x += 8, vp += 4)
             {
               __m128i v, t; // workers
-              v = _mm_loadu_si128((__m128i *)vp);
+              v = _mm_loadu_si128((__m128i*)vp);
 
               t = _mm_and_si128(nibble_mask, v);
               v = _mm_and_si128(_mm_srli_epi16(v, 4), nibble_mask);
@@ -1468,7 +1469,7 @@ namespace ojph
               v = _mm_min_epu8(v, t);
 
               v = _mm_sub_epi16(cc, v);
-              _mm_storeu_si128((__m128i *)(vp + v_n_size), v);
+              _mm_storeu_si128((__m128i*)(vp + v_n_size), v);
             }
           }
 
@@ -1479,22 +1480,22 @@ namespace ojph
 
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
-            // process two quads
+            //process two quads
             __m128i w0, w1; // workers
             __m128i inf_u_q, U_q;
             // determine U_q
             {
               __m128i gamma, emax, kappa, u_q; // needed locally
 
-              inf_u_q = _mm_loadu_si128((__m128i *)sp);
+              inf_u_q = _mm_loadu_si128((__m128i*)sp);
               gamma = _mm_and_si128(inf_u_q, _mm_set1_epi32(0xF0));
               w0 = _mm_sub_epi32(gamma, _mm_set1_epi32(1));
               gamma = _mm_and_si128(gamma, w0);
               gamma = _mm_cmpeq_epi32(gamma, _mm_setzero_si128());
 
-              emax = _mm_loadu_si128((__m128i *)(vp + v_n_size));
+              emax = _mm_loadu_si128((__m128i*)(vp + v_n_size)); 
               w0 = _mm_bsrli_si128(emax, 4);
-              emax = _mm_max_epi16(w0, emax); // no max_epi32 in ssse3
+              emax = _mm_max_epi16(w0, emax); // no max_epi32 in ssse3              
               emax = _mm_andnot_si128(gamma, emax);
 
               kappa = _mm_set1_epi32(1);
@@ -1512,22 +1513,22 @@ namespace ojph
             __m128i vn = _mm_set1_epi32(2);
             __m128i row0 = decode_one_quad32<0>(inf_u_q, U_q, &magsgn, p, vn);
             __m128i row1 = decode_one_quad32<1>(inf_u_q, U_q, &magsgn, p, vn);
-            w0 = _mm_loadu_si128((__m128i *)vp);
-            w0 = _mm_and_si128(w0, _mm_set_epi32(0, 0, 0, -1));
+            w0 = _mm_loadu_si128((__m128i*)vp);
+            w0 = _mm_and_si128(w0, _mm_set_epi32(0,0,0,-1));
             w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i *)vp, w0);
+            _mm_storeu_si128((__m128i*)vp, w0);  
 
-            // interleave in ssse3 style
+            //interleave in ssse3 style
             w0 = _mm_unpacklo_epi32(row0, row1);
             w1 = _mm_unpackhi_epi32(row0, row1);
             row0 = _mm_unpacklo_epi32(w0, w1);
             row1 = _mm_unpackhi_epi32(w0, w1);
-            _mm_store_si128((__m128i *)dp, row0);
-            _mm_store_si128((__m128i *)(dp + stride), row1);
+            _mm_store_si128((__m128i*)dp, row0);
+            _mm_store_si128((__m128i*)(dp + stride), row1);
           }
         }
       }
-      else
+      else 
       {
         // reduce bitplane by 16 because we now have 16 bits instead of 32
         p -= 16;
@@ -1552,12 +1553,12 @@ namespace ojph
 
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
-            // here we process two quads
+            //here we process two quads
             __m128i w0, w1; // workers
             __m128i inf_u_q, U_q;
             // determine U_q
             {
-              inf_u_q = _mm_loadu_si128((__m128i *)sp);
+              inf_u_q = _mm_loadu_si128((__m128i*)sp);
               U_q = _mm_srli_epi32(inf_u_q, 16);
 
               w0 = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
@@ -1568,20 +1569,20 @@ namespace ojph
 
             __m128i vn = _mm_set1_epi16(2);
             __m128i row = decode_two_quad16(inf_u_q, U_q, &magsgn, p, vn);
-            w0 = _mm_loadu_si128((__m128i *)vp);
-            w0 = _mm_and_si128(w0, _mm_set_epi16(0, 0, 0, 0, 0, 0, 0, -1));
+            w0 = _mm_loadu_si128((__m128i*)vp);
+            w0 = _mm_and_si128(w0, _mm_set_epi16(0,0,0,0,0,0,0,-1));
             w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i *)vp, w0);
+            _mm_storeu_si128((__m128i*)vp, w0);  
 
-            // interleave in ssse3 style
-            w0 = _mm_shuffle_epi8(row,
-                                  _mm_set_epi16(0x0D0C, -1, 0x0908, -1,
-                                                0x0504, -1, 0x0100, -1));
-            _mm_store_si128((__m128i *)dp, w0);
-            w1 = _mm_shuffle_epi8(row,
-                                  _mm_set_epi16(0x0F0E, -1, 0x0B0A, -1,
-                                                0x0706, -1, 0x0302, -1));
-            _mm_store_si128((__m128i *)(dp + stride), w1);
+            //interleave in ssse3 style 
+            w0 = _mm_shuffle_epi8(row, 
+              _mm_set_epi16(0x0D0C, -1, 0x0908, -1,
+                            0x0504, -1, 0x0100, -1));
+            _mm_store_si128((__m128i*)dp, w0);
+            w1 = _mm_shuffle_epi8(row, 
+              _mm_set_epi16(0x0F0E, -1, 0x0B0A, -1,
+                            0x0706, -1, 0x0302, -1));
+            _mm_store_si128((__m128i*)(dp + stride), w1);
           }
         }
 
@@ -1591,16 +1592,18 @@ namespace ojph
             // perform 15 - count_leading_zeros(*vp) here
             ui16 *vp = v_n_scratch;
             const __m128i lut_lo = _mm_set_epi8(
-                4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 7, 15);
+              4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 7, 15
+            );
             const __m128i lut_hi = _mm_set_epi8(
-                0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 15);
+              0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 15
+            );
             const __m128i nibble_mask = _mm_set1_epi8(0x0F);
             const __m128i byte_offset8 = _mm_set1_epi16(8);
             const __m128i cc = _mm_set1_epi16(15);
             for (ui32 x = 0; x <= width; x += 16, vp += 8)
             {
               __m128i v, t; // workers
-              v = _mm_loadu_si128((__m128i *)vp);
+              v = _mm_loadu_si128((__m128i*)vp);
 
               t = _mm_and_si128(nibble_mask, v);
               v = _mm_and_si128(_mm_srli_epi16(v, 4), nibble_mask);
@@ -1613,7 +1616,7 @@ namespace ojph
               v = _mm_min_epu8(v, t);
 
               v = _mm_sub_epi16(cc, v);
-              _mm_storeu_si128((__m128i *)(vp + v_n_size), v);
+              _mm_storeu_si128((__m128i*)(vp + v_n_size), v);
             }
           }
 
@@ -1624,25 +1627,25 @@ namespace ojph
 
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
-            // process two quads
+            //process two quads
             __m128i w0, w1; // workers
             __m128i inf_u_q, U_q;
             // determine U_q
             {
               __m128i gamma, emax, kappa, u_q; // needed locally
 
-              inf_u_q = _mm_loadu_si128((__m128i *)sp);
+              inf_u_q = _mm_loadu_si128((__m128i*)sp);
               gamma = _mm_and_si128(inf_u_q, _mm_set1_epi32(0xF0));
               w0 = _mm_sub_epi32(gamma, _mm_set1_epi32(1));
               gamma = _mm_and_si128(gamma, w0);
               gamma = _mm_cmpeq_epi32(gamma, _mm_setzero_si128());
 
-              emax = _mm_loadu_si128((__m128i *)(vp + v_n_size));
+              emax = _mm_loadu_si128((__m128i*)(vp + v_n_size)); 
               w0 = _mm_bsrli_si128(emax, 2);
               emax = _mm_max_epi16(w0, emax); // no max_epi32 in ssse3
-              emax = _mm_shuffle_epi8(emax,
-                                      _mm_set_epi16(-1, 0x0706, -1, 0x0504,
-                                                    -1, 0x0302, -1, 0x0100));
+              emax = _mm_shuffle_epi8(emax, 
+                _mm_set_epi16(-1, 0x0706, -1, 0x0504, 
+                              -1, 0x0302, -1, 0x0100));
               emax = _mm_andnot_si128(gamma, emax);
 
               kappa = _mm_set1_epi32(1);
@@ -1659,19 +1662,19 @@ namespace ojph
 
             __m128i vn = _mm_set1_epi16(2);
             __m128i row = decode_two_quad16(inf_u_q, U_q, &magsgn, p, vn);
-            w0 = _mm_loadu_si128((__m128i *)vp);
-            w0 = _mm_and_si128(w0, _mm_set_epi16(0, 0, 0, 0, 0, 0, 0, -1));
+            w0 = _mm_loadu_si128((__m128i*)vp);
+            w0 = _mm_and_si128(w0, _mm_set_epi16(0,0,0,0,0,0,0,-1));
             w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i *)vp, w0);
+            _mm_storeu_si128((__m128i*)vp, w0);  
 
-            w0 = _mm_shuffle_epi8(row,
-                                  _mm_set_epi16(0x0D0C, -1, 0x0908, -1,
-                                                0x0504, -1, 0x0100, -1));
-            _mm_store_si128((__m128i *)dp, w0);
-            w1 = _mm_shuffle_epi8(row,
-                                  _mm_set_epi16(0x0F0E, -1, 0x0B0A, -1,
-                                                0x0706, -1, 0x0302, -1));
-            _mm_store_si128((__m128i *)(dp + stride), w1);
+            w0 = _mm_shuffle_epi8(row, 
+              _mm_set_epi16(0x0D0C, -1, 0x0908, -1,
+                            0x0504, -1, 0x0100, -1));
+            _mm_store_si128((__m128i*)dp, w0);
+            w1 = _mm_shuffle_epi8(row, 
+              _mm_set_epi16(0x0F0E, -1, 0x0B0A, -1,
+                            0x0706, -1, 0x0302, -1));
+            _mm_store_si128((__m128i*)(dp + stride), w1);
           }
         }
 
@@ -1683,9 +1686,9 @@ namespace ojph
       {
         // We use scratch again, we can divide it into multiple regions
         // sigma holds all the significant samples, and it cannot
-        // be modified after it is set.  it will be used during the
+        // be modified after it is set.  it will be used during the 
         // Magnitude Refinement Pass
-        ui16 *const sigma = scratch;
+        ui16* const sigma = scratch;
 
         ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
                                          // ui16 contains 4 columns
@@ -1700,22 +1703,22 @@ namespace ojph
           const __m128i mask_3 = _mm_set1_epi32(0x30);
           const __m128i mask_C = _mm_set1_epi32(0xC0);
           const __m128i shuffle_mask = _mm_set_epi32(-1, -1, -1, 0x0C080400);
-          for (y = 0; y < height; y += 4)
+          for (y = 0; y < height; y += 4) 
           {
-            ui16 *sp = scratch + (y >> 1) * sstr;
-            ui16 *dp = sigma + (y >> 2) * mstr;
-            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2)
+            ui16* sp = scratch + (y >> 1) * sstr;
+            ui16* dp = sigma + (y >> 2) * mstr;
+            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2) 
             {
               __m128i s0, s1, u3, uC, t0, t1;
 
-              s0 = _mm_loadu_si128((__m128i *)(sp));
+              s0 = _mm_loadu_si128((__m128i*)(sp));
               u3 = _mm_and_si128(s0, mask_3);
               u3 = _mm_srli_epi32(u3, 4);
               uC = _mm_and_si128(s0, mask_C);
               uC = _mm_srli_epi32(uC, 2);
               t0 = _mm_or_si128(u3, uC);
 
-              s1 = _mm_loadu_si128((__m128i *)(sp + sstr));
+              s1 = _mm_loadu_si128((__m128i*)(sp + sstr));
               u3 = _mm_and_si128(s1, mask_3);
               u3 = _mm_srli_epi32(u3, 2);
               uC = _mm_and_si128(s1, mask_C);
@@ -1731,10 +1734,10 @@ namespace ojph
           }
           {
             // reset one row after the codeblock
-            ui16 *dp = sigma + (y >> 2) * mstr;
+            ui16* dp = sigma + (y >> 2) * mstr;
             __m128i zero = _mm_setzero_si128();
             for (ui32 x = 0; x < width; x += 32, dp += 8)
-              _mm_storeu_si128((__m128i *)dp, zero);
+              _mm_storeu_si128((__m128i*)dp, zero);
             dp[0] = 0; // set an extra entry on the right with 0
           }
         }
@@ -1758,11 +1761,9 @@ namespace ojph
           for (ui32 y = 0; y < height; y += 4)
           {
             ui32 pattern = 0xFFFFu; // a pattern needed samples
-            if (height - y < 4)
-            {
+            if (height - y < 4) {
               pattern = 0x7777u;
-              if (height - y < 3)
-              {
+              if (height - y < 3) {
                 pattern = 0x3333u;
                 if (height - y < 2)
                   pattern = 0x1111u;
@@ -1794,23 +1795,23 @@ namespace ojph
               // We need data for at least 5 columns out of 8.
               // Therefore loading 32 bits is easier than loading 16 bits
               // twice.
-              ui32 ps = *(ui32 *)prev_sig;
-              ui32 ns = *(ui32 *)(cur_sig + mstr);
+              ui32 ps = *(ui32*)prev_sig;
+              ui32 ns = *(ui32*)(cur_sig + mstr);
               ui32 u = (ps & 0x88888888) >> 3; // the row on top
               if (!stripe_causal)
-                u |= (ns & 0x11111111) << 3; // the row below
+                u |= (ns & 0x11111111) << 3;   // the row below
 
-              ui32 cs = *(ui32 *)cur_sig;
+              ui32 cs = *(ui32*)cur_sig;
               // vertical integration
-              ui32 mbr = cs;                 // this sig. info.
-              mbr |= (cs & 0x77777777) << 1; // above neighbors
-              mbr |= (cs & 0xEEEEEEEE) >> 1; // below neighbors
+              ui32 mbr =  cs;                // this sig. info.
+              mbr |= (cs & 0x77777777) << 1; //above neighbors
+              mbr |= (cs & 0xEEEEEEEE) >> 1; //below neighbors
               mbr |= u;
               // horizontal integration
               ui32 t = mbr;
-              mbr |= t << 4;     // neighbors on the left
-              mbr |= t >> 4;     // neighbors on the right
-              mbr |= prev >> 12; // significance of previous group
+              mbr |= t << 4;      // neighbors on the left
+              mbr |= t >> 4;      // neighbors on the right
+              mbr |= prev >> 12;  // significance of previous group
 
               // remove outside samples, and already significant samples
               mbr &= pattern;
@@ -1831,7 +1832,7 @@ namespace ojph
                   if ((col_mask & new_sig) == 0)
                     continue;
 
-                  // scan one column
+                  //scan one column
                   ui32 sample_mask = 0x1111u & col_mask;
                   if (new_sig & sample_mask)
                   {
@@ -1841,8 +1842,7 @@ namespace ojph
                       ui32 t = 0x33u << i;
                       new_sig |= t & inv_sig;
                     }
-                    cwd >>= 1;
-                    ++cnt;
+                    cwd >>= 1; ++cnt;
                   }
 
                   sample_mask <<= 1;
@@ -1854,8 +1854,7 @@ namespace ojph
                       ui32 t = 0x76u << i;
                       new_sig |= t & inv_sig;
                     }
-                    cwd >>= 1;
-                    ++cnt;
+                    cwd >>= 1; ++cnt;
                   }
 
                   sample_mask <<= 1;
@@ -1867,8 +1866,7 @@ namespace ojph
                       ui32 t = 0xECu << i;
                       new_sig |= t & inv_sig;
                     }
-                    cwd >>= 1;
-                    ++cnt;
+                    cwd >>= 1; ++cnt;
                   }
 
                   sample_mask <<= 1;
@@ -1880,8 +1878,7 @@ namespace ojph
                       ui32 t = 0xC8u << i;
                       new_sig |= t & inv_sig;
                     }
-                    cwd >>= 1;
-                    ++cnt;
+                    cwd >>= 1; ++cnt;
                   }
                 }
 
@@ -1893,15 +1890,15 @@ namespace ojph
                   // value of 0 if new_sig bit is 0, and 0xFF if new_sig is 1
                   __m128i new_sig_vec = _mm_set1_epi16((si16)new_sig);
                   new_sig_vec = _mm_shuffle_epi8(new_sig_vec,
-                                                 _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0));
+                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
                   new_sig_vec = _mm_and_si128(new_sig_vec,
-                                              _mm_set1_epi64x((si64)0x8040201008040201));
+                    _mm_set1_epi64x((si64)0x8040201008040201));
                   new_sig_vec = _mm_cmpeq_epi8(new_sig_vec,
-                                               _mm_set1_epi64x((si64)0x8040201008040201));
+                    _mm_set1_epi64x((si64)0x8040201008040201));
 
                   // find cumulative sums
                   // to find which bit in cwd we should extract
-                  __m128i inc_sum = new_sig_vec;   // inclusive scan
+                  __m128i inc_sum = new_sig_vec; // inclusive scan
                   inc_sum = _mm_abs_epi8(inc_sum); // cvrt to 0 or 1
                   inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
                   inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
@@ -1915,11 +1912,11 @@ namespace ojph
                   // with a value of 0 or 1.
                   cwd_vec = _mm_set1_epi16((si16)cwd);
                   cwd_vec = _mm_shuffle_epi8(cwd_vec,
-                                             _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0));
+                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
                   cwd_vec = _mm_and_si128(cwd_vec,
-                                          _mm_set1_epi64x((si64)0x8040201008040201));
+                    _mm_set1_epi64x((si64)0x8040201008040201));
                   cwd_vec = _mm_cmpeq_epi8(cwd_vec,
-                                           _mm_set1_epi64x((si64)0x8040201008040201));
+                    _mm_set1_epi64x((si64)0x8040201008040201));
                   cwd_vec = _mm_abs_epi8(cwd_vec);
 
                   // Obtain bit from cwd_vec correspondig to ex_sum
@@ -1928,14 +1925,13 @@ namespace ojph
 
                   // load data and set spp coefficients
                   __m128i m =
-                      _mm_set_epi8(-1, -1, -1, 12, -1, -1, -1, 8, -1, -1, -1, 4, -1, -1, -1, 0);
+                    _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
                   __m128i val = _mm_set1_epi32(3 << (p - 2));
                   ui32 *dp = dpp;
-                  for (int c = 0; c < 4; ++c)
-                  {
+                  for (int c = 0; c < 4; ++ c) {
                     __m128i s0, s0_ns, s0_val;
                     // load coefficients
-                    s0 = _mm_load_si128((__m128i *)dp);
+                    s0 = _mm_load_si128((__m128i*)dp);
 
                     // epi32 is -1 only for coefficient that
                     // are changed during the SPP
@@ -1951,7 +1947,7 @@ namespace ojph
                     // update vector
                     s0 = _mm_or_si128(s0, s0_val);
                     // store coefficients
-                    _mm_store_si128((__m128i *)dp, s0);
+                    _mm_store_si128((__m128i*)dp, s0);
                     // prepare for next row
                     dp += stride;
                     m = _mm_add_epi32(m, _mm_set1_epi32(1));
@@ -1965,8 +1961,8 @@ namespace ojph
 
               // vertical integration for the new sig. info.
               t = new_sig;
-              new_sig |= (t & 0x7777) << 1; // above neighbors
-              new_sig |= (t & 0xEEEE) >> 1; // below neighbors
+              new_sig |= (t & 0x7777) << 1; //above neighbors
+              new_sig |= (t & 0xEEEE) >> 1; //below neighbors
               // add sig. info. from the row on top and below
               prev = new_sig | u;
               // we need only the bits in 0xF000
@@ -1987,10 +1983,10 @@ namespace ojph
             ui32 *dpp = decoded_data + y * stride;
             for (ui32 i = 0; i < width; i += 4, dpp += 4)
             {
-              // Process one entry from sigma array at a time
-              //  Each nibble (4 bits) in the sigma array represents 4 rows,
+              //Process one entry from sigma array at a time
+              // Each nibble (4 bits) in the sigma array represents 4 rows,
               ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
-              ui16 sig = *cur_sig++;             // 16 bit that will be processed now
+              ui16 sig = *cur_sig++; // 16 bit that will be processed now
               int total_bits = 0;
               if (sig) // if any of the 32 bits are set
               {
@@ -2000,11 +1996,11 @@ namespace ojph
                 // spread the 16 bits in sig to 0 or 1 bytes in sig_vec
                 __m128i sig_vec = _mm_set1_epi16((si16)sig);
                 sig_vec = _mm_shuffle_epi8(sig_vec,
-                                           _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0));
+                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
                 sig_vec = _mm_and_si128(sig_vec,
-                                        _mm_set1_epi64x((si64)0x8040201008040201));
+                  _mm_set1_epi64x((si64)0x8040201008040201));
                 sig_vec = _mm_cmpeq_epi8(sig_vec,
-                                         _mm_set1_epi64x((si64)0x8040201008040201));
+                  _mm_set1_epi64x((si64)0x8040201008040201));
                 sig_vec = _mm_abs_epi8(sig_vec);
 
                 // find cumulative sums
@@ -2024,24 +2020,23 @@ namespace ojph
                 // represented as binary 01
                 __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
                 cwd_vec = _mm_shuffle_epi8(cwd_vec,
-                                           _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0));
-                cwd_vec = _mm_and_si128(cwd_vec,
-                                        _mm_set1_epi64x((si64)0x8040201008040201));
-                cwd_vec = _mm_cmpeq_epi8(cwd_vec,
-                                         _mm_set1_epi64x((si64)0x8040201008040201));
+                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                cwd_vec = _mm_and_si128(cwd_vec, 
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                cwd_vec = _mm_cmpeq_epi8(cwd_vec, 
+                  _mm_set1_epi64x((si64)0x8040201008040201));
                 cwd_vec = _mm_add_epi8(cwd_vec, _mm_set1_epi8(1));
                 cwd_vec = _mm_add_epi8(cwd_vec, cwd_vec);
                 cwd_vec = _mm_or_si128(cwd_vec, _mm_set1_epi8(1));
 
                 // load data and insert the mrp bit
                 __m128i m =
-                    _mm_set_epi8(-1, -1, -1, 12, -1, -1, -1, 8, -1, -1, -1, 4, -1, -1, -1, 0);
+                  _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
                 ui32 *dp = dpp;
-                for (int c = 0; c < 4; ++c)
-                {
+                for (int c = 0; c < 4; ++c) {
                   __m128i s0, s0_sig, s0_idx, s0_val;
-                  // load coefficients
-                  s0 = _mm_load_si128((__m128i *)dp);
+                  // load coefficients                  
+                  s0 = _mm_load_si128((__m128i*)dp);
                   // find significant samples in this row
                   s0_sig = _mm_shuffle_epi8(sig_vec, m);
                   s0_sig = _mm_cmpeq_epi8(s0_sig, _mm_setzero_si128());
@@ -2054,7 +2049,7 @@ namespace ojph
                   s0_val = _mm_slli_epi32(s0_val, (si32)p - 2);
                   s0 = _mm_xor_si128(s0, s0_val);
                   // store coefficients
-                  _mm_store_si128((__m128i *)dp, s0);
+                  _mm_store_si128((__m128i*)dp, s0);
                   // prepare for next row
                   dp += stride;
                   m = _mm_add_epi32(m, _mm_set1_epi32(1));

--- a/Native/Common/OpenJPH/coding/ojph_block_decoder_wasm.cpp
+++ b/Native/Common/OpenJPH/coding/ojph_block_decoder_wasm.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -52,18 +52,16 @@
 
 #include <wasm_simd128.h>
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
-//************************************************************************/
-/** @brief Macros that help with typing and space
- */
-#define OJPH_REPEAT2(a) a, a
-#define OJPH_REPEAT4(a) a, a, a, a
-#define OJPH_REPEAT8(a) a, a, a, a, a, a, a, a
-#define OJPH_REPEAT16(a) a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a
+    //************************************************************************/
+    /** @brief Macros that help with typing and space
+     */
+    #define OJPH_REPEAT2(a) a,a
+    #define OJPH_REPEAT4(a) a,a,a,a
+    #define OJPH_REPEAT8(a) a,a,a,a,a,a,a,a
+    #define OJPH_REPEAT16(a) a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a
 
     //************************************************************************/
     /** @brief MEL state structure for reading and decoding the MEL bitstream
@@ -71,29 +69,27 @@ namespace ojph
      *  A number of events is decoded from the MEL bitstream ahead of time
      *  and stored in run/num_runs.
      *  Each run represents the number of zero events before a one event.
-     */
-    struct dec_mel_st
-    {
+     */ 
+    struct dec_mel_st {
       dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
-                     k(0), num_runs(0), runs(0)
-      {
-      }
+        k(0), num_runs(0), runs(0)
+      {}
       // data decoding machinery
-      ui8 *data;    //!< the address of data (or bitstream)
-      ui64 tmp;     //!< temporary buffer for read data
-      int bits;     //!< number of bits stored in tmp
-      int size;     //!< number of bytes in MEL code
-      bool unstuff; //!< true if the next bit needs to be unstuffed
-      int k;        //!< state of MEL decoder
+      ui8* data;    //!<the address of data (or bitstream)
+      ui64 tmp;     //!<temporary buffer for read data
+      int bits;     //!<number of bits stored in tmp
+      int size;     //!<number of bytes in MEL code
+      bool unstuff; //!<true if the next bit needs to be unstuffed
+      int k;        //!<state of MEL decoder
 
       // queue of decoded runs
-      int num_runs; //!< number of decoded runs left in runs (maximum 8)
-      ui64 runs;    //!< runs of decoded MEL codewords (7 bits/run)
+      int num_runs; //!<number of decoded runs left in runs (maximum 8)
+      ui64 runs;    //!<runs of decoded MEL codewords (7 bits/run)
     };
 
     //************************************************************************/
     /** @brief Reads and unstuffs the MEL bitstream
-     *
+     * 
      *  This design needs more bytes in the codeblock buffer than the length
      *  of the cleanup pass by up to 2 bytes.
      *
@@ -103,165 +99,165 @@ namespace ojph
      *
      *  @param [in]  melp is a pointer to dec_mel_st structure
      */
-    static inline void mel_read(dec_mel_st *melp)
+    static inline
+    void mel_read(dec_mel_st *melp)
     {
-      if (melp->bits > 32) // there are enough bits in the tmp variable
-        return;            // return without reading new data
+      if (melp->bits > 32)  //there are enough bits in the tmp variable
+        return;             // return without reading new data
 
-      ui32 val = 0xFFFFFFFF; // feed in 0xFF if buffer is exhausted
-      if (melp->size > 4)
-      {                            // if there is data in the MEL segment
-        val = *(ui32 *)melp->data; // read 32 bits from MEL data
+      ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
+      if (melp->size > 4) {        // if there is data in the MEL segment
+        val = *(ui32*)melp->data;  // read 32 bits from MEL data
         melp->data += 4;           // advance pointer
         melp->size -= 4;           // reduce counter
       }
       else if (melp->size > 0)
       { // 4 or less
         int i = 0;
-        while (melp->size > 1)
-        {
-          ui32 v = *melp->data++;     // read one byte at a time
-          ui32 m = ~(0xFFu << i);     // mask of location
-          val = (val & m) | (v << i); // put one byte in its correct location
+        while (melp->size > 1) {   
+          ui32 v = *melp->data++;    // read one byte at a time
+          ui32 m = ~(0xFFu << i);    // mask of location
+          val = (val & m) | (v << i);// put one byte in its correct location
           --melp->size;
           i += 8;
         }
         // size equal to 1
-        ui32 v = *melp->data++; // the one before the last is different
-        v |= 0xF;               // MEL and VLC segments can overlap
+        ui32 v = *melp->data++;    // the one before the last is different 
+        v |= 0xF;                  // MEL and VLC segments can overlap
         ui32 m = ~(0xFFu << i);
         val = (val & m) | (v << i);
         --melp->size;
       }
-
+      
       // next we unstuff them before adding them to the buffer
       int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
-                                     // the previously read byte requires
+                                     // the previously read byte requires 
                                      // unstuffing
 
       // data is unstuffed and accumulated in t
       // bits has the number of bits in t
-      ui32 t = val & 0xFF;
+      ui32 t = val & 0xFF; 
       bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
-      bits -= unstuff;                       // there is one less bit in t if unstuffing is needed
-      t = t << (8 - unstuff);                // move up to make room for the next byte
+      bits -= unstuff; // there is one less bit in t if unstuffing is needed
+      t = t << (8 - unstuff); // move up to make room for the next byte
 
-      // this is a repeat of the above
-      t |= (val >> 8) & 0xFF;
+      //this is a repeat of the above
+      t |= (val>>8) & 0xFF;
       unstuff = (((val >> 8) & 0xFF) == 0xFF);
       bits -= unstuff;
       t = t << (8 - unstuff);
 
-      t |= (val >> 16) & 0xFF;
+      t |= (val>>16) & 0xFF;
       unstuff = (((val >> 16) & 0xFF) == 0xFF);
       bits -= unstuff;
       t = t << (8 - unstuff);
 
-      t |= (val >> 24) & 0xFF;
+      t |= (val>>24) & 0xFF;
       melp->unstuff = (((val >> 24) & 0xFF) == 0xFF);
 
       // move t to tmp, and push the result all the way up, so we read from
       // the MSB
       melp->tmp |= ((ui64)t) << (64 - bits - melp->bits);
-      melp->bits += bits; // increment the number of bits in tmp
+      melp->bits += bits; //increment the number of bits in tmp
     }
 
     //************************************************************************/
     /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
-     *
+     * 
      *  Runs are stored in "runs" and the number of runs in "num_runs".
-     *  Each run represents a number of zero events that may or may not
+     *  Each run represents a number of zero events that may or may not 
      *  terminate in a 1 event.
      *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
-     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating
-     *  with 1, contain the number of consecutive 0 zero events * 2; for the
-     *  case terminating with 0, they store (number of consecutive 0 zero
+     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating 
+     *  with 1, contain the number of consecutive 0 zero events * 2; for the 
+     *  case terminating with 0, they store (number of consecutive 0 zero 
      *  events - 1) * 2.
      *  A total of 6 bits (made up of 1 + 5) should have been enough.
      *
      *  @param [in]  melp is a pointer to dec_mel_st structure
      */
-    static inline void mel_decode(dec_mel_st *melp)
+    static inline
+    void mel_decode(dec_mel_st *melp)
     {
-      static const int mel_exp[13] = {// MEL exponents
-                                      0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5};
+      static const int mel_exp[13] = { //MEL exponents
+        0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5
+      };
 
       if (melp->bits < 6) // if there are less than 6 bits in tmp
         mel_read(melp);   // then read from the MEL bitstream
                           // 6 bits is the largest decodable MEL cwd
 
-      // repeat so long that there is enough decodable bits in tmp,
-      //  and the runs store is not full (num_runs < 8)
+      //repeat so long that there is enough decodable bits in tmp,
+      // and the runs store is not full (num_runs < 8)
       while (melp->bits >= 6 && melp->num_runs < 8)
       {
         int eval = mel_exp[melp->k]; // number of bits associated with state
         int run = 0;
-        if (melp->tmp & (1ull << 63)) // The next bit to decode (stored in MSB)
-        {                             // one is found
-          run = 1 << eval;
-          run--;                                         // consecutive runs of 0 events - 1
-          melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12; // increment, max is 12
-          melp->tmp <<= 1;                               // consume one bit from tmp
+        if (melp->tmp & (1ull<<63)) //The next bit to decode (stored in MSB)
+        { //one is found
+          run = 1 << eval;  
+          run--; // consecutive runs of 0 events - 1
+          melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12;//increment, max is 12
+          melp->tmp <<= 1; // consume one bit from tmp
           melp->bits -= 1;
           run = run << 1; // a stretch of zeros not terminating in one
         }
         else
-        { // 0 is found
+        { //0 is found
           run = (int)(melp->tmp >> (63 - eval)) & ((1 << eval) - 1);
-          melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; // decrement, min is 0
-          melp->tmp <<= eval + 1;                      // consume eval + 1 bits (max is 6)
+          melp->k = melp->k - 1 > 0 ? melp->k - 1 : 0; //decrement, min is 0
+          melp->tmp <<= eval + 1; //consume eval + 1 bits (max is 6)
           melp->bits -= eval + 1;
           run = (run << 1) + 1; // a stretch of zeros terminating with one
         }
         eval = melp->num_runs * 7;           // 7 bits per run
         melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
         melp->runs |= ((ui64)run) << eval;   // store the value in runs
-        melp->num_runs++;                    // increment count
+        melp->num_runs++;                    // increment count  
       }
     }
 
     //************************************************************************/
     /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
      *         some bytes in order to get the read address to a multiple
-     *         of 4
+     *         of 4 
      *
      *  @param [in]  melp is a pointer to dec_mel_st structure
      *  @param [in]  bbuf is a pointer to byte buffer
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  scup is the length of MEL+VLC segments
      */
-    static inline void mel_init(dec_mel_st *melp, ui8 *bbuf, int lcup, int scup)
+    static inline
+    void mel_init(dec_mel_st *melp, ui8* bbuf, int lcup, int scup)
     {
       melp->data = bbuf + lcup - scup; // move the pointer to the start of MEL
       melp->bits = 0;                  // 0 bits in tmp
       melp->tmp = 0;                   //
       melp->unstuff = false;           // no unstuffing
       melp->size = scup - 1;           // size is the length of MEL+VLC-1
-      melp->k = 0;                     // 0 for state
+      melp->k = 0;                     // 0 for state 
       melp->num_runs = 0;              // num_runs is 0
       melp->runs = 0;                  //
 
-      // This code is borrowed; original is for a different architecture
-      // These few lines take care of the case where data is not at a multiple
-      //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
+      //This code is borrowed; original is for a different architecture
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MEL segment
       int num = 4 - (int)(intptr_t(melp->data) & 0x3);
-      for (int i = 0; i < num; ++i)
-      { // this code is similar to mel_read
+      for (int i = 0; i < num; ++i) { // this code is similar to mel_read
         assert(melp->unstuff == false || melp->data[0] <= 0x8F);
-        ui64 d = (melp->size > 0) ? *melp->data : 0xFF; // if buffer is consumed
-                                                        // set data to 0xFF
-        if (melp->size == 1)
-          d |= 0xF; // if this is MEL+VLC-1, set LSBs to 0xF
-                    //  see the standard
-        melp->data += melp->size-- > 0;        // increment if the end is not reached
-        int d_bits = 8 - melp->unstuff;        // if unstuffing is needed, reduce by 1
-        melp->tmp = (melp->tmp << d_bits) | d; // store bits in tmp
-        melp->bits += d_bits;                  // increment tmp by number of bits
-        melp->unstuff = ((d & 0xFF) == 0xFF);  // true of next byte needs
-                                              // unstuffing
+        ui64 d = (melp->size > 0) ? *melp->data : 0xFF;//if buffer is consumed
+                                                       //set data to 0xFF
+        if (melp->size == 1) d |= 0xF; //if this is MEL+VLC-1, set LSBs to 0xF
+                                       // see the standard
+        melp->data += melp->size-- > 0; //increment if the end is not reached
+        int d_bits = 8 - melp->unstuff; //if unstuffing is needed, reduce by 1
+        melp->tmp = (melp->tmp << d_bits) | d; //store bits in tmp
+        melp->bits += d_bits;  //increment tmp by number of bits
+        melp->unstuff = ((d & 0xFF) == 0xFF); //true of next byte needs 
+                                              //unstuffing
       }
-      melp->tmp <<= (64 - melp->bits); // push all the way up so the first bit
-                                       //  is the MSB
+      melp->tmp <<= (64 - melp->bits); //push all the way up so the first bit
+                                       // is the MSB
     }
 
     //************************************************************************/
@@ -269,14 +265,15 @@ namespace ojph
      *         MEL segment is decoded
      *
      * @param [in]  melp is a pointer to dec_mel_st structure
-     */
-    static inline int mel_get_run(dec_mel_st *melp)
+     */    
+    static inline
+    int mel_get_run(dec_mel_st *melp)
     {
-      if (melp->num_runs == 0) // if no runs, decode more bit from MEL segment
+      if (melp->num_runs == 0)  //if no runs, decode more bit from MEL segment
         mel_decode(melp);
 
-      int t = melp->runs & 0x7F; // retrieve one run
-      melp->runs >>= 7;          // remove the retrieved run
+      int t = melp->runs & 0x7F; //retrieve one run
+      melp->runs >>= 7;  // remove the retrieved run
       melp->num_runs--;
       return t; // return run
     }
@@ -284,60 +281,58 @@ namespace ojph
     //************************************************************************/
     /** @brief A structure for reading and unstuffing a segment that grows
      *         backward, such as VLC and MRP
-     */
-    struct rev_struct
-    {
+     */ 
+    struct rev_struct {
       rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
-      {
-      }
-      // storage
-      ui8 *data;    //!< pointer to where to read data
-      ui64 tmp;     //!< temporary buffer of read data
-      ui32 bits;    //!< number of bits stored in tmp
-      int size;     //!< number of bytes left
-      bool unstuff; //!< true if the last byte is more than 0x8F
-                    //!< then the current byte is unstuffed if it is 0x7F
+      {}
+      //storage
+      ui8* data;     //!<pointer to where to read data
+      ui64 tmp;	     //!<temporary buffer of read data
+      ui32 bits;     //!<number of bits stored in tmp
+      int size;      //!<number of bytes left
+      bool unstuff;  //!<true if the last byte is more than 0x8F
+                     //!<then the current byte is unstuffed if it is 0x7F
     };
 
     //************************************************************************/
     /** @brief Read and unstuff data from a backwardly-growing segment
      *
      *  This reader can read up to 8 bytes from before the VLC segment.
-     *  Care must be taken not read from unreadable memory, causing a
+     *  Care must be taken not read from unreadable memory, causing a 
      *  segmentation fault.
-     *
+     * 
      *  Note that there is another subroutine rev_read_mrp that is slightly
      *  different.  The other one fills zeros when the buffer is exhausted.
      *  This one basically does not care if the bytes are consumed, because
      *  any extra data should not be used in the actual decoding.
      *
-     *  Unstuffing is needed to prevent sequences more than 0xFF8F from
+     *  Unstuffing is needed to prevent sequences more than 0xFF8F from 
      *  appearing in the bits stream; since we are reading backward, we keep
-     *  watch when a value larger than 0x8F appears in the bitstream.
-     *  If the byte following this is 0x7F, we unstuff this byte (ignore the
+     *  watch when a value larger than 0x8F appears in the bitstream. 
+     *  If the byte following this is 0x7F, we unstuff this byte (ignore the 
      *  MSB of that byte, which should be 0).
      *
      *  @param [in]  vlcp is a pointer to rev_struct structure
      */
-    static inline void rev_read(rev_struct *vlcp)
+    static inline 
+    void rev_read(rev_struct *vlcp)
     {
-      // process 4 bytes at a time
-      if (vlcp->bits > 32) // if there are more than 32 bits in tmp, then
-        return;            // reading 32 bits can overflow vlcp->tmp
+      //process 4 bytes at a time
+      if (vlcp->bits > 32)  // if there are more than 32 bits in tmp, then 
+        return;             // reading 32 bits can overflow vlcp->tmp
       ui32 val = 0;
-      // the next line (the if statement) needs to be tested first
-      if (vlcp->size > 3) // if there are more than 3 bytes left in VLC
+      //the next line (the if statement) needs to be tested first
+      if (vlcp->size > 3)  // if there are more than 3 bytes left in VLC
       {
         // (vlcp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32 *)(vlcp->data - 3); // then read 32 bits
-        vlcp->data -= 4;                 // move data pointer back by 4
-        vlcp->size -= 4;                 // reduce available byte by 4
+        val = *(ui32*)(vlcp->data - 3); // then read 32 bits
+        vlcp->data -= 4;          // move data pointer back by 4
+        vlcp->size -= 4;          // reduce available byte by 4
       }
       else if (vlcp->size > 0)
       { // 4 or less
         int i = 24;
-        while (vlcp->size > 0)
-        {
+        while (vlcp->size > 0) {   
           ui32 v = *vlcp->data--; // read one byte at a time
           val |= (v << i);        // put byte in its correct location
           --vlcp->size;
@@ -345,15 +340,15 @@ namespace ojph
         }
       }
 
-      // accumulate in tmp, number of bits in tmp are stored in bits
-      ui32 tmp = val >> 24; // start with the MSB byte
+      //accumulate in tmp, number of bits in tmp are stored in bits
+      ui32 tmp = val >> 24;  //start with the MSB byte
       ui32 bits;
 
       // test unstuff (previous byte is >0x8F), and this byte is 0x7F
       bits = 8 - ((vlcp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
-      bool unstuff = (val >> 24) > 0x8F; // this is for the next byte
+      bool unstuff = (val >> 24) > 0x8F; //this is for the next byte
 
-      tmp |= ((val >> 16) & 0xFF) << bits; // process the next byte
+      tmp |= ((val >> 16) & 0xFF) << bits; //process the next byte
       bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
       unstuff = ((val >> 16) & 0xFF) > 0x8F;
 
@@ -372,7 +367,7 @@ namespace ojph
     }
 
     //************************************************************************/
-    /** @brief Initiates the rev_struct structure and reads a few bytes to
+    /** @brief Initiates the rev_struct structure and reads a few bytes to 
      *         move the read address to multiple of 4
      *
      *  There is another similar rev_init_mrp subroutine.  The difference is
@@ -385,54 +380,55 @@ namespace ojph
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  scup is the length of MEL+VLC segments
      */
-    static inline void rev_init(rev_struct *vlcp, ui8 *data, int lcup, int scup)
+    static inline 
+    void rev_init(rev_struct *vlcp, ui8* data, int lcup, int scup)
     {
-      // first byte has only the upper 4 bits
+      //first byte has only the upper 4 bits
       vlcp->data = data + lcup - 2;
 
-      // size can not be larger than this, in fact it should be smaller
+      //size can not be larger than this, in fact it should be smaller
       vlcp->size = scup - 2;
 
-      ui32 d = *vlcp->data--;                  // read one byte (this is a half byte)
-      vlcp->tmp = d >> 4;                      // both initialize and set
-      vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); // check standard
-      vlcp->unstuff = (d | 0xF) > 0x8F;        // this is useful for the next byte
+      ui32 d = *vlcp->data--; // read one byte (this is a half byte)
+      vlcp->tmp = d >> 4;    // both initialize and set
+      vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); //check standard
+      vlcp->unstuff = (d | 0xF) > 0x8F; //this is useful for the next byte
 
-      // This code is designed for an architecture that read address should
-      //  align to the read size (address multiple of 4 if read size is 4)
-      // These few lines take care of the case where data is not at a multiple
-      //  of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
-      //  To read 32 bits, read from (vlcp->data - 3)
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
+      // To read 32 bits, read from (vlcp->data - 3)
       int num = 1 + (int)(intptr_t(vlcp->data) & 0x3);
       int tnum = num < vlcp->size ? num : vlcp->size;
-      for (int i = 0; i < tnum; ++i)
-      {
+      for (int i = 0; i < tnum; ++i) {
         ui64 d;
-        d = *vlcp->data--; // read one byte and move read pointer
-        // check if the last byte was >0x8F (unstuff == true) and this is 0x7F
+        d = *vlcp->data--;  // read one byte and move read pointer
+        //check if the last byte was >0x8F (unstuff == true) and this is 0x7F
         ui32 d_bits = 8 - ((vlcp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
         vlcp->tmp |= d << vlcp->bits; // move data to vlcp->tmp
         vlcp->bits += d_bits;
         vlcp->unstuff = d > 0x8F; // for next byte
       }
       vlcp->size -= tnum;
-      rev_read(vlcp); // read another 32 buts
+      rev_read(vlcp);  // read another 32 buts
     }
 
     //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
      *
      *  By the end of this call, vlcp->tmp must have no less than 33 bits
      *
      *  @param [in]  vlcp is a pointer to rev_struct structure
      */
-    static inline ui32 rev_fetch(rev_struct *vlcp)
+    static inline 
+    ui32 rev_fetch(rev_struct *vlcp)
     {
-      if (vlcp->bits < 32) // if there are less then 32 bits, read more
+      if (vlcp->bits < 32)  // if there are less then 32 bits, read more
       {
-        rev_read(vlcp);      // read 32 bits, but unstuffing might reduce this
-        if (vlcp->bits < 32) // if there is still space in vlcp->tmp for 32 bits
-          rev_read(vlcp);    // read another 32
+        rev_read(vlcp);     // read 32 bits, but unstuffing might reduce this
+        if (vlcp->bits < 32)// if there is still space in vlcp->tmp for 32 bits
+          rev_read(vlcp);   // read another 32
       }
       return (ui32)vlcp->tmp; // return the head (bottom-most) of vlcp->tmp
     }
@@ -443,7 +439,8 @@ namespace ojph
      *  @param [in]  vlcp is a pointer to rev_struct structure
      *  @param [in]  num_bits is the number of bits to be removed
      */
-    static inline ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
+    static inline 
+    ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
     {
       assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
       vlcp->tmp >>= num_bits;         // remove bits
@@ -462,23 +459,23 @@ namespace ojph
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
      */
-    static inline void rev_read_mrp(rev_struct *mrp)
+    static inline 
+    void rev_read_mrp(rev_struct *mrp)
     {
-      // process 4 bytes at a time
+      //process 4 bytes at a time
       if (mrp->bits > 32)
         return;
       ui32 val = 0;
-      if (mrp->size > 3)                // If there are 3 byte or more
-      {                                 // (mrp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32 *)(mrp->data - 3); // read 32 bits
-        mrp->data -= 4;                 // move back pointer
-        mrp->size -= 4;                 // reduce count
+      if (mrp->size > 3) // If there are 3 byte or more
+      { // (mrp->data - 3) move pointer back to read 32 bits at once
+        val = *(ui32*)(mrp->data - 3); // read 32 bits
+        mrp->data -= 4;                // move back pointer
+        mrp->size -= 4;                // reduce count
       }
       else if (mrp->size > 0)
       {
         int i = 24;
-        while (mrp->size > 0)
-        {
+        while (mrp->size > 0) {   
           ui32 v = *mrp->data--; // read one byte at a time
           val |= (v << i);       // put byte in its correct location
           --mrp->size;
@@ -486,14 +483,14 @@ namespace ojph
         }
       }
 
-      // accumulate in tmp, and keep count in bits
+      //accumulate in tmp, and keep count in bits
       ui32 bits, tmp = val >> 24;
 
-      // test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
+      //test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
       bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
       bool unstuff = (val >> 24) > 0x8F;
 
-      // process the next byte
+      //process the next byte
       tmp |= ((val >> 16) & 0xFF) << bits;
       bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
       unstuff = ((val >> 16) & 0xFF) > 0x8F;
@@ -508,7 +505,7 @@ namespace ojph
 
       mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
       mrp->bits += bits;
-      mrp->unstuff = unstuff; // next byte
+      mrp->unstuff = unstuff;             // next byte
     }
 
     //************************************************************************/
@@ -518,7 +515,7 @@ namespace ojph
      *         an architecture that read size must be compatible with the
      *         alignment of the read address
      *
-     *  There is another similar subroutine rev_init.  This subroutine does
+     *  There is another similar subroutine rev_init.  This subroutine does 
      *  NOT skip the first 12 bits, and starts with unstuff set to true.
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
@@ -526,7 +523,8 @@ namespace ojph
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  len2 is the length of SPP+MRP segments
      */
-    static inline void rev_init_mrp(rev_struct *mrp, ui8 *data, int lcup, int len2)
+    static inline 
+    void rev_init_mrp(rev_struct *mrp, ui8* data, int lcup, int len2)
     {
       mrp->data = data + lcup + len2 - 1;
       mrp->size = len2;
@@ -534,17 +532,16 @@ namespace ojph
       mrp->bits = 0;
       mrp->tmp = 0;
 
-      // This code is designed for an architecture that read address should
-      //  align to the read size (address multiple of 4 if read size is 4)
-      // These few lines take care of the case where data is not at a multiple
-      //  of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
+      //This code is designed for an architecture that read address should
+      // align to the read size (address multiple of 4 if read size is 4)
+      //These few lines take care of the case where data is not at a multiple
+      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
       int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
-      for (int i = 0; i < num; ++i)
-      {
+      for (int i = 0; i < num; ++i) {
         ui64 d;
-        // read a byte, 0 if no more data
-        d = (mrp->size-- > 0) ? *mrp->data-- : 0;
-        // check if unstuffing is needed
+        //read a byte, 0 if no more data
+        d = (mrp->size-- > 0) ? *mrp->data-- : 0; 
+        //check if unstuffing is needed
         ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
         mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
         mrp->bits += d_bits;
@@ -554,21 +551,22 @@ namespace ojph
     }
 
     //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
      *
      *  By the end of this call, mrp->tmp must have no less than 33 bits
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
      */
-    static inline ui32 rev_fetch_mrp(rev_struct *mrp)
+    static inline 
+    ui32 rev_fetch_mrp(rev_struct *mrp)
     {
       if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
       {
-        rev_read_mrp(mrp);   // read 30-32 bits from mrp
-        if (mrp->bits < 32)  // if there is a space of 32 bits
-          rev_read_mrp(mrp); // read more
+        rev_read_mrp(mrp);    // read 30-32 bits from mrp
+        if (mrp->bits < 32)   // if there is a space of 32 bits
+          rev_read_mrp(mrp);  // read more
       }
-      return (ui32)mrp->tmp; // return the head of mrp->tmp
+      return (ui32)mrp->tmp;  // return the head of mrp->tmp
     }
 
     //************************************************************************/
@@ -580,27 +578,26 @@ namespace ojph
     inline ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
     {
       assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
-      mrp->tmp >>= num_bits;         // discard the lowest num_bits bits
+      mrp->tmp >>= num_bits;  // discard the lowest num_bits bits
       mrp->bits -= num_bits;
-      return (ui32)mrp->tmp; // return data after consumption
+      return (ui32)mrp->tmp;  // return data after consumption
     }
 
     //************************************************************************/
-    /** @brief State structure for reading and unstuffing of forward-growing
+    /** @brief State structure for reading and unstuffing of forward-growing 
      *         bitstreams; these are: MagSgn and SPP bitstreams
      */
-    struct frwd_struct
-    {
-      const ui8 *data; //!< pointer to bitstream
-      ui8 tmp[48];     //!< temporary buffer of read data + 16 extra
-      ui32 bits;       //!< number of bits stored in tmp
-      ui32 unstuff;    //!< 1 if a bit needs to be unstuffed from next byte
-      int size;        //!< size of data
+    struct frwd_struct {
+      const ui8* data;  //!<pointer to bitstream
+      ui8 tmp[48];      //!<temporary buffer of read data + 16 extra
+      ui32 bits;        //!<number of bits stored in tmp
+      ui32 unstuff;     //!<1 if a bit needs to be unstuffed from next byte
+      int size;         //!<size of data
     };
 
     //************************************************************************/
     /** @brief Read and unstuffs 16 bytes from forward-growing bitstream
-     *
+     *  
      *  A template is used to accommodate a different requirement for
      *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
      *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
@@ -616,8 +613,9 @@ namespace ojph
      *  @param  [in]  msp is a pointer to frwd_struct structure
      *
      */
-    template <int X>
-    static inline void frwd_read(frwd_struct *msp)
+    template<int X>
+    static inline 
+    void frwd_read(frwd_struct *msp)
     {
       assert(msp->bits <= 128);
 
@@ -628,28 +626,28 @@ namespace ojph
       msp->data += bytes;
       msp->size -= bytes;
       ui32 bits = 128;
-      offset = wasm_i64x2_const(0x0706050403020100, 0x0F0E0D0C0B0A0908);
+      offset = wasm_i64x2_const(0x0706050403020100,0x0F0E0D0C0B0A0908);
       validity = wasm_i8x16_gt(validity, offset);
       all_xff = wasm_i8x16_const(OJPH_REPEAT16(-1));
       if (X == 0xFF) // the compiler should remove this if statement
       {
         v128_t t = wasm_v128_xor(validity, all_xff); // complement
-        val = wasm_v128_or(t, val);                  // fill with 0xFF
+        val = wasm_v128_or(t, val); // fill with 0xFF
       }
       else if (X == 0)
-        val = wasm_v128_and(validity, val); // fill with zeros
+        val = wasm_v128_and(validity, val); // fill with zeros 
       else
         assert(0);
 
       v128_t ff_bytes;
       ff_bytes = wasm_i8x16_eq(val, all_xff);
       ff_bytes = wasm_v128_and(ff_bytes, validity);
-      ui32 flags = wasm_i8x16_bitmask(ff_bytes);
+      ui32 flags = wasm_i8x16_bitmask(ff_bytes); 
       flags <<= 1; // unstuff following byte
       ui32 next_unstuff = flags >> 16;
       flags |= msp->unstuff;
       flags &= 0xFFFF;
-      while (flags)
+      while (flags) 
       { // bit unstuffing occurs on average once every 256 bytes
         // therefore it is not an issue if it is a bit slow
         // here we process 16 bytes
@@ -662,12 +660,12 @@ namespace ojph
         t = wasm_i8x16_splat((char)loc);
         m = wasm_i8x16_gt(offset, t);
 
-        t = wasm_v128_and(m, val); // keep bits at locations larger than loc
-        c = wasm_u64x2_shr(t, 1);  // 1 bits left
+        t = wasm_v128_and(m, val);    // keep bits at locations larger than loc
+        c = wasm_u64x2_shr(t, 1);     // 1 bits left
         t = wasm_i64x2_shuffle(t, wasm_i64x2_const(0, 0), 1, 2);
-        t = wasm_i64x2_shl(t, 63); // keep the MSB only
-        t = wasm_v128_or(t, c);    // combine the above 3 steps
-
+        t = wasm_i64x2_shl(t, 63);    // keep the MSB only
+        t = wasm_v128_or(t, c);       // combine the above 3 steps
+                                    
         val = wasm_v128_or(t, wasm_v128_andnot(val, m));
       }
 
@@ -677,7 +675,7 @@ namespace ojph
       ui32 cur_bits = msp->bits & 7;
       v128_t b1, b2;
       b1 = wasm_i64x2_shl(val, cur_bits);
-      // next shift 8 bytes right
+      //next shift 8 bytes right
       b2 = wasm_i64x2_shuffle(wasm_i64x2_const(0, 0), val, 1, 2);
       b2 = wasm_u64x2_shr(b2, 64u - cur_bits);
       b2 = (cur_bits > 0) ? b2 : wasm_i64x2_const(0, 0);
@@ -693,21 +691,22 @@ namespace ojph
       msp->tmp[cur_bytes] = (ui8)upper; // copy byte
 
       msp->bits += bits;
-      msp->unstuff = next_unstuff; // next unstuff
+      msp->unstuff = next_unstuff;   // next unstuff
       assert(msp->unstuff == 0 || msp->unstuff == 1);
     }
 
     //************************************************************************/
     /** @brief Initialize frwd_struct struct and reads some bytes
-     *
+     *  
      *  @tparam      X is the value fed in when the bitstream is exhausted.
      *               See frwd_read regarding the template
      *  @param [in]  msp is a pointer to frwd_struct
      *  @param [in]  data is a pointer to the start of data
      *  @param [in]  size is the number of byte in the bitstream
      */
-    template <int X>
-    static inline void frwd_init(frwd_struct *msp, const ui8 *data, int size)
+    template<int X>
+    static inline 
+    void frwd_init(frwd_struct *msp, const ui8* data, int size)
     {
       msp->data = data;
       wasm_v128_store(msp->tmp, wasm_i64x2_const(0, 0));
@@ -727,12 +726,13 @@ namespace ojph
      *  @param [in]  msp is a pointer to frwd_struct
      *  @param [in]  num_bits is the number of bit to consume
      */
-    static inline void frwd_advance(frwd_struct *msp, ui32 num_bits)
+    static inline 
+    void frwd_advance(frwd_struct *msp, ui32 num_bits)
     {
       assert(num_bits > 0 && num_bits <= msp->bits && num_bits < 128);
       msp->bits -= num_bits;
 
-      v128_t *p = (v128_t *)(msp->tmp + ((num_bits >> 3) & 0x18));
+      v128_t *p = (v128_t*)(msp->tmp + ((num_bits >> 3) & 0x18));
       num_bits &= 63;
 
       v128_t v0, v1, c0, c1, t;
@@ -768,13 +768,14 @@ namespace ojph
      *               See frwd_read regarding the template
      *  @param [in]  msp is a pointer to frwd_struct
      */
-    template <int X>
-    static inline v128_t frwd_fetch(frwd_struct *msp)
+    template<int X>
+    static inline
+    v128_t frwd_fetch(frwd_struct *msp)
     {
       if (msp->bits <= 128)
       {
         frwd_read<X>(msp);
-        if (msp->bits <= 128) // need to test
+        if (msp->bits <= 128) //need to test
           frwd_read<X>(msp);
       }
       v128_t t = wasm_v128_load(msp->tmp);
@@ -794,8 +795,9 @@ namespace ojph
      *  @return v128_t decoded quad
      */
     template <int N>
-    static inline v128_t decode_one_quad32(const v128_t inf_u_q, v128_t U_q,
-                                           frwd_struct *magsgn, ui32 p, v128_t &vn)
+    static inline 
+    v128_t decode_one_quad32(const v128_t inf_u_q, v128_t U_q,
+                              frwd_struct* magsgn, ui32 p, v128_t& vn)
     {
       v128_t w0;    // workers
       v128_t insig; // lanes hold FF's if samples are insignificant
@@ -805,13 +807,13 @@ namespace ojph
       row = wasm_i64x2_const(0, 0);
       w0 = wasm_i32x4_shuffle(inf_u_q, inf_u_q, N, N, N, N);
       // we keeps e_k, e_1, and rho in w2
-      flags = wasm_v128_and(w0, wasm_i32x4_const(0x1110, 0x2220, 0x4440, 0x8880));
+      flags = wasm_v128_and(w0, wasm_i32x4_const(0x1110,0x2220,0x4440,0x8880));
       insig = wasm_i32x4_eq(flags, wasm_i64x2_const(0, 0));
-      if (wasm_i8x16_bitmask(insig) != 0xFFFF) // are all insignificant?
+      if (wasm_i8x16_bitmask(insig) != 0xFFFF) //are all insignificant?
       {
         U_q = wasm_i32x4_shuffle(U_q, U_q, N, N, N, N);
-        flags = wasm_i16x8_mul(flags, wasm_i16x8_const(8, 8, 4, 4, 2, 2, 1, 1));
-        v128_t ms_vec = frwd_fetch<0xFF>(magsgn);
+        flags = wasm_i16x8_mul(flags, wasm_i16x8_const(8,8,4,4,2,2,1,1));
+        v128_t ms_vec = frwd_fetch<0xFF>(magsgn); 
 
         // U_q holds U_q for this quad
         // flags has e_k, e_1, and rho such that e_k is sitting in the
@@ -826,39 +828,38 @@ namespace ojph
         // find cumulative sums
         // to find at which bit in ms_vec the sample starts
         v128_t ex_sum, shfl, inc_sum = m_n; // inclusive scan
-        shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0, 0), inc_sum, 3, 4, 5, 6);
+        shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum, 3, 4, 5, 6);
         inc_sum = wasm_i32x4_add(inc_sum, shfl);
-        shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0, 0), inc_sum, 1, 2);
+        shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum, 1, 2);
         inc_sum = wasm_i32x4_add(inc_sum, shfl);
         int total_mn = wasm_u16x8_extract_lane(inc_sum, 6);
-        ex_sum = wasm_i32x4_shuffle(wasm_i64x2_const(0, 0), inc_sum, 3, 4, 5, 6);
+        ex_sum = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum, 3, 4, 5, 6);
 
         // find the starting byte and starting bit
         v128_t byte_idx = wasm_u32x4_shr(ex_sum, 3);
-        v128_t bit_idx =
-            wasm_v128_and(ex_sum, wasm_i32x4_const(OJPH_REPEAT4(7)));
-        byte_idx = wasm_i8x16_swizzle(byte_idx,
-                                      wasm_i32x4_const(0x00000000, 0x04040404, 0x08080808, 0x0C0C0C0C));
-        byte_idx =
-            wasm_i32x4_add(byte_idx, wasm_i32x4_const(OJPH_REPEAT4(0x03020100)));
+        v128_t bit_idx = 
+          wasm_v128_and(ex_sum, wasm_i32x4_const(OJPH_REPEAT4(7)));
+        byte_idx = wasm_i8x16_swizzle(byte_idx, 
+          wasm_i32x4_const(0x00000000, 0x04040404, 0x08080808, 0x0C0C0C0C));
+        byte_idx = 
+          wasm_i32x4_add(byte_idx, wasm_i32x4_const(OJPH_REPEAT4(0x03020100)));
         v128_t d0 = wasm_i8x16_swizzle(ms_vec, byte_idx);
-        byte_idx =
-            wasm_i32x4_add(byte_idx, wasm_i32x4_const(OJPH_REPEAT4(0x01010101)));
+        byte_idx = 
+          wasm_i32x4_add(byte_idx, wasm_i32x4_const(OJPH_REPEAT4(0x01010101)));
         v128_t d1 = wasm_i8x16_swizzle(ms_vec, byte_idx);
 
         // shift samples values to correct location
         bit_idx = wasm_v128_or(bit_idx, wasm_i32x4_shl(bit_idx, 16));
         v128_t bit_shift = wasm_i8x16_swizzle(
-            wasm_i8x16_const(-1, 127, 63, 31, 15, 7, 3, 1,
-                             -1, 127, 63, 31, 15, 7, 3, 1),
-            bit_idx);
-        bit_shift =
-            wasm_i16x8_add(bit_shift, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
+          wasm_i8x16_const(-1, 127, 63, 31, 15, 7, 3, 1,
+                           -1, 127, 63, 31, 15, 7, 3, 1), bit_idx);
+        bit_shift = 
+          wasm_i16x8_add(bit_shift, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
         d0 = wasm_i16x8_mul(d0, bit_shift);
         d0 = wasm_u16x8_shr(d0, 8); // we should have 8 bits in the LSB
         d1 = wasm_i16x8_mul(d1, bit_shift);
-        d1 = // 8 in MSB
-            wasm_v128_and(d1, wasm_u32x4_const(OJPH_REPEAT4(0xFF00FF00)));
+        d1 =  // 8 in MSB
+          wasm_v128_and(d1, wasm_u32x4_const(OJPH_REPEAT4(0xFF00FF00)));
         d0 = wasm_v128_or(d0, d1);
 
         // find location of e_k and mask
@@ -873,23 +874,23 @@ namespace ojph
         // next e_1
         w0 = wasm_v128_and(flags, wasm_i32x4_const(OJPH_REPEAT4(0x800)));
         w0 = wasm_i32x4_eq(w0, wasm_i64x2_const(0, 0));
-        w0 = wasm_v128_andnot(shift, w0);    // e_1 in correct position
-        ms_vec = wasm_v128_or(ms_vec, w0);   // e_1
-        w0 = wasm_i32x4_shl(ms_vec, 31);     // sign
+        w0 = wasm_v128_andnot(shift, w0);  // e_1 in correct position
+        ms_vec = wasm_v128_or(ms_vec, w0); // e_1
+        w0 = wasm_i32x4_shl(ms_vec, 31);   // sign
         ms_vec = wasm_v128_or(ms_vec, ones); // bin center
         v128_t tvn = ms_vec;
-        ms_vec = wasm_i32x4_add(ms_vec, twos); // + 2
+        ms_vec = wasm_i32x4_add(ms_vec, twos);// + 2
         ms_vec = wasm_i32x4_shl(ms_vec, p - 1);
-        ms_vec = wasm_v128_or(ms_vec, w0);     // sign
+        ms_vec = wasm_v128_or(ms_vec, w0); // sign
         row = wasm_v128_andnot(ms_vec, insig); // significant only
 
         ms_vec = wasm_v128_andnot(tvn, insig); // significant only
-        if (N == 0)                            // the compiler should remove one
-          tvn = wasm_i8x16_swizzle(ms_vec,
-                                   wasm_i32x4_const(0x07060504, 0x0F0E0D0C, -1, -1));
+        if (N == 0) // the compiler should remove one
+          tvn = wasm_i8x16_swizzle(ms_vec, 
+            wasm_i32x4_const(0x07060504, 0x0F0E0D0C, -1, -1));
         else if (N == 1)
-          tvn = wasm_i8x16_swizzle(ms_vec,
-                                   wasm_i32x4_const(-1, 0x07060504, 0x0F0E0D0C, -1));
+          tvn = wasm_i8x16_swizzle(ms_vec, 
+            wasm_i32x4_const(-1, 0x07060504, 0x0F0E0D0C, -1));
         else
           assert(0);
         vn = wasm_v128_or(vn, tvn);
@@ -900,7 +901,7 @@ namespace ojph
       return row;
     }
 
-    //************************************************************************/
+   //************************************************************************/
     /** @brief decodes twos consecutive quads (one octet), using 16 bit data
      *
      *  @param inf_u_q  decoded VLC code, with interleaved u values
@@ -910,30 +911,31 @@ namespace ojph
      *  @param vn       used for handling E values (stores v_n values)
      *  @return v128_t decoded quad
      */
-    static inline v128_t decode_two_quad16(const v128_t inf_u_q, v128_t U_q,
-                                           frwd_struct *magsgn, ui32 p, v128_t &vn)
+    static inline 
+    v128_t decode_two_quad16(const v128_t inf_u_q, v128_t U_q, 
+                              frwd_struct* magsgn, ui32 p, v128_t& vn)
     {
-      v128_t w0;    // workers
-      v128_t insig; // lanes hold FF's if samples are insignificant
-      v128_t flags; // lanes hold e_k, e_1, and rho
-      v128_t row;   // decoded row
+      v128_t w0;     // workers
+      v128_t insig;  // lanes hold FF's if samples are insignificant
+      v128_t flags;  // lanes hold e_k, e_1, and rho
+      v128_t row;    // decoded row
 
       row = wasm_i64x2_const(0, 0);
-      w0 = wasm_i8x16_swizzle(inf_u_q,
-                              wasm_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100,
-                                               0x0504, 0x0504, 0x0504, 0x0504));
+      w0 = wasm_i8x16_swizzle(inf_u_q, 
+        wasm_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100,
+                         0x0504, 0x0504, 0x0504, 0x0504));
       // we keeps e_k, e_1, and rho in w2
-      flags = wasm_v128_and(w0,
-                            wasm_u16x8_const(0x1110, 0x2220, 0x4440, 0x8880,
-                                             0x1110, 0x2220, 0x4440, 0x8880));
+      flags = wasm_v128_and(w0, 
+        wasm_u16x8_const(0x1110, 0x2220, 0x4440, 0x8880, 
+                         0x1110, 0x2220, 0x4440, 0x8880));
       insig = wasm_i16x8_eq(flags, wasm_i64x2_const(0, 0));
-      if (wasm_i8x16_bitmask(insig) != 0xFFFF) // are all insignificant?
+      if (wasm_i8x16_bitmask(insig) != 0xFFFF) //are all insignificant?
       {
-        U_q = wasm_i8x16_swizzle(U_q,
-                                 wasm_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100,
-                                                  0x0504, 0x0504, 0x0504, 0x0504));
-        flags = wasm_i16x8_mul(flags, wasm_i16x8_const(8, 4, 2, 1, 8, 4, 2, 1));
-        v128_t ms_vec = frwd_fetch<0xFF>(magsgn);
+        U_q = wasm_i8x16_swizzle(U_q, 
+          wasm_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100, 
+                           0x0504, 0x0504, 0x0504, 0x0504));
+        flags = wasm_i16x8_mul(flags, wasm_i16x8_const(8,4,2,1,8,4,2,1));
+        v128_t ms_vec = frwd_fetch<0xFF>(magsgn); 
 
         // U_q holds U_q for this quad
         // flags has e_k, e_1, and rho such that e_k is sitting in the
@@ -948,43 +950,42 @@ namespace ojph
         // find cumulative sums
         // to find at which bit in ms_vec the sample starts
         v128_t ex_sum, shfl, inc_sum = m_n; // inclusive scan
-        shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0, 0),
-                                  inc_sum, 7, 8, 9, 10, 11, 12, 13, 14);
+        shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), 
+          inc_sum, 7, 8, 9, 10, 11, 12, 13, 14);
         inc_sum = wasm_i16x8_add(inc_sum, shfl);
-        shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0, 0), inc_sum, 3, 4, 5, 6);
+        shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum, 3, 4, 5, 6);
         inc_sum = wasm_i16x8_add(inc_sum, shfl);
-        shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0, 0), inc_sum, 1, 2);
+        shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum, 1, 2);
         inc_sum = wasm_i16x8_add(inc_sum, shfl);
         int total_mn = wasm_u16x8_extract_lane(inc_sum, 7);
-        ex_sum = wasm_i16x8_shuffle(wasm_i64x2_const(0, 0),
-                                    inc_sum, 7, 8, 9, 10, 11, 12, 13, 14);
+        ex_sum = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), 
+          inc_sum, 7, 8, 9, 10, 11, 12, 13, 14);
 
         // find the starting byte and starting bit
         v128_t byte_idx = wasm_u16x8_shr(ex_sum, 3);
-        v128_t bit_idx =
-            wasm_v128_and(ex_sum, wasm_i16x8_const(OJPH_REPEAT8(7)));
-        byte_idx = wasm_i8x16_swizzle(byte_idx,
-                                      wasm_i16x8_const(0x0000, 0x0202, 0x0404, 0x0606,
-                                                       0x0808, 0x0A0A, 0x0C0C, 0x0E0E));
-        byte_idx =
-            wasm_i16x8_add(byte_idx, wasm_i16x8_const(OJPH_REPEAT8(0x0100)));
+        v128_t bit_idx = 
+          wasm_v128_and(ex_sum, wasm_i16x8_const(OJPH_REPEAT8(7)));
+        byte_idx = wasm_i8x16_swizzle(byte_idx, 
+          wasm_i16x8_const(0x0000, 0x0202, 0x0404, 0x0606, 
+                           0x0808, 0x0A0A, 0x0C0C, 0x0E0E));
+        byte_idx = 
+          wasm_i16x8_add(byte_idx, wasm_i16x8_const(OJPH_REPEAT8(0x0100)));
         v128_t d0 = wasm_i8x16_swizzle(ms_vec, byte_idx);
-        byte_idx =
-            wasm_i16x8_add(byte_idx, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
+        byte_idx = 
+          wasm_i16x8_add(byte_idx, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
         v128_t d1 = wasm_i8x16_swizzle(ms_vec, byte_idx);
 
         // shift samples values to correct location
         v128_t bit_shift = wasm_i8x16_swizzle(
-            wasm_i8x16_const(-1, 127, 63, 31, 15, 7, 3, 1,
-                             -1, 127, 63, 31, 15, 7, 3, 1),
-            bit_idx);
-        bit_shift =
-            wasm_i16x8_add(bit_shift, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
+          wasm_i8x16_const(-1, 127, 63, 31, 15, 7, 3, 1,
+                           -1, 127, 63, 31, 15, 7, 3, 1), bit_idx);
+        bit_shift = 
+          wasm_i16x8_add(bit_shift, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
         d0 = wasm_i16x8_mul(d0, bit_shift);
         d0 = wasm_u16x8_shr(d0, 8); // we should have 8 bits in the LSB
         d1 = wasm_i16x8_mul(d1, bit_shift);
         d1 = // 8 in MSB
-            wasm_v128_and(d1, wasm_i16x8_const(OJPH_REPEAT8((si16)0xFF00)));
+          wasm_v128_and(d1, wasm_i16x8_const(OJPH_REPEAT8((si16)0xFF00))); 
         d0 = wasm_v128_or(d0, d1);
 
         // find location of e_k and mask
@@ -1005,22 +1006,22 @@ namespace ojph
         // next e_1
         w0 = wasm_v128_and(flags, wasm_i16x8_const(OJPH_REPEAT8(0x800)));
         w0 = wasm_i16x8_eq(w0, wasm_i64x2_const(0, 0));
-        w0 = wasm_v128_andnot(shift, w0);    // e_1 in correct position
-        ms_vec = wasm_v128_or(ms_vec, w0);   // e_1
-        w0 = wasm_i16x8_shl(ms_vec, 15);     // sign
+        w0 = wasm_v128_andnot(shift, w0);  // e_1 in correct position
+        ms_vec = wasm_v128_or(ms_vec, w0); // e_1
+        w0 = wasm_i16x8_shl(ms_vec, 15);   // sign
         ms_vec = wasm_v128_or(ms_vec, ones); // bin center
         v128_t tvn = ms_vec;
-        ms_vec = wasm_i16x8_add(ms_vec, twos); // + 2
+        ms_vec = wasm_i16x8_add(ms_vec, twos);// + 2
         ms_vec = wasm_i16x8_shl(ms_vec, p - 1);
-        ms_vec = wasm_v128_or(ms_vec, w0);     // sign
+        ms_vec = wasm_v128_or(ms_vec, w0); // sign
         row = wasm_v128_andnot(ms_vec, insig); // significant only
 
         ms_vec = wasm_v128_andnot(tvn, insig); // significant only
-        w0 = wasm_i8x16_swizzle(ms_vec,
-                                wasm_i16x8_const(0x0302, 0x0706, -1, -1, -1, -1, -1, -1));
+        w0 = wasm_i8x16_swizzle(ms_vec, 
+          wasm_i16x8_const(0x0302, 0x0706, -1, -1, -1, -1, -1, -1));
         vn = wasm_v128_or(vn, w0);
-        w0 = wasm_i8x16_swizzle(ms_vec,
-                                wasm_i16x8_const(-1, 0x0B0A, 0x0F0E, -1, -1, -1, -1, -1));
+        w0 = wasm_i8x16_swizzle(ms_vec, 
+          wasm_i16x8_const(-1, 0x0B0A, 0x0F0E, -1, -1, -1, -1, -1));
         vn = wasm_v128_or(vn, w0);
 
         if (total_mn)
@@ -1028,6 +1029,7 @@ namespace ojph
       }
       return row;
     }
+
 
     //************************************************************************/
     /** @brief Decodes one codeblock, processing the cleanup, siginificance
@@ -1041,12 +1043,12 @@ namespace ojph
      *  @param [in]   lengths1 is the length of cleanup pass
      *  @param [in]   lengths2 is the length of refinement passes (either SPP
      *                only or SPP+MRP)
-     *  @param [in]   width is the decoded codeblock width
+     *  @param [in]   width is the decoded codeblock width 
      *  @param [in]   height is the decoded codeblock height
-     *  @param [in]   stride is the decoded codeblock buffer stride
+     *  @param [in]   stride is the decoded codeblock buffer stride 
      *  @param [in]   stripe_causal is true for stripe causal mode
      */
-    bool ojph_decode_codeblock_wasm(ui8 *coded_data, ui32 *decoded_data,
+    bool ojph_decode_codeblock_wasm(ui8* coded_data, ui32* decoded_data,
                                     ui32 missing_msbs, ui32 num_passes,
                                     ui32 lengths1, ui32 lengths2,
                                     ui32 width, ui32 height, ui32 stride,
@@ -1068,13 +1070,13 @@ namespace ojph
       {
         OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
                               "This codeblocks has %d passes.\n",
-                  num_passes);
+                              num_passes);
         return false;
       }
 
       if (missing_msbs > 30) // p < 0
       {
-        if (insufficient_precision == false)
+        if (insufficient_precision == false) 
         {
           insufficient_precision = true;
           OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
@@ -1082,26 +1084,23 @@ namespace ojph
                                 "displayed again.\n");
         }
         return false;
-      }
+      }       
       else if (missing_msbs == 30) // p == 0
-      {                            // not enough precision to decode and set the bin center to 1
-        if (modify_code == false)
-        {
+      { // not enough precision to decode and set the bin center to 1
+        if (modify_code == false) {
           modify_code = true;
           OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
                                 "pass. The code can be modified to support "
                                 "this case. This message will not be "
                                 "displayed again.\n");
         }
-        return false; // 32 bits are not enough to decode this
-      }
+         return false;         // 32 bits are not enough to decode this
+       }
       else if (missing_msbs == 29) // if p is 1, then num_passes must be 1
       {
-        if (num_passes > 1)
-        {
+        if (num_passes > 1) {
           num_passes = 1;
-          if (truncate_spp_mrp == false)
-          {
+          if (truncate_spp_mrp == false) {
             truncate_spp_mrp = true;
             OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
                                   "nor MagRef passes; both will be skipped. "
@@ -1122,34 +1121,34 @@ namespace ojph
 
       // read scup and fix the bytes there
       int lcup, scup;
-      lcup = (int)lengths1; // length of CUP
-      // scup is the length of MEL + VLC
-      scup = (((int)coded_data[lcup - 1]) << 4) + (coded_data[lcup - 2] & 0xF);
-      if (scup < 2 || scup > lcup || scup > 4079) // something is wrong
+      lcup = (int)lengths1;  // length of CUP
+      //scup is the length of MEL + VLC
+      scup = (((int)coded_data[lcup-1]) << 4) + (coded_data[lcup-2] & 0xF);
+      if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
         return false;
 
-      // The temporary storage scratch holds two types of data in an
+      // The temporary storage scratch holds two types of data in an 
       // interleaved fashion. The interleaving allows us to use one
       // memory pointer.
       // We have one entry for a decoded VLC code, and one entry for UVLC.
-      // Entries are 16 bits each, corresponding to one quad,
-      // but since we want to use XMM registers of the SSE family
+      // Entries are 16 bits each, corresponding to one quad, 
+      // but since we want to use XMM registers of the SSE family 
       // of SIMD; we allocated 16 bytes or more per quad row; that is,
       // the width is no smaller than 16 bytes (or 8 entries), and the
       // height is 512 quads
-      // Each VLC entry contains, in the following order, starting
+      // Each VLC entry contains, in the following order, starting 
       // from MSB
       // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
       // Each entry in UVLC contains u_q
       // One extra row to handle the case of SPP propagating downwards
       // when codeblock width is 4
-      ui16 scratch[8 * 513] = {0}; // 8+ kB
+      ui16 scratch[8 * 513] = {0};          // 8+ kB
 
       // We need an extra two entries (one inf and one u_q) beyond
-      // the last column.
-      // If the block width is 4 (2 quads), then we use sstr of 8
-      // (enough for 4 quads). If width is 8 (4 quads) we use
-      // sstr is 16 (enough for 8 quads). For a width of 16 (8
+      // the last column. 
+      // If the block width is 4 (2 quads), then we use sstr of 8 
+      // (enough for 4 quads). If width is 8 (4 quads) we use 
+      // sstr is 16 (enough for 8 quads). For a width of 16 (8 
       // quads), we use 24 (enough for 12 quads).
       ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
 
@@ -1158,11 +1157,11 @@ namespace ojph
       ui32 mmsbp2 = missing_msbs + 2;
 
       // The cleanup pass is decoded in two steps; in step one,
-      // the VLC and MEL segments are decoded, generating a record that
+      // the VLC and MEL segments are decoded, generating a record that 
       // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
       // This information should be sufficient for the next step.
       // In step 2, we decode the MagSgn segment.
-
+      
       // step 1 decoding VLC and MEL segments
       {
         // init structures
@@ -1178,7 +1177,7 @@ namespace ojph
         ui32 vlc_val;
         ui32 c_q = 0;
         ui16 *sp = scratch;
-        // initial quad row
+        //initial quad row
         for (ui32 x = 0; x < width; sp += 4)
         {
           // decode VLC
@@ -1187,111 +1186,111 @@ namespace ojph
           // first quad
           vlc_val = rev_fetch(&vlc);
 
-          // decode VLC using the context c_q and the head of VLC bitstream
-          ui16 t0 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
+          //decode VLC using the context c_q and the head of VLC bitstream
+          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
 
           // if context is zero, use one MEL event
-          if (c_q == 0) // zero context
+          if (c_q == 0) //zero context
           {
-            run -= 2; // subtract 2, since events number if multiplied by 2
+            run -= 2; //subtract 2, since events number if multiplied by 2
 
-            // Is the run terminated in 1? if so, use decoded VLC code,
-            // otherwise, discard decoded data, since we will decoded again
+            // Is the run terminated in 1? if so, use decoded VLC code, 
+            // otherwise, discard decoded data, since we will decoded again 
             // using a different context
             t0 = (run == -1) ? t0 : 0;
 
             // is run -1 or -2? this means a run has been consumed
-            if (run < 0)
-              run = mel_get_run(&mel); // get another run
+            if (run < 0) 
+              run = mel_get_run(&mel);  // get another run
           }
-          // run -= (c_q == 0) ? 2 : 0;
-          // t0 = (c_q != 0 || run == -1) ? t0 : 0;
-          // if (run < 0)
-          //   run = mel_get_run(&mel);  // get another run
-          sp[0] = t0;
+          //run -= (c_q == 0) ? 2 : 0;
+          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[0] = t0; 
           x += 2;
 
           // prepare context for the next quad; eqn. 1 in ITU T.814
           c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
 
-          // remove data from vlc stream (0 bits are removed if vlc is not used)
+          //remove data from vlc stream (0 bits are removed if vlc is not used)
           vlc_val = rev_advance(&vlc, t0 & 0x7);
 
-          // second quad
+          //second quad
           ui16 t1 = 0;
 
-          // decode VLC using the context c_q and the head of VLC bitstream
-          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
+          //decode VLC using the context c_q and the head of VLC bitstream
+          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)]; 
 
           // if context is zero, use one MEL event
-          if (c_q == 0 && x < width) // zero context
+          if (c_q == 0 && x < width) //zero context
           {
-            run -= 2; // subtract 2, since events number if multiplied by 2
+            run -= 2; //subtract 2, since events number if multiplied by 2
 
             // if event is 0, discard decoded t1
             t1 = (run == -1) ? t1 : 0;
 
-            if (run < 0)               // have we consumed all events in a run
+            if (run < 0) // have we consumed all events in a run
               run = mel_get_run(&mel); // if yes, then get another run
           }
           t1 = x < width ? t1 : 0;
-          // run -= (c_q == 0 && x < width) ? 2 : 0;
-          // t1 = (c_q != 0 || run == -1) ? t1 : 0;
-          // if (run < 0)
-          //   run = mel_get_run(&mel);  // get another run
+          //run -= (c_q == 0 && x < width) ? 2 : 0;
+          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
           sp[2] = t1;
           x += 2;
 
-          // prepare context for the next quad, eqn. 1 in ITU T.814
+          //prepare context for the next quad, eqn. 1 in ITU T.814
           c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
 
-          // remove data from vlc stream, if qinf is not used, cwdlen is 0
+          //remove data from vlc stream, if qinf is not used, cwdlen is 0
           vlc_val = rev_advance(&vlc, t1 & 0x7);
-
+          
           // decode u
           /////////////
           // uvlc_mode is made up of u_offset bits from the quad pair
           ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-          if (uvlc_mode == 0xc0) // if both u_offset are set, get an event from
-          {                      // the MEL run of events
-            run -= 2;            // subtract 2, since events number if multiplied by 2
+          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
+          {                     // the MEL run of events
+            run -= 2; //subtract 2, since events number if multiplied by 2
 
             uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
                                                  // is 0x40
 
-            if (run < 0) // if run is consumed (run is -1 or -2), get another run
+            if (run < 0)//if run is consumed (run is -1 or -2), get another run
               run = mel_get_run(&mel);
           }
-          // run -= (uvlc_mode == 0xc0) ? 2 : 0;
-          // uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
-          // if (run < 0)
-          //   run = mel_get_run(&mel);  // get another run
+          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
+          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
 
-          // decode uvlc_mode to get u for both quads
+          //decode uvlc_mode to get u for both quads
           ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
-          // remove total prefix length
-          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-          uvlc_entry >>= 3;
-          // extract suffixes for quad 0 and 1
-          ui32 len = uvlc_entry & 0xF;           // suffix length for 2 quads
-          ui32 tmp = vlc_val & ((1 << len) - 1); // suffix value for 2 quads
+          //remove total prefix length
+          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7); 
+          uvlc_entry >>= 3; 
+          //extract suffixes for quad 0 and 1
+          ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+          ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
           vlc_val = rev_advance(&vlc, len);
           uvlc_entry >>= 4;
           // quad 0 length
           len = uvlc_entry & 0x7; // quad 0 suffix length
           uvlc_entry >>= 3;
-          ui16 u_q = (ui16)(1 + (uvlc_entry & 7) + (tmp & ~(0xFFU << len))); // kap. 1
-          sp[1] = u_q;
-          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len)); // kappa == 1
-          sp[3] = u_q;
+          ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len))); //kap. 1
+          sp[1] = u_q; 
+          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
+          sp[3] = u_q; 
         }
         sp[0] = sp[1] = 0;
 
-        // non initial quad rows
+        //non initial quad rows
         for (ui32 y = 2; y < height; y += 2)
         {
-          c_q = 0;                              // context
-          ui16 *sp = scratch + (y >> 1) * sstr; // this row of quads
+          c_q = 0;                                // context
+          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
 
           for (ui32 x = 0; x < width; sp += 4)
           {
@@ -1305,27 +1304,27 @@ namespace ojph
             // first quad
             vlc_val = rev_fetch(&vlc);
 
-            // decode VLC using the context c_q and the head of VLC bitstream
-            ui16 t0 = vlc_tbl1[c_q + (vlc_val & 0x7F)];
+            //decode VLC using the context c_q and the head of VLC bitstream
+            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
 
             // if context is zero, use one MEL event
-            if (c_q == 0) // zero context
+            if (c_q == 0) //zero context
             {
-              run -= 2; // subtract 2, since events number is multiplied by 2
+              run -= 2; //subtract 2, since events number is multiplied by 2
 
-              // Is the run terminated in 1? if so, use decoded VLC code,
-              // otherwise, discard decoded data, since we will decoded again
+              // Is the run terminated in 1? if so, use decoded VLC code, 
+              // otherwise, discard decoded data, since we will decoded again 
               // using a different context
               t0 = (run == -1) ? t0 : 0;
 
               // is run -1 or -2? this means a run has been consumed
-              if (run < 0)
-                run = mel_get_run(&mel); // get another run
+              if (run < 0) 
+                run = mel_get_run(&mel);  // get another run
             }
-            // run -= (c_q == 0) ? 2 : 0;
-            // t0 = (c_q != 0 || run == -1) ? t0 : 0;
-            // if (run < 0)
-            //   run = mel_get_run(&mel);  // get another run
+            //run -= (c_q == 0) ? 2 : 0;
+            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
             sp[0] = t0;
             x += 2;
 
@@ -1338,32 +1337,32 @@ namespace ojph
             c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
             c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
 
-            // remove data from vlc stream (0 bits are removed if vlc is unused)
+            //remove data from vlc stream (0 bits are removed if vlc is unused)
             vlc_val = rev_advance(&vlc, t0 & 0x7);
 
-            // second quad
+            //second quad
             ui16 t1 = 0;
 
-            // decode VLC using the context c_q and the head of VLC bitstream
-            t1 = vlc_tbl1[c_q + (vlc_val & 0x7F)];
+            //decode VLC using the context c_q and the head of VLC bitstream
+            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)]; 
 
             // if context is zero, use one MEL event
-            if (c_q == 0 && x < width) // zero context
+            if (c_q == 0 && x < width) //zero context
             {
-              run -= 2; // subtract 2, since events number if multiplied by 2
+              run -= 2; //subtract 2, since events number if multiplied by 2
 
               // if event is 0, discard decoded t1
               t1 = (run == -1) ? t1 : 0;
 
-              if (run < 0)               // have we consumed all events in a run
+              if (run < 0) // have we consumed all events in a run
                 run = mel_get_run(&mel); // if yes, then get another run
             }
             t1 = x < width ? t1 : 0;
-            // run -= (c_q == 0 && x < width) ? 2 : 0;
-            // t1 = (c_q != 0 || run == -1) ? t1 : 0;
-            // if (run < 0)
-            //   run = mel_get_run(&mel);  // get another run
-            sp[2] = t1;
+            //run -= (c_q == 0 && x < width) ? 2 : 0;
+            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[2] = t1; 
             x += 2;
 
             // partial c_q, will be completed when we process the next quad
@@ -1372,26 +1371,26 @@ namespace ojph
             // sigma_q (nw)
             c_q |= sp[2 - (si32)sstr] & 0x80;
 
-            // remove data from vlc stream, if qinf is not used, cwdlen is 0
+            //remove data from vlc stream, if qinf is not used, cwdlen is 0
             vlc_val = rev_advance(&vlc, t1 & 0x7);
-
+          
             // decode u
             /////////////
             // uvlc_mode is made up of u_offset bits from the quad pair
             ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
             ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
-            // remove total prefix length
+            //remove total prefix length
             vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
             uvlc_entry >>= 3;
-            // extract suffixes for quad 0 and 1
-            ui32 len = uvlc_entry & 0xF;           // suffix length for 2 quads
-            ui32 tmp = vlc_val & ((1 << len) - 1); // suffix value for 2 quads
+            //extract suffixes for quad 0 and 1
+            ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+            ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
             vlc_val = rev_advance(&vlc, len);
             uvlc_entry >>= 4;
             // quad 0 length
             len = uvlc_entry & 0x7; // quad 0 suffix length
             uvlc_entry >>= 3;
-            ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFU << len))); // u_q
+            ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFU << len))); //u_q
             sp[1] = u_q;
             u_q = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
             sp[3] = u_q;
@@ -1430,7 +1429,7 @@ namespace ojph
 
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
-            // here we process two quads
+            //here we process two quads
             v128_t w0, w1; // workers
             v128_t inf_u_q, U_q;
             // determine U_q
@@ -1448,12 +1447,12 @@ namespace ojph
             v128_t row0 = decode_one_quad32<0>(inf_u_q, U_q, &magsgn, p, vn);
             v128_t row1 = decode_one_quad32<1>(inf_u_q, U_q, &magsgn, p, vn);
             w0 = wasm_v128_load(vp);
-            w0 = wasm_v128_and(w0, wasm_i32x4_const(-1, 0, 0, 0));
+            w0 = wasm_v128_and(w0, wasm_i32x4_const(-1,0,0,0));
             w0 = wasm_v128_or(w0, vn);
-            wasm_v128_store(vp, w0);
+            wasm_v128_store(vp, w0);            
 
-            // interleave in ssse3 style
-
+            //interleave in ssse3 style 
+                 
             w0 = wasm_i32x4_shuffle(row0, row1, 0, 4, 1, 5);
             w1 = wasm_i32x4_shuffle(row0, row1, 2, 6, 3, 7);
             row0 = wasm_i32x4_shuffle(w0, w1, 0, 4, 1, 5);
@@ -1469,9 +1468,11 @@ namespace ojph
             // perform 31 - count_leading_zeros(*vp) here
             ui32 *vp = v_n_scratch;
             const v128_t lut_lo = wasm_i8x16_const(
-                31, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4);
+              31, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4
+            );
             const v128_t lut_hi = wasm_i8x16_const(
-                31, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+              31, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0
+            );
             const v128_t nibble_mask = wasm_i8x16_const(OJPH_REPEAT16(0x0F));
             const v128_t byte_offset8 = wasm_i16x8_const(OJPH_REPEAT8(8));
             const v128_t byte_offset16 = wasm_i16x8_const(OJPH_REPEAT8(16));
@@ -1507,7 +1508,7 @@ namespace ojph
 
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
-            // process two quads
+            //process two quads
             v128_t w0, w1; // workers
             v128_t inf_u_q, U_q;
             // determine U_q
@@ -1515,15 +1516,15 @@ namespace ojph
               v128_t gamma, emax, kappa, u_q; // needed locally
 
               inf_u_q = wasm_v128_load(sp);
-              gamma =
-                  wasm_v128_and(inf_u_q, wasm_i32x4_const(OJPH_REPEAT4(0xF0)));
+              gamma = 
+                wasm_v128_and(inf_u_q, wasm_i32x4_const(OJPH_REPEAT4(0xF0)));
               w0 = wasm_i32x4_sub(gamma, wasm_i32x4_const(OJPH_REPEAT4(1)));
               gamma = wasm_v128_and(gamma, w0);
               gamma = wasm_i32x4_eq(gamma, wasm_i64x2_const(0, 0));
 
               emax = wasm_v128_load(vp + v_n_size);
-              w0 = wasm_i32x4_shuffle(emax, wasm_i64x2_const(0, 0), 1, 2, 3, 4);
-              emax = wasm_i16x8_max(w0, emax); // no max_epi32 in ssse3
+              w0 = wasm_i32x4_shuffle(emax, wasm_i64x2_const(0,0), 1, 2, 3, 4);
+              emax = wasm_i16x8_max(w0, emax); // no max_epi32 in ssse3              
               emax = wasm_v128_andnot(emax, gamma);
 
               kappa = wasm_i32x4_const(OJPH_REPEAT4(1));
@@ -1542,21 +1543,21 @@ namespace ojph
             v128_t row0 = decode_one_quad32<0>(inf_u_q, U_q, &magsgn, p, vn);
             v128_t row1 = decode_one_quad32<1>(inf_u_q, U_q, &magsgn, p, vn);
             w0 = wasm_v128_load(vp);
-            w0 = wasm_v128_and(w0, wasm_i32x4_const(-1, 0, 0, 0));
+            w0 = wasm_v128_and(w0, wasm_i32x4_const(-1,0,0,0));
             w0 = wasm_v128_or(w0, vn);
-            wasm_v128_store(vp, w0);
+            wasm_v128_store(vp, w0);  
 
-            // interleave in ssse3 style
-            w0 = wasm_i32x4_shuffle(row0, row1, 0, 4, 1, 5);
-            w1 = wasm_i32x4_shuffle(row0, row1, 2, 6, 3, 7);
-            row0 = wasm_i32x4_shuffle(w0, w1, 0, 4, 1, 5);
-            row1 = wasm_i32x4_shuffle(w0, w1, 2, 6, 3, 7);
+            //interleave in ssse3 style
+            w0 = wasm_i32x4_shuffle(row0, row1, 0, 4, 1, 5); 
+            w1 = wasm_i32x4_shuffle(row0, row1, 2, 6, 3, 7); 
+            row0 = wasm_i32x4_shuffle(w0, w1, 0, 4, 1, 5); 
+            row1 = wasm_i32x4_shuffle(w0, w1, 2, 6, 3, 7); 
             wasm_v128_store(dp, row0);
             wasm_v128_store(dp + stride, row1);
           }
         }
       }
-      else
+      else 
       {
         // reduce bitplane by 16 because we now have 16 bits instead of 32
         p -= 16;
@@ -1581,7 +1582,7 @@ namespace ojph
 
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
-            // here we process two quads
+            //here we process two quads
             v128_t w0, w1; // workers
             v128_t inf_u_q, U_q;
             // determine U_q
@@ -1598,18 +1599,18 @@ namespace ojph
             v128_t vn = wasm_i16x8_const(OJPH_REPEAT8(2));
             v128_t row = decode_two_quad16(inf_u_q, U_q, &magsgn, p, vn);
             w0 = wasm_v128_load(vp);
-            w0 = wasm_v128_and(w0, wasm_i16x8_const(-1, 0, 0, 0, 0, 0, 0, 0));
+            w0 = wasm_v128_and(w0, wasm_i16x8_const(-1,0,0,0,0,0,0,0));
             w0 = wasm_v128_or(w0, vn);
-            wasm_v128_store(vp, w0);
+            wasm_v128_store(vp, w0);  
 
-            // interleave in ssse3 style
-            w0 = wasm_i8x16_swizzle(row,
-                                    wasm_i16x8_const(-1, 0x0100, -1, 0x0504,
-                                                     -1, 0x0908, -1, 0x0D0C));
+            //interleave in ssse3 style 
+            w0 = wasm_i8x16_swizzle(row, 
+              wasm_i16x8_const(-1, 0x0100, -1, 0x0504, 
+                               -1, 0x0908, -1, 0x0D0C));
             wasm_v128_store(dp, w0);
-            w1 = wasm_i8x16_swizzle(row,
-                                    wasm_i16x8_const(-1, 0x0302, -1, 0x0706,
-                                                     -1, 0x0B0A, -1, 0x0F0E));
+            w1 = wasm_i8x16_swizzle(row, 
+              wasm_i16x8_const(-1, 0x0302, -1, 0x0706, 
+                               -1, 0x0B0A, -1, 0x0F0E));
             wasm_v128_store(dp + stride, w1);
           }
         }
@@ -1620,9 +1621,11 @@ namespace ojph
             // perform 15 - count_leading_zeros(*vp) here
             ui16 *vp = v_n_scratch;
             const v128_t lut_lo = wasm_i8x16_const(
-                15, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4);
+              15, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4
+            );
             const v128_t lut_hi = wasm_i8x16_const(
-                15, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+              15, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0
+            );
             const v128_t nibble_mask = wasm_i8x16_const(OJPH_REPEAT16(0x0F));
             const v128_t byte_offset8 = wasm_i16x8_const(OJPH_REPEAT8(8));
             const v128_t cc = wasm_i16x8_const(OJPH_REPEAT8(15));
@@ -1653,7 +1656,7 @@ namespace ojph
 
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
-            // process two quads
+            //process two quads
             v128_t w0, w1; // workers
             v128_t inf_u_q, U_q;
             // determine U_q
@@ -1661,19 +1664,19 @@ namespace ojph
               v128_t gamma, emax, kappa, u_q; // needed locally
 
               inf_u_q = wasm_v128_load(sp);
-              gamma =
-                  wasm_v128_and(inf_u_q, wasm_i32x4_const(OJPH_REPEAT4(0xF0)));
+              gamma = 
+                wasm_v128_and(inf_u_q, wasm_i32x4_const(OJPH_REPEAT4(0xF0)));
               w0 = wasm_i32x4_sub(gamma, wasm_i32x4_const(OJPH_REPEAT4(1)));
               gamma = wasm_v128_and(gamma, w0);
               gamma = wasm_i32x4_eq(gamma, wasm_i64x2_const(0, 0));
 
               emax = wasm_v128_load(vp + v_n_size);
-              w0 = wasm_i16x8_shuffle(emax,
-                                      wasm_i64x2_const(0, 0), 1, 2, 3, 4, 5, 6, 7, 8);
+              w0 = wasm_i16x8_shuffle(emax, 
+                wasm_i64x2_const(0, 0), 1, 2, 3, 4, 5, 6, 7, 8);
               emax = wasm_i16x8_max(w0, emax); // no max_epi32 in ssse3
-              emax = wasm_i8x16_swizzle(emax,
-                                        wasm_i16x8_const(0x0100, -1, 0x0302, -1,
-                                                         0x0504, -1, 0x0706, -1));
+              emax = wasm_i8x16_swizzle(emax, 
+                wasm_i16x8_const(0x0100, -1, 0x0302, -1, 
+                                 0x0504, -1, 0x0706, -1));
               emax = wasm_v128_andnot(emax, gamma);
 
               kappa = wasm_i32x4_const(OJPH_REPEAT4(1));
@@ -1691,17 +1694,17 @@ namespace ojph
             v128_t vn = wasm_i16x8_const(OJPH_REPEAT8(2));
             v128_t row = decode_two_quad16(inf_u_q, U_q, &magsgn, p, vn);
             w0 = wasm_v128_load(vp);
-            w0 = wasm_v128_and(w0, wasm_i16x8_const(-1, 0, 0, 0, 0, 0, 0, 0));
+            w0 = wasm_v128_and(w0, wasm_i16x8_const(-1,0,0,0,0,0,0,0));
             w0 = wasm_v128_or(w0, vn);
-            wasm_v128_store(vp, w0);
+            wasm_v128_store(vp, w0);  
 
-            w0 = wasm_i8x16_swizzle(row,
-                                    wasm_i16x8_const(-1, 0x0100, -1, 0x0504,
-                                                     -1, 0x0908, -1, 0x0D0C));
+            w0 = wasm_i8x16_swizzle(row, 
+              wasm_i16x8_const(-1, 0x0100, -1, 0x0504, 
+                               -1, 0x0908, -1, 0x0D0C));
             wasm_v128_store(dp, w0);
-            w1 = wasm_i8x16_swizzle(row,
-                                    wasm_i16x8_const(-1, 0x0302, -1, 0x0706,
-                                                     -1, 0x0B0A, -1, 0x0F0E));
+            w1 = wasm_i8x16_swizzle(row, 
+              wasm_i16x8_const(-1, 0x0302, -1, 0x0706, 
+                               -1, 0x0B0A, -1, 0x0F0E));
             wasm_v128_store(dp + stride, w1);
           }
         }
@@ -1714,9 +1717,9 @@ namespace ojph
       {
         // We use scratch again, we can divide it into multiple regions
         // sigma holds all the significant samples, and it cannot
-        // be modified after it is set.  it will be used during the
+        // be modified after it is set.  it will be used during the 
         // Magnitude Refinement Pass
-        ui16 *const sigma = scratch;
+        ui16* const sigma = scratch;
 
         ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
                                          // ui16 contains 4 columns
@@ -1730,12 +1733,12 @@ namespace ojph
 
           const v128_t mask_3 = wasm_i32x4_const(OJPH_REPEAT4(0x30));
           const v128_t mask_C = wasm_i32x4_const(OJPH_REPEAT4(0xC0));
-          const v128_t shuffle_mask = wasm_i32x4_const(0x0C080400, -1, -1, -1);
-          for (y = 0; y < height; y += 4)
+          const v128_t shuffle_mask = wasm_i32x4_const(0x0C080400,-1,-1,-1);
+          for (y = 0; y < height; y += 4) 
           {
-            ui16 *sp = scratch + (y >> 1) * sstr;
-            ui16 *dp = sigma + (y >> 2) * mstr;
-            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2)
+            ui16* sp = scratch + (y >> 1) * sstr;
+            ui16* dp = sigma + (y >> 2) * mstr;
+            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2) 
             {
               v128_t s0, s1, u3, uC, t0, t1;
 
@@ -1761,7 +1764,7 @@ namespace ojph
           }
           {
             // reset one row after the codeblock
-            ui16 *dp = sigma + (y >> 2) * mstr;
+            ui16* dp = sigma + (y >> 2) * mstr;
             v128_t zero = wasm_i64x2_const(0, 0);
             for (ui32 x = 0; x < width; x += 32, dp += 8)
               wasm_v128_store(dp, zero);
@@ -1788,11 +1791,9 @@ namespace ojph
           for (ui32 y = 0; y < height; y += 4)
           {
             ui32 pattern = 0xFFFFu; // a pattern needed samples
-            if (height - y < 4)
-            {
+            if (height - y < 4) {
               pattern = 0x7777u;
-              if (height - y < 3)
-              {
+              if (height - y < 3) {
                 pattern = 0x3333u;
                 if (height - y < 2)
                   pattern = 0x1111u;
@@ -1824,23 +1825,23 @@ namespace ojph
               // We need data for at least 5 columns out of 8.
               // Therefore loading 32 bits is easier than loading 16 bits
               // twice.
-              ui32 ps = *(ui32 *)prev_sig;
-              ui32 ns = *(ui32 *)(cur_sig + mstr);
+              ui32 ps = *(ui32*)prev_sig;
+              ui32 ns = *(ui32*)(cur_sig + mstr);
               ui32 u = (ps & 0x88888888) >> 3; // the row on top
               if (!stripe_causal)
-                u |= (ns & 0x11111111) << 3; // the row below
+                u |= (ns & 0x11111111) << 3;   // the row below
 
-              ui32 cs = *(ui32 *)cur_sig;
+              ui32 cs = *(ui32*)cur_sig;
               // vertical integration
-              ui32 mbr = cs;                 // this sig. info.
-              mbr |= (cs & 0x77777777) << 1; // above neighbors
-              mbr |= (cs & 0xEEEEEEEE) >> 1; // below neighbors
+              ui32 mbr =  cs;                // this sig. info.
+              mbr |= (cs & 0x77777777) << 1; //above neighbors
+              mbr |= (cs & 0xEEEEEEEE) >> 1; //below neighbors
               mbr |= u;
               // horizontal integration
               ui32 t = mbr;
-              mbr |= t << 4;     // neighbors on the left
-              mbr |= t >> 4;     // neighbors on the right
-              mbr |= prev >> 12; // significance of previous group
+              mbr |= t << 4;      // neighbors on the left
+              mbr |= t >> 4;      // neighbors on the right
+              mbr |= prev >> 12;  // significance of previous group
 
               // remove outside samples, and already significant samples
               mbr &= pattern;
@@ -1861,7 +1862,7 @@ namespace ojph
                   if ((col_mask & new_sig) == 0)
                     continue;
 
-                  // scan one column
+                  //scan one column
                   ui32 sample_mask = 0x1111u & col_mask;
                   if (new_sig & sample_mask)
                   {
@@ -1871,8 +1872,7 @@ namespace ojph
                       ui32 t = 0x33u << i;
                       new_sig |= t & inv_sig;
                     }
-                    cwd >>= 1;
-                    ++cnt;
+                    cwd >>= 1; ++cnt;
                   }
 
                   sample_mask <<= 1;
@@ -1884,8 +1884,7 @@ namespace ojph
                       ui32 t = 0x76u << i;
                       new_sig |= t & inv_sig;
                     }
-                    cwd >>= 1;
-                    ++cnt;
+                    cwd >>= 1; ++cnt;
                   }
 
                   sample_mask <<= 1;
@@ -1897,8 +1896,7 @@ namespace ojph
                       ui32 t = 0xECu << i;
                       new_sig |= t & inv_sig;
                     }
-                    cwd >>= 1;
-                    ++cnt;
+                    cwd >>= 1; ++cnt;
                   }
 
                   sample_mask <<= 1;
@@ -1910,8 +1908,7 @@ namespace ojph
                       ui32 t = 0xC8u << i;
                       new_sig |= t & inv_sig;
                     }
-                    cwd >>= 1;
-                    ++cnt;
+                    cwd >>= 1; ++cnt;
                   }
                 }
 
@@ -1921,42 +1918,42 @@ namespace ojph
                   // value of 0 if new_sig bit is 0, and 0xFF if new_sig is 1
                   v128_t new_sig_vec = wasm_i16x8_splat((si16)new_sig);
                   new_sig_vec = wasm_i8x16_swizzle(new_sig_vec,
-                                                   wasm_i8x16_const(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1));
+                    wasm_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
                   new_sig_vec = wasm_v128_and(new_sig_vec,
-                                              wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                    wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
                   new_sig_vec = wasm_i8x16_eq(new_sig_vec,
-                                              wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                    wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
 
                   // find cumulative sums
                   // to find which bit in cwd we should extract
                   v128_t ex_sum, shfl, inc_sum = new_sig_vec; // inclusive scan
-                  inc_sum = wasm_i8x16_abs(inc_sum);          // cvrt to 0 or 1
-                  shfl = wasm_i8x16_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
+                  inc_sum = wasm_i8x16_abs(inc_sum); // cvrt to 0 or 1                  
+                  shfl = wasm_i8x16_shuffle(wasm_i64x2_const(0,0), inc_sum,
+                    15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
                   inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                  shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                            7, 8, 9, 10, 11, 12, 13, 14);
+                  shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                    7, 8, 9, 10, 11, 12, 13, 14);
                   inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                  shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                            3, 4, 5, 6);
+                  shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                    3, 4, 5, 6);
                   inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                  shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                            1, 2);
+                  shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                    1, 2);
                   inc_sum = wasm_i8x16_add(inc_sum, shfl);
                   cnt += wasm_u8x16_extract_lane(inc_sum, 15);
                   // exclusive scan
-                  ex_sum = wasm_i8x16_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                              15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
+                  ex_sum = wasm_i8x16_shuffle(wasm_i64x2_const(0,0), inc_sum,
+                    15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
 
                   // Spread cwd, such that each bit is in one byte
                   // with a value of 0 or 1.
                   cwd_vec = wasm_i16x8_splat((si16)cwd);
                   cwd_vec = wasm_i8x16_swizzle(cwd_vec,
-                                               wasm_i8x16_const(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1));
+                    wasm_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
                   cwd_vec = wasm_v128_and(cwd_vec,
-                                          wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                    wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
                   cwd_vec = wasm_i8x16_eq(cwd_vec,
-                                          wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                    wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
                   cwd_vec = wasm_i8x16_abs(cwd_vec);
 
                   // Obtain bit from cwd_vec correspondig to ex_sum
@@ -1965,11 +1962,10 @@ namespace ojph
 
                   // load data and set spp coefficients
                   v128_t m = wasm_i8x16_const(
-                      0, -1, -1, -1, 4, -1, -1, -1, 8, -1, -1, -1, 12, -1, -1, -1);
+                    0,-1,-1,-1,4,-1,-1,-1,8,-1,-1,-1,12,-1,-1,-1);
                   v128_t val = wasm_i32x4_splat(3 << (p - 2));
                   ui32 *dp = dpp;
-                  for (int c = 0; c < 4; ++c)
-                  {
+                  for (int c = 0; c < 4; ++ c) {
                     v128_t s0, s0_ns, s0_val;
                     // load coefficients
                     s0 = wasm_v128_load(dp);
@@ -1977,8 +1973,8 @@ namespace ojph
                     // epi32 is -1 only for coefficient that
                     // are changed during the SPP
                     s0_ns = wasm_i8x16_swizzle(new_sig_vec, m);
-                    s0_ns = wasm_i32x4_eq(s0_ns,
-                                          wasm_i32x4_const(OJPH_REPEAT4(0xFF)));
+                    s0_ns = wasm_i32x4_eq(s0_ns, 
+                      wasm_i32x4_const(OJPH_REPEAT4(0xFF)));
 
                     // obtain sign for coefficients in SPP
                     s0_val = wasm_i8x16_swizzle(v, m);
@@ -2003,8 +1999,8 @@ namespace ojph
 
               // vertical integration for the new sig. info.
               t = new_sig;
-              new_sig |= (t & 0x7777) << 1; // above neighbors
-              new_sig |= (t & 0xEEEE) >> 1; // below neighbors
+              new_sig |= (t & 0x7777) << 1; //above neighbors
+              new_sig |= (t & 0xEEEE) >> 1; //below neighbors
               // add sig. info. from the row on top and below
               prev = new_sig | u;
               // we need only the bits in 0xF000
@@ -2025,10 +2021,10 @@ namespace ojph
             ui32 *dpp = decoded_data + y * stride;
             for (ui32 i = 0; i < width; i += 4, dpp += 4)
             {
-              // Process one entry from sigma array at a time
-              //  Each nibble (4 bits) in the sigma array represents 4 rows,
+              //Process one entry from sigma array at a time
+              // Each nibble (4 bits) in the sigma array represents 4 rows,
               ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
-              ui16 sig = *cur_sig++;             // 16 bit that will be processed now
+              ui16 sig = *cur_sig++; // 16 bit that will be processed now
               int total_bits = 0;
               if (sig) // if any of the 32 bits are set
               {
@@ -2038,32 +2034,32 @@ namespace ojph
                 // spread the 16 bits in sig to 0 or 1 bytes in sig_vec
                 v128_t sig_vec = wasm_i16x8_splat((si16)sig);
                 sig_vec = wasm_i8x16_swizzle(sig_vec,
-                                             wasm_i8x16_const(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1));
+                  wasm_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
                 sig_vec = wasm_v128_and(sig_vec,
-                                        wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                  wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
                 sig_vec = wasm_i8x16_eq(sig_vec,
-                                        wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                  wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
                 sig_vec = wasm_i8x16_abs(sig_vec);
 
                 // find cumulative sums
                 // to find which bit in cwd we should extract
                 v128_t ex_sum, shfl, inc_sum = sig_vec; // inclusive scan
-                shfl = wasm_i8x16_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                          15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
+                shfl = wasm_i8x16_shuffle(wasm_i64x2_const(0,0), inc_sum,
+                  15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
                 inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                          7, 8, 9, 10, 11, 12, 13, 14);
+                shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                  7, 8, 9, 10, 11, 12, 13, 14);
                 inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                          3, 4, 5, 6);
+                shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                  3, 4, 5, 6);
                 inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                          1, 2);
+                shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                  1, 2);
                 inc_sum = wasm_i8x16_add(inc_sum, shfl);
                 total_bits = wasm_u8x16_extract_lane(inc_sum, 15);
                 // exclusive scan
-                ex_sum = wasm_i8x16_shuffle(wasm_i64x2_const(0, 0), inc_sum,
-                                            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
+                ex_sum = wasm_i8x16_shuffle(wasm_i64x2_const(0,0), inc_sum,
+                  15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
 
                 // Spread the 16 bits in cwd to inverted 0 or 1 bytes in
                 // cwd_vec. Then, convert these to a form suitable
@@ -2072,25 +2068,24 @@ namespace ojph
                 // represented as binary 01
                 v128_t cwd_vec = wasm_i16x8_splat((si16)cwd);
                 cwd_vec = wasm_i8x16_swizzle(cwd_vec,
-                                             wasm_i8x16_const(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1));
-                cwd_vec = wasm_v128_and(cwd_vec,
-                                        wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
-                cwd_vec = wasm_i8x16_eq(cwd_vec,
-                                        wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
-                cwd_vec =
-                    wasm_i8x16_add(cwd_vec, wasm_i8x16_const(OJPH_REPEAT16(1)));
+                  wasm_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
+                cwd_vec = wasm_v128_and(cwd_vec, 
+                  wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                cwd_vec = wasm_i8x16_eq(cwd_vec, 
+                  wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                cwd_vec = 
+                  wasm_i8x16_add(cwd_vec, wasm_i8x16_const(OJPH_REPEAT16(1)));
                 cwd_vec = wasm_i8x16_add(cwd_vec, cwd_vec);
-                cwd_vec =
-                    wasm_v128_or(cwd_vec, wasm_i8x16_const(OJPH_REPEAT16(1)));
+                cwd_vec = 
+                  wasm_v128_or(cwd_vec, wasm_i8x16_const(OJPH_REPEAT16(1)));
 
                 // load data and insert the mrp bit
-                v128_t m = wasm_i8x16_const(0, -1, -1, -1, 4, -1, -1, -1,
-                                            8, -1, -1, -1, 12, -1, -1, -1);
+                v128_t m = wasm_i8x16_const(0,-1,-1,-1,4,-1,-1,-1,
+                                            8,-1,-1,-1,12,-1,-1,-1);
                 ui32 *dp = dpp;
-                for (int c = 0; c < 4; ++c)
-                {
+                for (int c = 0; c < 4; ++c) {
                   v128_t s0, s0_sig, s0_idx, s0_val;
-                  // load coefficients
+                  // load coefficients                  
                   s0 = wasm_v128_load(dp);
                   // find significant samples in this row
                   s0_sig = wasm_i8x16_swizzle(sig_vec, m);

--- a/Native/Common/OpenJPH/coding/ojph_block_encoder.cpp
+++ b/Native/Common/OpenJPH/coding/ojph_block_encoder.cpp
@@ -44,45 +44,40 @@
 #include <cstring>
 #include <cstdint>
 #include <climits>
+#include <mutex>
 
 #include "ojph_mem.h"
 #include "ojph_arch.h"
 #include "ojph_block_encoder.h"
 #include "ojph_message.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     /////////////////////////////////////////////////////////////////////////
     // tables
     /////////////////////////////////////////////////////////////////////////
 
-    // VLC encoding
-    //  index is (c_q << 8) + (rho << 4) + eps
-    //  data is  (cwd << 8) + (cwd_len << 4) + eps
-    //  table 0 is for the initial line of quads
-    static ui16 vlc_tbl0[2048] = {0};
-    static ui16 vlc_tbl1[2048] = {0};
+    //VLC encoding
+    // index is (c_q << 8) + (rho << 4) + eps
+    // data is  (cwd << 8) + (cwd_len << 4) + eps
+    // table 0 is for the initial line of quads
+    static ui16 vlc_tbl0[2048] = { 0 };
+    static ui16 vlc_tbl1[2048] = { 0 };
 
-    // UVLC encoding
+    //UVLC encoding
     const int num_uvlc_entries = 75;
-    struct uvlc_tbl_struct
-    {
+    struct uvlc_tbl_struct {
       ui8 pre, pre_len, suf, suf_len, ext, ext_len;
     };
     static uvlc_tbl_struct uvlc_tbl[num_uvlc_entries];
-
+    
     /////////////////////////////////////////////////////////////////////////
     static bool vlc_init_tables()
     {
-      struct vlc_src_table
-      {
-        int c_q, rho, u_off, e_k, e_1, cwd, cwd_len;
-      };
+      struct vlc_src_table { int c_q, rho, u_off, e_k, e_1, cwd, cwd_len; };
       vlc_src_table tbl0[] = {
-#include "table0.h"
+    #include "table0.h"
       };
       size_t tbl0_size = sizeof(tbl0) / sizeof(vlc_src_table);
 
@@ -90,7 +85,7 @@ namespace ojph
       for (ui32 i = 0; i < 16; ++i)
         pattern_popcnt[i] = (si32)population_count(i);
 
-      vlc_src_table *src_tbl = tbl0;
+      vlc_src_table* src_tbl = tbl0;
       ui16 *tgt_tbl = vlc_tbl0;
       size_t tbl_size = tbl0_size;
       for (int i = 0; i < 2048; ++i)
@@ -110,8 +105,8 @@ namespace ojph
                 if (src_tbl[j].u_off == 1)
                   if ((emb & src_tbl[j].e_k) == src_tbl[j].e_1)
                   {
-                    // now we need to find the smallest cwd with the highest
-                    //  number of bits set in e_k
+                    //now we need to find the smallest cwd with the highest
+                    // number of bits set in e_k
                     int ones_count = pattern_popcnt[src_tbl[j].e_k];
                     if (ones_count >= best_e_k)
                     {
@@ -134,12 +129,13 @@ namespace ojph
             }
           }
           assert(best_entry);
-          tgt_tbl[i] = (ui16)((best_entry->cwd << 8) + (best_entry->cwd_len << 4) + best_entry->e_k);
+          tgt_tbl[i] = (ui16)((best_entry->cwd<<8) + (best_entry->cwd_len<<4)
+                             + best_entry->e_k);
         }
       }
 
       vlc_src_table tbl1[] = {
-#include "table1.h"
+    #include "table1.h"
       };
       size_t tbl1_size = sizeof(tbl1) / sizeof(vlc_src_table);
 
@@ -163,8 +159,8 @@ namespace ojph
                 if (src_tbl[j].u_off == 1)
                   if ((emb & src_tbl[j].e_k) == src_tbl[j].e_1)
                   {
-                    // now we need to find the smallest cwd with the highest
-                    //  number of bits set in e_k
+                    //now we need to find the smallest cwd with the highest
+                    // number of bits set in e_k
                     int ones_count = pattern_popcnt[src_tbl[j].e_k];
                     if (ones_count >= best_e_k)
                     {
@@ -187,9 +183,11 @@ namespace ojph
             }
           }
           assert(best_entry);
-          tgt_tbl[i] = (ui16)((best_entry->cwd << 8) + (best_entry->cwd_len << 4) + best_entry->e_k);
+          tgt_tbl[i] = (ui16)((best_entry->cwd<<8) + (best_entry->cwd_len<<4)
+                             + best_entry->e_k);
         }
       }
+
 
       return true;
     }
@@ -197,7 +195,7 @@ namespace ojph
     /////////////////////////////////////////////////////////////////////////
     static bool uvlc_init_tables()
     {
-      // code goes from 0 to 31, extension and 32 are not supported here
+      //code goes from 0 to 31, extension and 32 are not supported here
       uvlc_tbl[0].pre = 0;
       uvlc_tbl[0].pre_len = 0;
       uvlc_tbl[0].suf = 0;
@@ -257,42 +255,38 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static bool tables_initialized = false;
-
-    /////////////////////////////////////////////////////////////////////////
-    bool initialize_block_encoder_tables()
-    {
-      if (!tables_initialized)
-      {
+    bool initialize_block_encoder_tables() {
+      static bool tables_initialized = false;
+      static std::once_flag tables_initialized_flag;
+      std::call_once(tables_initialized_flag, []() {
         memset(vlc_tbl0, 0, 2048 * sizeof(ui16));
         memset(vlc_tbl1, 0, 2048 * sizeof(ui16));
         tables_initialized = vlc_init_tables();
         tables_initialized = tables_initialized && uvlc_init_tables();
-      }
+      });
       return tables_initialized;
     }
 
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-    struct mel_struct
-    {
-      // storage
-      ui8 *buf;      // pointer to data buffer
-      ui32 pos;      // position of next writing within buf
-      ui32 buf_size; // size of buffer, which we must not exceed
+    struct mel_struct {
+      //storage
+      ui8* buf;      //pointer to data buffer
+      ui32 pos;      //position of next writing within buf
+      ui32 buf_size; //size of buffer, which we must not exceed
 
       // all these can be replaced by bytes
-      int remaining_bits; // number of empty bits in tmp
-      int tmp;            // temporary storage of coded bits
-      int run;            // number of 0 run
-      int k;              // state
-      int threshold;      // threshold where one bit must be coded
+      int remaining_bits; //number of empty bits in tmp
+      int tmp;            //temporary storage of coded bits
+      int run;            //number of 0 run
+      int k;              //state
+      int threshold;      //threshold where one bit must be coded
     };
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_init(mel_struct *melp, ui32 buffer_size, ui8 *data)
+    mel_init(mel_struct* melp, ui32 buffer_size, ui8* data)
     {
       melp->buf = data;
       melp->pos = 0;
@@ -306,7 +300,7 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_emit_bit(mel_struct *melp, int v)
+    mel_emit_bit(mel_struct* melp, int v)
     {
       assert(v == 0 || v == 1);
       melp->tmp = (melp->tmp << 1) + v;
@@ -324,10 +318,10 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_encode(mel_struct *melp, bool bit)
+    mel_encode(mel_struct* melp, bool bit)
     {
-      // MEL exponent
-      static const int mel_exp[13] = {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5};
+      //MEL exponent
+      static const int mel_exp[13] = {0,0,0,1,1,1,2,2,2,3,3,4,5};
 
       if (bit == false)
       {
@@ -355,24 +349,23 @@ namespace ojph
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-    struct vlc_struct
-    {
-      // storage
-      ui8 *buf;      // pointer to data buffer
-      ui32 pos;      // position of next writing within buf
-      ui32 buf_size; // size of buffer, which we must not exceed
+    struct vlc_struct {
+      //storage
+      ui8* buf;      //pointer to data buffer
+      ui32 pos;      //position of next writing within buf
+      ui32 buf_size; //size of buffer, which we must not exceed
 
-      int used_bits;             // number of occupied bits in tmp
-      int tmp;                   // temporary storage of coded bits
-      bool last_greater_than_8F; // true if last byte us greater than 0x8F
+      int used_bits; //number of occupied bits in tmp
+      int tmp;       //temporary storage of coded bits
+      bool last_greater_than_8F; //true if last byte us greater than 0x8F
     };
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_init(vlc_struct *vlcp, ui32 buffer_size, ui8 *data)
+    vlc_init(vlc_struct* vlcp, ui32 buffer_size, ui8* data)
     {
-      vlcp->buf = data + buffer_size - 1; // points to last byte
-      vlcp->pos = 1;                      // locations will be all -pos
+      vlcp->buf = data + buffer_size - 1; //points to last byte
+      vlcp->pos = 1;                      //locations will be all -pos
       vlcp->buf_size = buffer_size;
 
       vlcp->buf[0] = 0xFF;
@@ -383,7 +376,7 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_encode(vlc_struct *vlcp, int cwd, int cwd_len)
+    vlc_encode(vlc_struct* vlcp, int cwd, int cwd_len)
     {
       while (cwd_len > 0)
       {
@@ -402,7 +395,7 @@ namespace ojph
           if (vlcp->last_greater_than_8F && vlcp->tmp != 0x7F)
           {
             vlcp->last_greater_than_8F = false;
-            continue; // one empty bit remaining
+            continue; //one empty bit remaining
           }
           *(vlcp->buf - vlcp->pos) = (ui8)(vlcp->tmp);
           vlcp->pos++;
@@ -417,7 +410,7 @@ namespace ojph
     //
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    terminate_mel_vlc(mel_struct *melp, vlc_struct *vlcp)
+    terminate_mel_vlc(mel_struct* melp, vlc_struct* vlcp)
     {
       if (melp->run > 0)
         mel_emit_bit(melp, 1);
@@ -426,12 +419,14 @@ namespace ojph
       int mel_mask = (0xFF << melp->remaining_bits) & 0xFF;
       int vlc_mask = 0xFF >> (8 - vlcp->used_bits);
       if ((mel_mask | vlc_mask) == 0)
-        return; // last mel byte cannot be 0xFF, since then
-                // melp->remaining_bits would be < 8
+        return;  //last mel byte cannot be 0xFF, since then
+                 //melp->remaining_bits would be < 8
       if (melp->pos >= melp->buf_size)
         OJPH_ERROR(0x00020003, "mel encoder's buffer is full");
       int fuse = melp->tmp | vlcp->tmp;
-      if ((((fuse ^ melp->tmp) & mel_mask) | ((fuse ^ vlcp->tmp) & vlc_mask)) == 0 && (fuse != 0xFF) && vlcp->pos > 1)
+      if ( ( ((fuse ^ melp->tmp) & mel_mask)
+           | ((fuse ^ vlcp->tmp) & vlc_mask) ) == 0
+          && (fuse != 0xFF) && vlcp->pos > 1)
       {
         melp->buf[melp->pos++] = (ui8)fuse;
       }
@@ -439,7 +434,7 @@ namespace ojph
       {
         if (vlcp->pos >= vlcp->buf_size)
           OJPH_ERROR(0x00020004, "vlc encoder's buffer is full");
-        melp->buf[melp->pos++] = (ui8)melp->tmp; // melp->tmp cannot be 0xFF
+        melp->buf[melp->pos++] = (ui8)melp->tmp; //melp->tmp cannot be 0xFF
         *(vlcp->buf - vlcp->pos) = (ui8)vlcp->tmp;
         vlcp->pos++;
       }
@@ -448,21 +443,20 @@ namespace ojph
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-    struct ms_struct
-    {
-      // storage
-      ui8 *buf;      // pointer to data buffer
-      ui32 pos;      // position of next writing within buf
-      ui32 buf_size; // size of buffer, which we must not exceed
+    struct ms_struct {
+      //storage
+      ui8* buf;      //pointer to data buffer
+      ui32 pos;      //position of next writing within buf
+      ui32 buf_size; //size of buffer, which we must not exceed
 
-      int max_bits;  // maximum number of bits that can be store in tmp
-      int used_bits; // number of occupied bits in tmp
-      ui32 tmp;      // temporary storage of coded bits
+      int max_bits;  //maximum number of bits that can be store in tmp
+      int used_bits; //number of occupied bits in tmp
+      ui32 tmp;      //temporary storage of coded bits
     };
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    ms_init(ms_struct *msp, ui32 buffer_size, ui8 *data)
+    ms_init(ms_struct* msp, ui32 buffer_size, ui8* data)
     {
       msp->buf = data;
       msp->pos = 0;
@@ -474,7 +468,7 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    ms_encode(ms_struct *msp, ui32 cwd, int cwd_len)
+    ms_encode(ms_struct* msp, ui32 cwd, int cwd_len)
     {
       while (cwd_len > 0)
       {
@@ -497,7 +491,7 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    ms_encode64(ms_struct *msp, ui64 cwd, int cwd_len)
+    ms_encode64(ms_struct* msp, ui64 cwd, int cwd_len)
     {
       while (cwd_len > 0)
       {
@@ -516,15 +510,15 @@ namespace ojph
           msp->used_bits = 0;
         }
       }
-    }
+    }    
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    ms_terminate(ms_struct *msp)
+    ms_terminate(ms_struct* msp)
     {
       if (msp->used_bits)
       {
-        int t = msp->max_bits - msp->used_bits; // unused bits
+        int t = msp->max_bits - msp->used_bits; //unused bits
         msp->tmp |= (0xFF & ((1U << t) - 1)) << msp->used_bits;
         msp->used_bits += t;
         if (msp->tmp != 0xFF)
@@ -545,17 +539,17 @@ namespace ojph
     //
     //
     //////////////////////////////////////////////////////////////////////////
-    void ojph_encode_codeblock32(ui32 *buf, ui32 missing_msbs, ui32 num_passes,
+    void ojph_encode_codeblock32(ui32* buf, ui32 missing_msbs, ui32 num_passes,
                                  ui32 width, ui32 height, ui32 stride,
-                                 ui32 *lengths,
+                                 ui32* lengths,
                                  ojph::mem_elastic_allocator *elastic,
-                                 ojph::coded_lists *&coded)
+                                 ojph::coded_lists *& coded)
     {
       assert(num_passes == 1);
-      (void)num_passes;                           // currently not used
-      const int ms_size = (16384 * 16 + 14) / 15; // more than enough
+      (void)num_passes;                      //currently not used
+      const int ms_size = (16384*16+14)/15;  //more than enough
       ui8 ms_buf[ms_size];
-      const int mel_vlc_size = 3072; // more than enough
+      const int mel_vlc_size = 3072;         //more than enough
       ui8 mel_vlc_buf[mel_vlc_size];
       const int mel_size = 192;
       ui8 *mel_buf = mel_vlc_buf;
@@ -571,87 +565,85 @@ namespace ojph
 
       ui32 p = 30 - missing_msbs;
 
-      // e_val: E values for a line (these are the highest set bit)
-      // cx_val: is the context values
-      // Each byte stores the info for the 2 sample. For E, it is maximum
-      //  of the two samples, while for cx, it is the OR of these two samples.
-      // The maximum is between the pixel at the bottom left of one quad
-      //  and the bottom right of the earlier quad. The same is true for cx.
-      // For a 1024 pixels, we need 512 bytes, the 2 extra,
-      //  one for the non-existing earlier quad, and one for beyond the
-      //  the end
+      //e_val: E values for a line (these are the highest set bit)
+      //cx_val: is the context values
+      //Each byte stores the info for the 2 sample. For E, it is maximum
+      // of the two samples, while for cx, it is the OR of these two samples.
+      //The maximum is between the pixel at the bottom left of one quad
+      // and the bottom right of the earlier quad. The same is true for cx.
+      //For a 1024 pixels, we need 512 bytes, the 2 extra,
+      // one for the non-existing earlier quad, and one for beyond the
+      // the end
       ui8 e_val[513];
       ui8 cx_val[513];
-      ui8 *lep = e_val;
-      lep[0] = 0;
-      ui8 *lcxp = cx_val;
-      lcxp[0] = 0;
+      ui8* lep = e_val;     lep[0] = 0;
+      ui8* lcxp = cx_val;   lcxp[0] = 0;
 
-      // initial row of quads
-      int e_qmax[2] = {0, 0}, e_q[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-      int rho[2] = {0, 0};
+      //initial row of quads
+      int e_qmax[2] = {0,0}, e_q[8] = {0,0,0,0,0,0,0,0};
+      int rho[2] = {0,0};
       int c_q0 = 0;
-      ui32 s[8] = {0, 0, 0, 0, 0, 0, 0, 0}, val, t;
+      ui32 s[8] = {0,0,0,0,0,0,0,0}, val, t;
       ui32 y = 0;
       ui32 *sp = buf;
       for (ui32 x = 0; x < width; x += 4)
       {
-        // prepare two quads
+        //prepare two quads
         t = sp[0];
-        val = t + t; // multiply by 2 and get rid of sign
-        val >>= p;   // 2 \mu_p + x
-        val &= ~1u;  // 2 \mu_p
+        val = t + t; //multiply by 2 and get rid of sign
+        val >>= p;  // 2 \mu_p + x
+        val &= ~1u; // 2 \mu_p
         if (val)
         {
           rho[0] = 1;
-          e_q[0] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+          e_q[0] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
           e_qmax[0] = e_q[0];
-          s[0] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+          s[0] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
         }
 
         t = height > 1 ? sp[stride] : 0;
         ++sp;
-        val = t + t; // multiply by 2 and get rid of sign
-        val >>= p;   // 2 \mu_p + x
-        val &= ~1u;  // 2 \mu_p
+        val = t + t; //multiply by 2 and get rid of sign
+        val >>= p; // 2 \mu_p + x
+        val &= ~1u;// 2 \mu_p
         if (val)
         {
           rho[0] += 2;
-          e_q[1] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+          e_q[1] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
           e_qmax[0] = ojph_max(e_qmax[0], e_q[1]);
-          s[1] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+          s[1] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
         }
 
-        if (x + 1 < width)
+        if (x+1 < width)
         {
           t = sp[0];
-          val = t + t; // multiply by 2 and get rid of sign
-          val >>= p;   // 2 \mu_p + x
-          val &= ~1u;  // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1u;// 2 \mu_p
           if (val)
           {
             rho[0] += 4;
-            e_q[2] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[2] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[0] = ojph_max(e_qmax[0], e_q[2]);
-            s[2] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+            s[2] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
           }
 
           t = height > 1 ? sp[stride] : 0;
           ++sp;
-          val = t + t; // multiply by 2 and get rid of sign
-          val >>= p;   // 2 \mu_p + x
-          val &= ~1u;  // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1u;// 2 \mu_p
           if (val)
           {
             rho[0] += 8;
-            e_q[3] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[3] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[0] = ojph_max(e_qmax[0], e_q[3]);
-            s[3] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+            s[3] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
           }
         }
 
-        int Uq0 = ojph_max(e_qmax[0], 1); // kappa_q = 1
-        int u_q0 = Uq0 - 1, u_q1 = 0;     // kappa_q = 1
+        int Uq0 = ojph_max(e_qmax[0], 1); //kappa_q = 1
+        int u_q0 = Uq0 - 1, u_q1 = 0; //kappa_q = 1
 
         int eps0 = 0;
         if (u_q0 > 0)
@@ -661,86 +653,84 @@ namespace ojph
           eps0 |= (e_q[2] == e_qmax[0]) << 2;
           eps0 |= (e_q[3] == e_qmax[0]) << 3;
         }
-        lep[0] = ojph_max(lep[0], (ui8)e_q[1]);
-        lep++;
+        lep[0] = ojph_max(lep[0], (ui8)e_q[1]); lep++;
         lep[0] = (ui8)e_q[3];
-        lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1));
-        lcxp++;
+        lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1)); lcxp++;
         lcxp[0] = (ui8)((rho[0] & 8) >> 3);
 
         ui16 tuple0 = vlc_tbl0[(c_q0 << 8) + (rho[0] << 4) + eps0];
         vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7);
 
         if (c_q0 == 0)
-          mel_encode(&mel, rho[0] != 0);
+            mel_encode(&mel, rho[0] != 0);
 
         int m = (rho[0] & 1) ? Uq0 - (tuple0 & 1) : 0;
-        ms_encode(&ms, s[0] & ((1U << m) - 1), m);
+        ms_encode(&ms, s[0] & ((1U<<m)-1), m);
         m = (rho[0] & 2) ? Uq0 - ((tuple0 & 2) >> 1) : 0;
-        ms_encode(&ms, s[1] & ((1U << m) - 1), m);
+        ms_encode(&ms, s[1] & ((1U<<m)-1), m);
         m = (rho[0] & 4) ? Uq0 - ((tuple0 & 4) >> 2) : 0;
-        ms_encode(&ms, s[2] & ((1U << m) - 1), m);
+        ms_encode(&ms, s[2] & ((1U<<m)-1), m);
         m = (rho[0] & 8) ? Uq0 - ((tuple0 & 8) >> 3) : 0;
-        ms_encode(&ms, s[3] & ((1U << m) - 1), m);
+        ms_encode(&ms, s[3] & ((1U<<m)-1), m);
 
-        if (x + 2 < width)
+        if (x+2 < width)
         {
           t = sp[0];
-          val = t + t; // multiply by 2 and get rid of sign
-          val >>= p;   // 2 \mu_p + x
-          val &= ~1u;  // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1u;// 2 \mu_p
           if (val)
           {
             rho[1] = 1;
-            e_q[4] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[4] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[1] = e_q[4];
-            s[4] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+            s[4] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
           }
 
           t = height > 1 ? sp[stride] : 0;
           ++sp;
-          val = t + t; // multiply by 2 and get rid of sign
-          val >>= p;   // 2 \mu_p + x
-          val &= ~1u;  // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1u;// 2 \mu_p
           if (val)
           {
             rho[1] += 2;
-            e_q[5] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[5] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[1] = ojph_max(e_qmax[1], e_q[5]);
-            s[5] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+            s[5] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
           }
 
-          if (x + 3 < width)
+          if (x+3 < width)
           {
             t = sp[0];
-            val = t + t; // multiply by 2 and get rid of sign
-            val >>= p;   // 2 \mu_p + x
-            val &= ~1u;  // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1u;// 2 \mu_p
             if (val)
             {
               rho[1] += 4;
-              e_q[6] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[6] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[1] = ojph_max(e_qmax[1], e_q[6]);
-              s[6] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+              s[6] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
             }
 
             t = height > 1 ? sp[stride] : 0;
             ++sp;
-            val = t + t; // multiply by 2 and get rid of sign
-            val >>= p;   // 2 \mu_p + x
-            val &= ~1u;  // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1u;// 2 \mu_p
             if (val)
             {
               rho[1] += 8;
-              e_q[7] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[7] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[1] = ojph_max(e_qmax[1], e_q[7]);
-              s[7] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+              s[7] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
             }
           }
 
           int c_q1 = (rho[0] >> 1) | (rho[0] & 1);
-          int Uq1 = ojph_max(e_qmax[1], 1); // kappa_q = 1
-          u_q1 = Uq1 - 1;                   // kappa_q = 1
+          int Uq1 = ojph_max(e_qmax[1], 1); //kappa_q = 1
+          u_q1 = Uq1 - 1; //kappa_q = 1
 
           int eps1 = 0;
           if (u_q1 > 0)
@@ -750,11 +740,9 @@ namespace ojph
             eps1 |= (e_q[6] == e_qmax[1]) << 2;
             eps1 |= (e_q[7] == e_qmax[1]) << 3;
           }
-          lep[0] = ojph_max(lep[0], (ui8)e_q[5]);
-          lep++;
+          lep[0] = ojph_max(lep[0], (ui8)e_q[5]); lep++;
           lep[0] = (ui8)e_q[7];
-          lcxp[0] |= (ui8)(lcxp[0] | (ui8)((rho[1] & 2) >> 1));
-          lcxp++;
+          lcxp[0] |= (ui8)(lcxp[0] | (ui8)((rho[1] & 2) >> 1)); lcxp++;
           lcxp[0] = (ui8)((rho[1] & 8) >> 3);
           ui16 tuple1 = vlc_tbl0[(c_q1 << 8) + (rho[1] << 4) + eps1];
           vlc_encode(&vlc, tuple1 >> 8, (tuple1 >> 4) & 7);
@@ -763,13 +751,13 @@ namespace ojph
             mel_encode(&mel, rho[1] != 0);
 
           int m = (rho[1] & 1) ? Uq1 - (tuple1 & 1) : 0;
-          ms_encode(&ms, s[4] & ((1U << m) - 1), m);
+          ms_encode(&ms, s[4] & ((1U<<m)-1), m);
           m = (rho[1] & 2) ? Uq1 - ((tuple1 & 2) >> 1) : 0;
-          ms_encode(&ms, s[5] & ((1U << m) - 1), m);
+          ms_encode(&ms, s[5] & ((1U<<m)-1), m);
           m = (rho[1] & 4) ? Uq1 - ((tuple1 & 4) >> 2) : 0;
-          ms_encode(&ms, s[6] & ((1U << m) - 1), m);
+          ms_encode(&ms, s[6] & ((1U<<m)-1), m);
           m = (rho[1] & 8) ? Uq1 - ((tuple1 & 8) >> 3) : 0;
-          ms_encode(&ms, s[7] & ((1U << m) - 1), m);
+          ms_encode(&ms, s[7] & ((1U<<m)-1), m);
         }
 
         if (u_q0 > 0 && u_q1 > 0)
@@ -777,10 +765,10 @@ namespace ojph
 
         if (u_q0 > 2 && u_q1 > 2)
         {
-          vlc_encode(&vlc, uvlc_tbl[u_q0 - 2].pre, uvlc_tbl[u_q0 - 2].pre_len);
-          vlc_encode(&vlc, uvlc_tbl[u_q1 - 2].pre, uvlc_tbl[u_q1 - 2].pre_len);
-          vlc_encode(&vlc, uvlc_tbl[u_q0 - 2].suf, uvlc_tbl[u_q0 - 2].suf_len);
-          vlc_encode(&vlc, uvlc_tbl[u_q1 - 2].suf, uvlc_tbl[u_q1 - 2].suf_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q0-2].pre, uvlc_tbl[u_q0-2].pre_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q1-2].pre, uvlc_tbl[u_q1-2].pre_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q0-2].suf, uvlc_tbl[u_q0-2].suf_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q1-2].suf, uvlc_tbl[u_q1-2].suf_len);
         }
         else if (u_q0 > 2 && u_q1 > 0)
         {
@@ -796,12 +784,11 @@ namespace ojph
           vlc_encode(&vlc, uvlc_tbl[u_q1].suf, uvlc_tbl[u_q1].suf_len);
         }
 
-        // prepare for next iteration
+        //prepare for next iteration
         c_q0 = (rho[1] >> 1) | (rho[1] & 1);
         s[0] = s[1] = s[2] = s[3] = s[4] = s[5] = s[6] = s[7] = 0;
-        e_q[0] = e_q[1] = e_q[2] = e_q[3] = e_q[4] = e_q[5] = e_q[6] = e_q[7] = 0;
-        rho[0] = rho[1] = 0;
-        e_qmax[0] = e_qmax[1] = 0;
+        e_q[0]=e_q[1]=e_q[2]=e_q[3]=e_q[4]=e_q[5]=e_q[6]=e_q[7]=0;
+        rho[0] = rho[1] = 0; e_qmax[0] = e_qmax[1] = 0;
       }
 
       lep[1] = 0;
@@ -818,61 +805,61 @@ namespace ojph
         sp = buf + y * stride;
         for (ui32 x = 0; x < width; x += 4)
         {
-          // prepare two quads
+          //prepare two quads
           t = sp[0];
-          val = t + t; // multiply by 2 and get rid of sign
-          val >>= p;   // 2 \mu_p + x
-          val &= ~1u;  // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1u;// 2 \mu_p
           if (val)
           {
             rho[0] = 1;
-            e_q[0] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[0] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[0] = e_q[0];
-            s[0] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+            s[0] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
           }
 
           t = y + 1 < height ? sp[stride] : 0;
           ++sp;
-          val = t + t; // multiply by 2 and get rid of sign
-          val >>= p;   // 2 \mu_p + x
-          val &= ~1u;  // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1u;// 2 \mu_p
           if (val)
           {
             rho[0] += 2;
-            e_q[1] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[1] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[0] = ojph_max(e_qmax[0], e_q[1]);
-            s[1] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+            s[1] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
           }
 
-          if (x + 1 < width)
+          if (x+1 < width)
           {
             t = sp[0];
-            val = t + t; // multiply by 2 and get rid of sign
-            val >>= p;   // 2 \mu_p + x
-            val &= ~1u;  // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1u;// 2 \mu_p
             if (val)
             {
               rho[0] += 4;
-              e_q[2] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[2] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[0] = ojph_max(e_qmax[0], e_q[2]);
-              s[2] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+              s[2] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
             }
 
             t = y + 1 < height ? sp[stride] : 0;
             ++sp;
-            val = t + t; // multiply by 2 and get rid of sign
-            val >>= p;   // 2 \mu_p + x
-            val &= ~1u;  // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1u;// 2 \mu_p
             if (val)
             {
               rho[0] += 8;
-              e_q[3] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[3] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[0] = ojph_max(e_qmax[0], e_q[3]);
-              s[3] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+              s[3] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
             }
           }
 
-          int kappa = (rho[0] & (rho[0] - 1)) ? ojph_max(1, max_e) : 1;
+          int kappa = (rho[0] & (rho[0]-1)) ? ojph_max(1,max_e) : 1;
           int Uq0 = ojph_max(e_qmax[0], kappa);
           int u_q0 = Uq0 - kappa, u_q1 = 0;
 
@@ -884,85 +871,83 @@ namespace ojph
             eps0 |= (e_q[2] == e_qmax[0]) << 2;
             eps0 |= (e_q[3] == e_qmax[0]) << 3;
           }
-          lep[0] = ojph_max(lep[0], (ui8)e_q[1]);
-          lep++;
+          lep[0] = ojph_max(lep[0], (ui8)e_q[1]); lep++;
           max_e = ojph_max(lep[0], lep[1]) - 1;
           lep[0] = (ui8)e_q[3];
-          lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1));
-          lcxp++;
+          lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1)); lcxp++;
           int c_q1 = lcxp[0] + (lcxp[1] << 2);
           lcxp[0] = (ui8)((rho[0] & 8) >> 3);
           ui16 tuple0 = vlc_tbl1[(c_q0 << 8) + (rho[0] << 4) + eps0];
           vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7);
 
           if (c_q0 == 0)
-            mel_encode(&mel, rho[0] != 0);
+              mel_encode(&mel, rho[0] != 0);
 
           int m = (rho[0] & 1) ? Uq0 - (tuple0 & 1) : 0;
-          ms_encode(&ms, s[0] & ((1U << m) - 1), m);
+          ms_encode(&ms, s[0] & ((1U<<m)-1), m);
           m = (rho[0] & 2) ? Uq0 - ((tuple0 & 2) >> 1) : 0;
-          ms_encode(&ms, s[1] & ((1U << m) - 1), m);
+          ms_encode(&ms, s[1] & ((1U<<m)-1), m);
           m = (rho[0] & 4) ? Uq0 - ((tuple0 & 4) >> 2) : 0;
-          ms_encode(&ms, s[2] & ((1U << m) - 1), m);
+          ms_encode(&ms, s[2] & ((1U<<m)-1), m);
           m = (rho[0] & 8) ? Uq0 - ((tuple0 & 8) >> 3) : 0;
-          ms_encode(&ms, s[3] & ((1U << m) - 1), m);
+          ms_encode(&ms, s[3] & ((1U<<m)-1), m);
 
-          if (x + 2 < width)
+          if (x+2 < width)
           {
             t = sp[0];
-            val = t + t; // multiply by 2 and get rid of sign
-            val >>= p;   // 2 \mu_p + x
-            val &= ~1u;  // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1u;// 2 \mu_p
             if (val)
             {
               rho[1] = 1;
-              e_q[4] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[4] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[1] = e_q[4];
-              s[4] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+              s[4] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
             }
 
             t = y + 1 < height ? sp[stride] : 0;
             ++sp;
-            val = t + t; // multiply by 2 and get rid of sign
-            val >>= p;   // 2 \mu_p + x
-            val &= ~1u;  // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1u;// 2 \mu_p
             if (val)
             {
               rho[1] += 2;
-              e_q[5] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[5] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[1] = ojph_max(e_qmax[1], e_q[5]);
-              s[5] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+              s[5] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
             }
 
-            if (x + 3 < width)
+            if (x+3 < width)
             {
               t = sp[0];
-              val = t + t; // multiply by 2 and get rid of sign
-              val >>= p;   // 2 \mu_p + x
-              val &= ~1u;  // 2 \mu_p
+              val = t + t; //multiply by 2 and get rid of sign
+              val >>= p; // 2 \mu_p + x
+              val &= ~1u;// 2 \mu_p
               if (val)
               {
                 rho[1] += 4;
-                e_q[6] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+                e_q[6] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
                 e_qmax[1] = ojph_max(e_qmax[1], e_q[6]);
-                s[6] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+                s[6] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
               }
 
               t = y + 1 < height ? sp[stride] : 0;
               ++sp;
-              val = t + t; // multiply by 2 and get rid of sign
-              val >>= p;   // 2 \mu_p + x
-              val &= ~1u;  // 2 \mu_p
+              val = t + t; //multiply by 2 and get rid of sign
+              val >>= p; // 2 \mu_p + x
+              val &= ~1u;// 2 \mu_p
               if (val)
               {
                 rho[1] += 8;
-                e_q[7] = 32 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+                e_q[7] = 32 - (int)count_leading_zeros(--val); //2\mu_p - 1
                 e_qmax[1] = ojph_max(e_qmax[1], e_q[7]);
-                s[7] = --val + (t >> 31); // v_n = 2(\mu_p-1) + s_n
+                s[7] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n
               }
             }
 
-            kappa = (rho[1] & (rho[1] - 1)) ? ojph_max(1, max_e) : 1;
+            kappa = (rho[1] & (rho[1]-1)) ? ojph_max(1,max_e) : 1;
             c_q1 |= ((rho[0] & 4) >> 1) | ((rho[0] & 8) >> 2);
             int Uq1 = ojph_max(e_qmax[1], kappa);
             u_q1 = Uq1 - kappa;
@@ -975,12 +960,10 @@ namespace ojph
               eps1 |= (e_q[6] == e_qmax[1]) << 2;
               eps1 |= (e_q[7] == e_qmax[1]) << 3;
             }
-            lep[0] = ojph_max(lep[0], (ui8)e_q[5]);
-            lep++;
+            lep[0] = ojph_max(lep[0], (ui8)e_q[5]); lep++;
             max_e = ojph_max(lep[0], lep[1]) - 1;
             lep[0] = (ui8)e_q[7];
-            lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[1] & 2) >> 1));
-            lcxp++;
+            lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[1] & 2) >> 1)); lcxp++;
             c_q0 = lcxp[0] + (lcxp[1] << 2);
             lcxp[0] = (ui8)((rho[1] & 8) >> 3);
             ui16 tuple1 = vlc_tbl1[(c_q1 << 8) + (rho[1] << 4) + eps1];
@@ -990,13 +973,13 @@ namespace ojph
               mel_encode(&mel, rho[1] != 0);
 
             int m = (rho[1] & 1) ? Uq1 - (tuple1 & 1) : 0;
-            ms_encode(&ms, s[4] & ((1U << m) - 1), m);
+            ms_encode(&ms, s[4] & ((1U<<m)-1), m);
             m = (rho[1] & 2) ? Uq1 - ((tuple1 & 2) >> 1) : 0;
-            ms_encode(&ms, s[5] & ((1U << m) - 1), m);
+            ms_encode(&ms, s[5] & ((1U<<m)-1), m);
             m = (rho[1] & 4) ? Uq1 - ((tuple1 & 4) >> 2) : 0;
-            ms_encode(&ms, s[6] & ((1U << m) - 1), m);
+            ms_encode(&ms, s[6] & ((1U<<m)-1), m);
             m = (rho[1] & 8) ? Uq1 - ((tuple1 & 8) >> 3) : 0;
-            ms_encode(&ms, s[7] & ((1U << m) - 1), m);
+            ms_encode(&ms, s[7] & ((1U<<m)-1), m);
           }
 
           vlc_encode(&vlc, uvlc_tbl[u_q0].pre, uvlc_tbl[u_q0].pre_len);
@@ -1004,19 +987,19 @@ namespace ojph
           vlc_encode(&vlc, uvlc_tbl[u_q0].suf, uvlc_tbl[u_q0].suf_len);
           vlc_encode(&vlc, uvlc_tbl[u_q1].suf, uvlc_tbl[u_q1].suf_len);
 
-          // prepare for next iteration
+          //prepare for next iteration
           c_q0 |= ((rho[1] & 4) >> 1) | ((rho[1] & 8) >> 2);
           s[0] = s[1] = s[2] = s[3] = s[4] = s[5] = s[6] = s[7] = 0;
-          e_q[0] = e_q[1] = e_q[2] = e_q[3] = e_q[4] = e_q[5] = e_q[6] = e_q[7] = 0;
-          rho[0] = rho[1] = 0;
-          e_qmax[0] = e_qmax[1] = 0;
+          e_q[0]=e_q[1]=e_q[2]=e_q[3]=e_q[4]=e_q[5]=e_q[6]=e_q[7]=0;
+          rho[0] = rho[1] = 0; e_qmax[0] = e_qmax[1] = 0;
         }
       }
+
 
       terminate_mel_vlc(&mel, &vlc);
       ms_terminate(&ms);
 
-      // copy to elastic
+      //copy to elastic
       lengths[0] = mel.pos + vlc.pos + ms.pos;
       elastic->get_buffer(mel.pos + vlc.pos + ms.pos, coded);
       memcpy(coded->buf, ms.buf, ms.pos);
@@ -1025,10 +1008,10 @@ namespace ojph
 
       // put in the interface locator word
       ui32 num_bytes = mel.pos + vlc.pos;
-      coded->buf[lengths[0] - 1] = (ui8)(num_bytes >> 4);
-      coded->buf[lengths[0] - 2] = coded->buf[lengths[0] - 2] & 0xF0;
-      coded->buf[lengths[0] - 2] =
-          (ui8)(coded->buf[lengths[0] - 2] | (num_bytes & 0xF));
+      coded->buf[lengths[0]-1] = (ui8)(num_bytes >> 4);
+      coded->buf[lengths[0]-2] = coded->buf[lengths[0]-2] & 0xF0;
+      coded->buf[lengths[0]-2] = 
+        (ui8)(coded->buf[lengths[0]-2] | (num_bytes & 0xF));
 
       coded->avail_size -= lengths[0];
     }
@@ -1040,30 +1023,30 @@ namespace ojph
     //
     //
     //////////////////////////////////////////////////////////////////////////
-    void ojph_encode_codeblock64(ui64 *buf, ui32 missing_msbs, ui32 num_passes,
+    void ojph_encode_codeblock64(ui64* buf, ui32 missing_msbs, ui32 num_passes,
                                  ui32 width, ui32 height, ui32 stride,
-                                 ui32 *lengths,
+                                 ui32* lengths,
                                  ojph::mem_elastic_allocator *elastic,
-                                 ojph::coded_lists *&coded)
+                                 ojph::coded_lists *& coded)
     {
       assert(num_passes == 1);
-      (void)num_passes; // currently not used
+      (void)num_passes;                      //currently not used
       // 38 bits/sample + 1 color + 4 wavelet = 43 bits per sample.
-      // * 4096 samples / 8 bits per byte = 22016; then rounded up to the
-      // nearest 1 kB, givin 22528.  This expanded further to take into
-      // consideration stuffing at a max rate of 16 bits per 15 bits
+      // * 4096 samples / 8 bits per byte = 22016; then rounded up to the 
+      // nearest 1 kB, givin 22528.  This expanded further to take into 
+      // consideration stuffing at a max rate of 16 bits per 15 bits 
       // (1 bit for every 15 bits of data); in reality, it is much smaller
       // than this.
-      const int ms_size = (22528 * 16 + 14) / 15; // more than enough
+      const int ms_size = (22528 * 16 + 14) / 15;  //more than enough
       ui8 ms_buf[ms_size];
       // For each quad, we need at most, 7 bits for VLC and 12 bits for UVLC.
-      // So we have 1024 quads * 19 / 8, which is 2432.  This must be
-      // multiplied by 16 / 15 to accommodate stuffing.
+      // So we have 1024 quads * 19 / 8, which is 2432.  This must be 
+      // multiplied by 16 / 15 to accommodate stuffing.  
       // The mel is at most around 1 bit/quad, giving around 128 byte -- in
-      // practice there was on case where it got to 132 bytes.  Even
+      // practice there was on case where it got to 132 bytes.  Even 
       // accounting for stuffing, it is smaller than 192.  Therefore,
       // 3072 is more than enough
-      const int mel_vlc_size = 3072; // more than enough
+      const int mel_vlc_size = 3072;         //more than enough
       ui8 mel_vlc_buf[mel_vlc_size];
       const int mel_size = 192;
       ui8 *mel_buf = mel_vlc_buf;
@@ -1079,87 +1062,85 @@ namespace ojph
 
       ui32 p = 62 - missing_msbs;
 
-      // e_val: E values for a line (these are the highest set bit)
-      // cx_val: is the context values
-      // Each byte stores the info for the 2 sample. For E, it is maximum
-      //  of the two samples, while for cx, it is the OR of these two samples.
-      // The maximum is between the pixel at the bottom left of one quad
-      //  and the bottom right of the earlier quad. The same is true for cx.
-      // For a 1024 pixels, we need 512 bytes, the 2 extra,
-      //  one for the non-existing earlier quad, and one for beyond the
-      //  the end
+      //e_val: E values for a line (these are the highest set bit)
+      //cx_val: is the context values
+      //Each byte stores the info for the 2 sample. For E, it is maximum
+      // of the two samples, while for cx, it is the OR of these two samples.
+      //The maximum is between the pixel at the bottom left of one quad
+      // and the bottom right of the earlier quad. The same is true for cx.
+      //For a 1024 pixels, we need 512 bytes, the 2 extra,
+      // one for the non-existing earlier quad, and one for beyond the
+      // the end
       ui8 e_val[513];
       ui8 cx_val[513];
-      ui8 *lep = e_val;
-      lep[0] = 0;
-      ui8 *lcxp = cx_val;
-      lcxp[0] = 0;
+      ui8* lep = e_val;     lep[0] = 0;
+      ui8* lcxp = cx_val;   lcxp[0] = 0;
 
-      // initial row of quads
-      int e_qmax[2] = {0, 0}, e_q[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-      int rho[2] = {0, 0};
+      //initial row of quads
+      int e_qmax[2] = {0,0}, e_q[8] = {0,0,0,0,0,0,0,0};
+      int rho[2] = {0,0};
       int c_q0 = 0;
-      ui64 s[8] = {0, 0, 0, 0, 0, 0, 0, 0}, val, t;
+      ui64 s[8] = {0,0,0,0,0,0,0,0}, val, t;
       ui32 y = 0;
       ui64 *sp = buf;
       for (ui32 x = 0; x < width; x += 4)
       {
-        // prepare two quads
+        //prepare two quads
         t = sp[0];
-        val = t + t;  // multiply by 2 and get rid of sign
-        val >>= p;    // 2 \mu_p + x
+        val = t + t; //multiply by 2 and get rid of sign
+        val >>= p;  // 2 \mu_p + x
         val &= ~1ULL; // 2 \mu_p
         if (val)
         {
           rho[0] = 1;
-          e_q[0] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+          e_q[0] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
           e_qmax[0] = e_q[0];
-          s[0] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+          s[0] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
         }
 
         t = height > 1 ? sp[stride] : 0;
         ++sp;
-        val = t + t;  // multiply by 2 and get rid of sign
-        val >>= p;    // 2 \mu_p + x
-        val &= ~1ULL; // 2 \mu_p
+        val = t + t; //multiply by 2 and get rid of sign
+        val >>= p; // 2 \mu_p + x
+        val &= ~1ULL;// 2 \mu_p
         if (val)
         {
           rho[0] += 2;
-          e_q[1] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+          e_q[1] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
           e_qmax[0] = ojph_max(e_qmax[0], e_q[1]);
-          s[1] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+          s[1] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
         }
 
         if (x + 1 < width)
         {
           t = sp[0];
-          val = t + t;  // multiply by 2 and get rid of sign
-          val >>= p;    // 2 \mu_p + x
-          val &= ~1ULL; // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1ULL;// 2 \mu_p
           if (val)
           {
             rho[0] += 4;
-            e_q[2] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[2] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[0] = ojph_max(e_qmax[0], e_q[2]);
-            s[2] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+            s[2] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
           }
 
           t = height > 1 ? sp[stride] : 0;
           ++sp;
-          val = t + t;  // multiply by 2 and get rid of sign
-          val >>= p;    // 2 \mu_p + x
-          val &= ~1ULL; // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1ULL;// 2 \mu_p
           if (val)
           {
             rho[0] += 8;
-            e_q[3] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[3] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[0] = ojph_max(e_qmax[0], e_q[3]);
-            s[3] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+            s[3] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
           }
         }
 
-        int Uq0 = ojph_max(e_qmax[0], 1); // kappa_q = 1
-        int u_q0 = Uq0 - 1, u_q1 = 0;     // kappa_q = 1
+        int Uq0 = ojph_max(e_qmax[0], 1); //kappa_q = 1
+        int u_q0 = Uq0 - 1, u_q1 = 0; //kappa_q = 1
 
         int eps0 = 0;
         if (u_q0 > 0)
@@ -1169,11 +1150,9 @@ namespace ojph
           eps0 |= (e_q[2] == e_qmax[0]) << 2;
           eps0 |= (e_q[3] == e_qmax[0]) << 3;
         }
-        lep[0] = ojph_max(lep[0], (ui8)e_q[1]);
-        lep++;
+        lep[0] = ojph_max(lep[0], (ui8)e_q[1]); lep++;
         lep[0] = (ui8)e_q[3];
-        lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1));
-        lcxp++;
+        lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1)); lcxp++;
         lcxp[0] = (ui8)((rho[0] & 8) >> 3);
 
         ui16 tuple0 = vlc_tbl0[(c_q0 << 8) + (rho[0] << 4) + eps0];
@@ -1194,61 +1173,61 @@ namespace ojph
         if (x + 2 < width)
         {
           t = sp[0];
-          val = t + t;  // multiply by 2 and get rid of sign
-          val >>= p;    // 2 \mu_p + x
-          val &= ~1ULL; // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1ULL;// 2 \mu_p
           if (val)
           {
             rho[1] = 1;
-            e_q[4] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[4] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[1] = e_q[4];
-            s[4] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+            s[4] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
           }
 
           t = height > 1 ? sp[stride] : 0;
           ++sp;
-          val = t + t;  // multiply by 2 and get rid of sign
-          val >>= p;    // 2 \mu_p + x
-          val &= ~1ULL; // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1ULL;// 2 \mu_p
           if (val)
           {
             rho[1] += 2;
-            e_q[5] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[5] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[1] = ojph_max(e_qmax[1], e_q[5]);
-            s[5] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+            s[5] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
           }
 
           if (x + 3 < width)
           {
             t = sp[0];
-            val = t + t;  // multiply by 2 and get rid of sign
-            val >>= p;    // 2 \mu_p + x
-            val &= ~1ULL; // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1ULL;// 2 \mu_p
             if (val)
             {
               rho[1] += 4;
-              e_q[6] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[6] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[1] = ojph_max(e_qmax[1], e_q[6]);
-              s[6] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+              s[6] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
             }
 
             t = height > 1 ? sp[stride] : 0;
             ++sp;
-            val = t + t;  // multiply by 2 and get rid of sign
-            val >>= p;    // 2 \mu_p + x
-            val &= ~1ULL; // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1ULL;// 2 \mu_p
             if (val)
             {
               rho[1] += 8;
-              e_q[7] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[7] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[1] = ojph_max(e_qmax[1], e_q[7]);
-              s[7] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+              s[7] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
             }
           }
 
           int c_q1 = (rho[0] >> 1) | (rho[0] & 1);
-          int Uq1 = ojph_max(e_qmax[1], 1); // kappa_q = 1
-          u_q1 = Uq1 - 1;                   // kappa_q = 1
+          int Uq1 = ojph_max(e_qmax[1], 1); //kappa_q = 1
+          u_q1 = Uq1 - 1; //kappa_q = 1
 
           int eps1 = 0;
           if (u_q1 > 0)
@@ -1258,11 +1237,9 @@ namespace ojph
             eps1 |= (e_q[6] == e_qmax[1]) << 2;
             eps1 |= (e_q[7] == e_qmax[1]) << 3;
           }
-          lep[0] = ojph_max(lep[0], (ui8)e_q[5]);
-          lep++;
+          lep[0] = ojph_max(lep[0], (ui8)e_q[5]); lep++;
           lep[0] = (ui8)e_q[7];
-          lcxp[0] |= (ui8)(lcxp[0] | (ui8)((rho[1] & 2) >> 1));
-          lcxp++;
+          lcxp[0] |= (ui8)(lcxp[0] | (ui8)((rho[1] & 2) >> 1)); lcxp++;
           lcxp[0] = (ui8)((rho[1] & 8) >> 3);
           ui16 tuple1 = vlc_tbl0[(c_q1 << 8) + (rho[1] << 4) + eps1];
           vlc_encode(&vlc, tuple1 >> 8, (tuple1 >> 4) & 7);
@@ -1285,12 +1262,12 @@ namespace ojph
 
         if (u_q0 > 2 && u_q1 > 2)
         {
-          vlc_encode(&vlc, uvlc_tbl[u_q0 - 2].pre, uvlc_tbl[u_q0 - 2].pre_len);
-          vlc_encode(&vlc, uvlc_tbl[u_q1 - 2].pre, uvlc_tbl[u_q1 - 2].pre_len);
-          vlc_encode(&vlc, uvlc_tbl[u_q0 - 2].suf, uvlc_tbl[u_q0 - 2].suf_len);
-          vlc_encode(&vlc, uvlc_tbl[u_q1 - 2].suf, uvlc_tbl[u_q1 - 2].suf_len);
-          vlc_encode(&vlc, uvlc_tbl[u_q0 - 2].ext, uvlc_tbl[u_q0 - 2].ext_len);
-          vlc_encode(&vlc, uvlc_tbl[u_q1 - 2].ext, uvlc_tbl[u_q1 - 2].ext_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q0-2].pre, uvlc_tbl[u_q0-2].pre_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q1-2].pre, uvlc_tbl[u_q1-2].pre_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q0-2].suf, uvlc_tbl[u_q0-2].suf_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q1-2].suf, uvlc_tbl[u_q1-2].suf_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q0-2].ext, uvlc_tbl[u_q0-2].ext_len);
+          vlc_encode(&vlc, uvlc_tbl[u_q1-2].ext, uvlc_tbl[u_q1-2].ext_len);
         }
         else if (u_q0 > 2 && u_q1 > 0)
         {
@@ -1309,12 +1286,11 @@ namespace ojph
           vlc_encode(&vlc, uvlc_tbl[u_q1].ext, uvlc_tbl[u_q1].ext_len);
         }
 
-        // prepare for next iteration
+        //prepare for next iteration
         c_q0 = (rho[1] >> 1) | (rho[1] & 1);
         s[0] = s[1] = s[2] = s[3] = s[4] = s[5] = s[6] = s[7] = 0;
-        e_q[0] = e_q[1] = e_q[2] = e_q[3] = e_q[4] = e_q[5] = e_q[6] = e_q[7] = 0;
-        rho[0] = rho[1] = 0;
-        e_qmax[0] = e_qmax[1] = 0;
+        e_q[0]=e_q[1]=e_q[2]=e_q[3]=e_q[4]=e_q[5]=e_q[6]=e_q[7]=0;
+        rho[0] = rho[1] = 0; e_qmax[0] = e_qmax[1] = 0;
       }
 
       lep[1] = 0;
@@ -1331,61 +1307,61 @@ namespace ojph
         sp = buf + y * stride;
         for (ui32 x = 0; x < width; x += 4)
         {
-          // prepare two quads
+          //prepare two quads
           t = sp[0];
-          val = t + t;  // multiply by 2 and get rid of sign
-          val >>= p;    // 2 \mu_p + x
-          val &= ~1ULL; // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1ULL;// 2 \mu_p
           if (val)
           {
             rho[0] = 1;
-            e_q[0] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[0] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[0] = e_q[0];
-            s[0] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+            s[0] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
           }
 
           t = y + 1 < height ? sp[stride] : 0;
           ++sp;
-          val = t + t;  // multiply by 2 and get rid of sign
-          val >>= p;    // 2 \mu_p + x
-          val &= ~1ULL; // 2 \mu_p
+          val = t + t; //multiply by 2 and get rid of sign
+          val >>= p; // 2 \mu_p + x
+          val &= ~1ULL;// 2 \mu_p
           if (val)
           {
             rho[0] += 2;
-            e_q[1] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+            e_q[1] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
             e_qmax[0] = ojph_max(e_qmax[0], e_q[1]);
-            s[1] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+            s[1] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
           }
 
           if (x + 1 < width)
           {
             t = sp[0];
-            val = t + t;  // multiply by 2 and get rid of sign
-            val >>= p;    // 2 \mu_p + x
-            val &= ~1ULL; // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1ULL;// 2 \mu_p
             if (val)
             {
               rho[0] += 4;
-              e_q[2] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[2] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[0] = ojph_max(e_qmax[0], e_q[2]);
-              s[2] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+              s[2] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
             }
 
             t = y + 1 < height ? sp[stride] : 0;
             ++sp;
-            val = t + t;  // multiply by 2 and get rid of sign
-            val >>= p;    // 2 \mu_p + x
-            val &= ~1ULL; // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1ULL;// 2 \mu_p
             if (val)
             {
               rho[0] += 8;
-              e_q[3] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[3] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[0] = ojph_max(e_qmax[0], e_q[3]);
-              s[3] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+              s[3] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
             }
           }
 
-          int kappa = (rho[0] & (rho[0] - 1)) ? ojph_max(1, max_e) : 1;
+          int kappa = (rho[0] & (rho[0]-1)) ? ojph_max(1,max_e) : 1;
           int Uq0 = ojph_max(e_qmax[0], kappa);
           int u_q0 = Uq0 - kappa, u_q1 = 0;
 
@@ -1397,19 +1373,17 @@ namespace ojph
             eps0 |= (e_q[2] == e_qmax[0]) << 2;
             eps0 |= (e_q[3] == e_qmax[0]) << 3;
           }
-          lep[0] = ojph_max(lep[0], (ui8)e_q[1]);
-          lep++;
+          lep[0] = ojph_max(lep[0], (ui8)e_q[1]); lep++;
           max_e = ojph_max(lep[0], lep[1]) - 1;
           lep[0] = (ui8)e_q[3];
-          lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1));
-          lcxp++;
+          lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1)); lcxp++;
           int c_q1 = lcxp[0] + (lcxp[1] << 2);
           lcxp[0] = (ui8)((rho[0] & 8) >> 3);
           ui16 tuple0 = vlc_tbl1[(c_q0 << 8) + (rho[0] << 4) + eps0];
           vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7);
 
           if (c_q0 == 0)
-            mel_encode(&mel, rho[0] != 0);
+              mel_encode(&mel, rho[0] != 0);
 
           int m = (rho[0] & 1) ? Uq0 - (tuple0 & 1) : 0;
           ms_encode64(&ms, s[0] & ((1ULL << m) - 1), m);
@@ -1423,59 +1397,59 @@ namespace ojph
           if (x + 2 < width)
           {
             t = sp[0];
-            val = t + t;  // multiply by 2 and get rid of sign
-            val >>= p;    // 2 \mu_p + x
-            val &= ~1ULL; // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1ULL;// 2 \mu_p
             if (val)
             {
               rho[1] = 1;
-              e_q[4] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[4] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[1] = e_q[4];
-              s[4] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+              s[4] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
             }
 
             t = y + 1 < height ? sp[stride] : 0;
             ++sp;
-            val = t + t;  // multiply by 2 and get rid of sign
-            val >>= p;    // 2 \mu_p + x
-            val &= ~1ULL; // 2 \mu_p
+            val = t + t; //multiply by 2 and get rid of sign
+            val >>= p; // 2 \mu_p + x
+            val &= ~1ULL;// 2 \mu_p
             if (val)
             {
               rho[1] += 2;
-              e_q[5] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+              e_q[5] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
               e_qmax[1] = ojph_max(e_qmax[1], e_q[5]);
-              s[5] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+              s[5] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
             }
 
             if (x + 3 < width)
             {
               t = sp[0];
-              val = t + t;  // multiply by 2 and get rid of sign
-              val >>= p;    // 2 \mu_p + x
-              val &= ~1ULL; // 2 \mu_p
+              val = t + t; //multiply by 2 and get rid of sign
+              val >>= p; // 2 \mu_p + x
+              val &= ~1ULL;// 2 \mu_p
               if (val)
               {
                 rho[1] += 4;
-                e_q[6] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+                e_q[6] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
                 e_qmax[1] = ojph_max(e_qmax[1], e_q[6]);
-                s[6] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+                s[6] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
               }
 
               t = y + 1 < height ? sp[stride] : 0;
               ++sp;
-              val = t + t;  // multiply by 2 and get rid of sign
-              val >>= p;    // 2 \mu_p + x
-              val &= ~1ULL; // 2 \mu_p
+              val = t + t; //multiply by 2 and get rid of sign
+              val >>= p; // 2 \mu_p + x
+              val &= ~1ULL;// 2 \mu_p
               if (val)
               {
                 rho[1] += 8;
-                e_q[7] = 64 - (int)count_leading_zeros(--val); // 2\mu_p - 1
+                e_q[7] = 64 - (int)count_leading_zeros(--val); //2\mu_p - 1
                 e_qmax[1] = ojph_max(e_qmax[1], e_q[7]);
-                s[7] = --val + (t >> 63); // v_n = 2(\mu_p-1) + s_n
+                s[7] = --val + (t >> 63); //v_n = 2(\mu_p-1) + s_n
               }
             }
 
-            kappa = (rho[1] & (rho[1] - 1)) ? ojph_max(1, max_e) : 1;
+            kappa = (rho[1] & (rho[1]-1)) ? ojph_max(1,max_e) : 1;
             c_q1 |= ((rho[0] & 4) >> 1) | ((rho[0] & 8) >> 2);
             int Uq1 = ojph_max(e_qmax[1], kappa);
             u_q1 = Uq1 - kappa;
@@ -1488,12 +1462,10 @@ namespace ojph
               eps1 |= (e_q[6] == e_qmax[1]) << 2;
               eps1 |= (e_q[7] == e_qmax[1]) << 3;
             }
-            lep[0] = ojph_max(lep[0], (ui8)e_q[5]);
-            lep++;
+            lep[0] = ojph_max(lep[0], (ui8)e_q[5]); lep++;
             max_e = ojph_max(lep[0], lep[1]) - 1;
             lep[0] = (ui8)e_q[7];
-            lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[1] & 2) >> 1));
-            lcxp++;
+            lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[1] & 2) >> 1)); lcxp++;
             c_q0 = lcxp[0] + (lcxp[1] << 2);
             lcxp[0] = (ui8)((rho[1] & 8) >> 3);
             ui16 tuple1 = vlc_tbl1[(c_q1 << 8) + (rho[1] << 4) + eps1];
@@ -1519,19 +1491,19 @@ namespace ojph
           vlc_encode(&vlc, uvlc_tbl[u_q0].ext, uvlc_tbl[u_q0].ext_len);
           vlc_encode(&vlc, uvlc_tbl[u_q1].ext, uvlc_tbl[u_q1].ext_len);
 
-          // prepare for next iteration
+          //prepare for next iteration
           c_q0 |= ((rho[1] & 4) >> 1) | ((rho[1] & 8) >> 2);
           s[0] = s[1] = s[2] = s[3] = s[4] = s[5] = s[6] = s[7] = 0;
-          e_q[0] = e_q[1] = e_q[2] = e_q[3] = e_q[4] = e_q[5] = e_q[6] = e_q[7] = 0;
-          rho[0] = rho[1] = 0;
-          e_qmax[0] = e_qmax[1] = 0;
+          e_q[0]=e_q[1]=e_q[2]=e_q[3]=e_q[4]=e_q[5]=e_q[6]=e_q[7]=0;
+          rho[0] = rho[1] = 0; e_qmax[0] = e_qmax[1] = 0;
         }
       }
+
 
       terminate_mel_vlc(&mel, &vlc);
       ms_terminate(&ms);
 
-      // copy to elastic
+      //copy to elastic
       lengths[0] = mel.pos + vlc.pos + ms.pos;
       elastic->get_buffer(mel.pos + vlc.pos + ms.pos, coded);
       memcpy(coded->buf, ms.buf, ms.pos);
@@ -1540,10 +1512,10 @@ namespace ojph
 
       // put in the interface locator word
       ui32 num_bytes = mel.pos + vlc.pos;
-      coded->buf[lengths[0] - 1] = (ui8)(num_bytes >> 4);
-      coded->buf[lengths[0] - 2] = coded->buf[lengths[0] - 2] & 0xF0;
-      coded->buf[lengths[0] - 2] =
-          (ui8)(coded->buf[lengths[0] - 2] | (num_bytes & 0xF));
+      coded->buf[lengths[0]-1] = (ui8)(num_bytes >> 4);
+      coded->buf[lengths[0]-2] = coded->buf[lengths[0]-2] & 0xF0;
+      coded->buf[lengths[0]-2] = 
+        (ui8)(coded->buf[lengths[0]-2] | (num_bytes & 0xF));
 
       coded->avail_size -= lengths[0];
     }

--- a/Native/Common/OpenJPH/coding/ojph_block_encoder.h
+++ b/Native/Common/OpenJPH/coding/ojph_block_encoder.h
@@ -35,50 +35,49 @@
 // Date: 17 September 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_BLOCK_ENCODER_H
 #define OJPH_BLOCK_ENCODER_H
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
   // defined elsewhere
   class mem_elastic_allocator;
   struct coded_lists;
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
     void
-    ojph_encode_codeblock32(ui32 *buf, ui32 missing_msbs, ui32 num_passes,
-                            ui32 width, ui32 height, ui32 stride,
-                            ui32 *lengths,
-                            ojph::mem_elastic_allocator *elastic,
-                            ojph::coded_lists *&coded);
+      ojph_encode_codeblock32(ui32* buf, ui32 missing_msbs, ui32 num_passes,
+                              ui32 width, ui32 height, ui32 stride,
+                              ui32* lengths, 
+                              ojph::mem_elastic_allocator *elastic,
+                              ojph::coded_lists *& coded);
 
     void
-    ojph_encode_codeblock64(ui64 *buf, ui32 missing_msbs, ui32 num_passes,
-                            ui32 width, ui32 height, ui32 stride,
-                            ui32 *lengths,
-                            ojph::mem_elastic_allocator *elastic,
-                            ojph::coded_lists *&coded);
+      ojph_encode_codeblock64(ui64* buf, ui32 missing_msbs, ui32 num_passes,
+                              ui32 width, ui32 height, ui32 stride,
+                              ui32* lengths, 
+                              ojph::mem_elastic_allocator *elastic,
+                              ojph::coded_lists *& coded);
 
     void
-    ojph_encode_codeblock_avx2(ui32 *buf, ui32 missing_msbs,
-                               ui32 num_passes, ui32 width, ui32 height,
-                               ui32 stride, ui32 *lengths,
-                               ojph::mem_elastic_allocator *elastic,
-                               ojph::coded_lists *&coded);
-
-    void
-    ojph_encode_codeblock_avx512(ui32 *buf, ui32 missing_msbs,
+      ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
                                  ui32 num_passes, ui32 width, ui32 height,
-                                 ui32 stride, ui32 *lengths,
-                                 ojph::mem_elastic_allocator *elastic,
-                                 ojph::coded_lists *&coded);
+                                 ui32 stride, ui32* lengths,
+                                 ojph::mem_elastic_allocator* elastic,
+                                 ojph::coded_lists*& coded);
+
+    void
+      ojph_encode_codeblock_avx512(ui32* buf, ui32 missing_msbs, 
+                                   ui32 num_passes, ui32 width, ui32 height, 
+                                   ui32 stride, ui32* lengths,
+                                   ojph::mem_elastic_allocator *elastic,
+                                   ojph::coded_lists *& coded);
 
     bool initialize_block_encoder_tables();
     bool initialize_block_encoder_tables_avx2();

--- a/Native/Common/OpenJPH/coding/ojph_block_encoder_avx2_apple.h
+++ b/Native/Common/OpenJPH/coding/ojph_block_encoder_avx2_apple.h
@@ -35,14 +35,6 @@
 // File: ojph_block_encoder_avx2.cpp
 //***************************************************************************/
 
-// Apple Clang on Intel produces corrupt bitstreams with several of the
-// scalar optimizations below (branchless VLC drain, 64-bit MagSgn, etc.)
-// for reasons not yet identified. Since this file is x86-only, the guard
-// does not affect Apple Silicon builds (which use NEON, not AVX2).
-#if defined(__apple_build_version__)
-#include "ojph_block_encoder_avx2_apple.h"
-#else
-
 #include "ojph_arch.h"
 #if defined(OJPH_ARCH_I386) || defined(OJPH_ARCH_X86_64)
 
@@ -81,8 +73,6 @@ namespace ojph {
     static ui32 vlc_tbl1[2048];
 
     //UVLC encoding
-    static ui32 uvlc_tbl_pair1[33 * 33];
-    static ui32 uvlc_tbl_pair2[33 * 33];
     static ui32 ulvc_cwd_pre[33];
     static int ulvc_cwd_pre_len[33];
     static ui32 ulvc_cwd_suf[33];
@@ -233,56 +223,6 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void uvlc_init_pair_tables()
-    {
-      for (int uq0 = 0; uq0 < 33; ++uq0) {
-        for (int uq1 = 0; uq1 < 33; ++uq1) {
-          ui32 cwd; int len;
-
-          cwd = 0; len = 0;
-          if (uq0 > 2 && uq1 > 2) {
-            cwd |= ulvc_cwd_pre[uq0 - 2];
-            len += ulvc_cwd_pre_len[uq0 - 2];
-            cwd |= ulvc_cwd_pre[uq1 - 2] << len;
-            len += ulvc_cwd_pre_len[uq1 - 2];
-            cwd |= ulvc_cwd_suf[uq0 - 2] << len;
-            len += ulvc_cwd_suf_len[uq0 - 2];
-            cwd |= ulvc_cwd_suf[uq1 - 2] << len;
-            len += ulvc_cwd_suf_len[uq1 - 2];
-          } else if (uq0 > 2 && uq1 > 0) {
-            cwd |= ulvc_cwd_pre[uq0];
-            len += ulvc_cwd_pre_len[uq0];
-            cwd |= (ui32)(uq1 - 1) << len;
-            len += 1;
-            cwd |= ulvc_cwd_suf[uq0] << len;
-            len += ulvc_cwd_suf_len[uq0];
-          } else {
-            cwd |= ulvc_cwd_pre[uq0];
-            len += ulvc_cwd_pre_len[uq0];
-            cwd |= ulvc_cwd_pre[uq1] << len;
-            len += ulvc_cwd_pre_len[uq1];
-            cwd |= ulvc_cwd_suf[uq0] << len;
-            len += ulvc_cwd_suf_len[uq0];
-            cwd |= ulvc_cwd_suf[uq1] << len;
-            len += ulvc_cwd_suf_len[uq1];
-          }
-          uvlc_tbl_pair1[uq0 * 33 + uq1] = (cwd << 5) | (ui32)len;
-
-          cwd = 0; len = 0;
-          cwd |= ulvc_cwd_pre[uq0];
-          len += ulvc_cwd_pre_len[uq0];
-          cwd |= ulvc_cwd_pre[uq1] << len;
-          len += ulvc_cwd_pre_len[uq1];
-          cwd |= ulvc_cwd_suf[uq0] << len;
-          len += ulvc_cwd_suf_len[uq0];
-          cwd |= ulvc_cwd_suf[uq1] << len;
-          len += ulvc_cwd_suf_len[uq1];
-          uvlc_tbl_pair2[uq0 * 33 + uq1] = (cwd << 5) | (ui32)len;
-        }
-      }
-    }
-
-    /////////////////////////////////////////////////////////////////////////
     bool initialize_block_encoder_tables_avx2() {
       static bool tables_initialized = false;
       static std::once_flag tables_initialized_flag;
@@ -291,7 +231,6 @@ namespace ojph {
         memset(vlc_tbl1, 0, 2048 * sizeof(ui32));
         tables_initialized = vlc_init_tables();
         tables_initialized = tables_initialized && uvlc_init_tables();
-        uvlc_init_pair_tables();
       });
       return tables_initialized;
     }
@@ -327,20 +266,16 @@ namespace ojph {
       melp->threshold = 1; // this is 1 << mel_exp[melp->k];
     }
 
-    static const int mel_exp[13] = {0,0,0,1,1,1,2,2,2,3,3,4,5};
-
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_emit_bits(mel_struct* melp, ui32 bits, int num_bits)
+    mel_emit_bit(mel_struct* melp, int v)
     {
-      melp->tmp = (melp->tmp << num_bits) | (int)bits;
-      melp->remaining_bits -= num_bits;
-      if (melp->remaining_bits <= 0) {
-        int excess = -melp->remaining_bits;
-        ui8 byte = (ui8)(melp->tmp >> excess);
-        melp->buf[melp->pos++] = byte;
-        melp->tmp &= (1 << excess) - 1;
-        melp->remaining_bits += 8 - (byte == 0xFF);
+      melp->tmp = (melp->tmp << 1) + v;
+      melp->remaining_bits--;
+      if (melp->remaining_bits == 0) {
+        melp->buf[melp->pos++] = (ui8)melp->tmp;
+        melp->remaining_bits = (melp->tmp == 0xFF ? 7 : 8);
+        melp->tmp = 0;
       }
     }
 
@@ -348,59 +283,33 @@ namespace ojph {
     static inline void
     mel_encode(mel_struct* melp, bool bit)
     {
+      //MEL exponent
+      static const int mel_exp[13] = {0,0,0,1,1,1,2,2,2,3,3,4,5};
+
       if (bit == false) {
         ++melp->run;
         if (melp->run >= melp->threshold) {
-          mel_emit_bits(melp, 1, 1);
+          mel_emit_bit(melp, 1);
           melp->run = 0;
           melp->k = ojph_min(12, melp->k + 1);
           melp->threshold = 1 << mel_exp[melp->k];
         }
       } else {
+        mel_emit_bit(melp, 0);
         int t = mel_exp[melp->k];
-        mel_emit_bits(melp, melp->run & ((1u << t) - 1), t + 1);
+        while (t > 0) {
+          mel_emit_bit(melp, (melp->run >> --t) & 1);
+        }
         melp->run = 0;
         melp->k = ojph_max(0, melp->k - 1);
         melp->threshold = 1 << mel_exp[melp->k];
       }
     }
 
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    mel_advance_run(mel_struct* melp, ui32 n)
-    {
-      ui32 remaining = n;
-      while (remaining > 0) {
-        ui32 space = (ui32)melp->threshold - (ui32)melp->run;
-        if (remaining >= space) {
-          remaining -= space;
-          mel_emit_bits(melp, 1, 1);
-          melp->run = 0;
-          melp->k = ojph_min(12, melp->k + 1);
-          melp->threshold = 1 << mel_exp[melp->k];
-        } else {
-          melp->run += (int)remaining;
-          remaining = 0;
-        }
-      }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    mel_encode_significance(mel_struct* melp)
-    {
-      int t = mel_exp[melp->k];
-      mel_emit_bits(melp, melp->run & ((1u << t) - 1), t + 1);
-      melp->run = 0;
-      melp->k = ojph_max(0, melp->k - 1);
-      melp->threshold = 1 << mel_exp[melp->k];
-    }
-
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-
-    struct vlc_struct {
+    struct vlc_struct_avx2 {
       //storage
       ui8* buf;      //pointer to data buffer
       ui32 pos;      //position of next writing within buf
@@ -413,7 +322,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_init(vlc_struct* vlcp, ui32 buffer_size, ui8* data)
+    vlc_init(vlc_struct_avx2* vlcp, ui32 buffer_size, ui8* data)
     {
       vlcp->buf = data + buffer_size - 1; //points to last byte
       vlcp->pos = 1;                      //locations will be all -pos
@@ -427,39 +336,39 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_drain(vlc_struct* vlcp)
+    vlc_encode(vlc_struct_avx2* vlcp, ui32 cwd, int cwd_len)
     {
+      vlcp->tmp |= (ui64)cwd << vlcp->used_bits;
+      vlcp->used_bits += cwd_len;
+
       while (vlcp->used_bits >= 8) {
-        int escape = (int)vlcp->last_greater_than_8F;
-        int is_7f = (int)((vlcp->tmp & 0x7F) == 0x7F);
-        int need_stuff = escape & is_7f;
-        int bits = 8 - need_stuff;
+          ui8 tmp;
 
-        ui8 byte = (ui8)(vlcp->tmp & ((1u << bits) - 1));
-        *(vlcp->buf - vlcp->pos) = byte;
-        vlcp->pos++;
-        vlcp->tmp >>= bits;
-        vlcp->used_bits -= bits;
-        vlcp->last_greater_than_8F = byte > 0x8F;
-      }
-    }
+          if (unlikely(vlcp->last_greater_than_8F)) {
+              tmp = vlcp->tmp & 0x7F;
 
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    vlc_encode(vlc_struct* vlcp, ui64 cwd, int cwd_len)
-    {
-      while (true) {
-        int avail = 64 - vlcp->used_bits;
-        if (likely(cwd_len <= avail)) {
-          vlcp->tmp |= cwd << vlcp->used_bits;
-          vlcp->used_bits += cwd_len;
-          return;
-        }
-        vlcp->tmp |= (cwd & ((1ULL << avail) - 1)) << vlcp->used_bits;
-        vlcp->used_bits = 64;
-        vlc_drain(vlcp);
-        cwd >>= avail;
-        cwd_len -= avail;
+              if (likely(tmp != 0x7F)) {
+                  tmp = vlcp->tmp & 0xFF;
+                  *(vlcp->buf - vlcp->pos) = tmp;
+                  vlcp->last_greater_than_8F = tmp > 0x8F;
+                  vlcp->tmp >>= 8;
+                  vlcp->used_bits -= 8;
+              } else {
+                  *(vlcp->buf - vlcp->pos) = tmp;
+                  vlcp->last_greater_than_8F = false;
+                  vlcp->tmp >>= 7;
+                  vlcp->used_bits -= 7;
+              }
+
+          } else {
+              tmp = vlcp->tmp & 0xFF;
+              *(vlcp->buf - vlcp->pos) = tmp;
+              vlcp->last_greater_than_8F = tmp > 0x8F;
+              vlcp->tmp >>= 8;
+              vlcp->used_bits -= 8;
+          }
+
+          vlcp->pos++;
       }
     }
 
@@ -467,10 +376,10 @@ namespace ojph {
     //
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    terminate_mel_vlc(mel_struct* melp, vlc_struct* vlcp)
+    terminate_mel_vlc(mel_struct* melp, vlc_struct_avx2* vlcp)
     {
       if (melp->run > 0)
-        mel_emit_bits(melp, 1, 1);
+        mel_emit_bit(melp, 1);
 
       if (vlcp->last_greater_than_8F && (vlcp->tmp & 0x7f) == 0x7f) {
         *(vlcp->buf - vlcp->pos) = 0x7f;
@@ -508,16 +417,15 @@ namespace ojph {
 /////////////////////////////////////////////////////////////////////////
 //
 /////////////////////////////////////////////////////////////////////////
-
     struct ms_struct {
       //storage
-      ui8* buf;        //pointer to data buffer
-      ui32 pos;        //position of next writing within buf
-      ui32 buf_size;   //size of buffer, which we must not exceed
+      ui8* buf;      //pointer to data buffer
+      ui32 pos;      //position of next writing within buf
+      ui32 buf_size; //size of buffer, which we must not exceed
 
-      int used_bits;   //number of occupied bits in tmp
-      ui64 tmp;        //temporary storage of coded bits (64-bit accumulator)
-      bool last_was_ff;//true if the last written byte was 0xFF
+      int max_bits;  //maximum number of bits that can be store in tmp
+      int used_bits; //number of occupied bits in tmp
+      ui32 tmp;      //temporary storage of coded bits
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -527,128 +435,51 @@ namespace ojph {
       msp->buf = data;
       msp->pos = 0;
       msp->buf_size = buffer_size;
+      msp->max_bits = 8;
       msp->used_bits = 0;
       msp->tmp = 0;
-      msp->last_was_ff = false;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    ms_drain(ms_struct* msp)
-    {
-      if (msp->last_was_ff) {
-        if (msp->used_bits < 7)
-          return;
-        msp->buf[msp->pos++] = (ui8)(msp->tmp & 0x7F);
-        msp->tmp >>= 7;
-        msp->used_bits -= 7;
-        msp->last_was_ff = false;
-      }
-
-      while (msp->used_bits >= 8) {
-        int n_bytes = msp->used_bits >> 3;
-        if (n_bytes > 8) n_bytes = 8;
-
-        ui64 word = msp->tmp;
-        ui64 valid_mask = (n_bytes < 8)
-                        ? (1ULL << (n_bytes * 8)) - 1 : ~(ui64)0;
-
-        ui64 w = ~word;
-        ui64 ff_detect = (w - 0x0101010101010101ULL) & ~w
-                       & 0x8080808080808080ULL;
-        ff_detect &= valid_mask;
-
-        if (likely(ff_detect == 0)) {
-          memcpy(msp->buf + msp->pos, &word, (size_t)n_bytes);
-          msp->pos += (ui32)n_bytes;
-          if (n_bytes < 8)
-            msp->tmp >>= (n_bytes * 8);
-          else
-            msp->tmp = 0;
-          msp->used_bits -= n_bytes * 8;
-        } else {
-          int ff_pos = (int)(count_trailing_zeros(ff_detect) >> 3);
-          int safe = ff_pos + 1;
-          memcpy(msp->buf + msp->pos, &word, (size_t)safe);
-          msp->pos += (ui32)safe;
-          int bits = safe * 8;
-          if (bits < 64)
-            msp->tmp >>= bits;
-          else
-            msp->tmp = 0;
-          msp->used_bits -= bits;
-
-          if (msp->used_bits >= 7) {
-            msp->buf[msp->pos++] = (ui8)(msp->tmp & 0x7F);
-            msp->tmp >>= 7;
-            msp->used_bits -= 7;
-            msp->last_was_ff = false;
-          } else {
-            msp->last_was_ff = true;
-            return;
-          }
-        }
-      }
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline void
-    ms_encode_nodefer(ms_struct* msp, ui64 cwd, int cwd_len)
-    {
-      while (true) {
-        int avail = 64 - msp->used_bits;
-        if (likely(cwd_len <= avail)) {
-          msp->tmp |= cwd << msp->used_bits;
-          msp->used_bits += cwd_len;
-          return;
-        }
-        msp->tmp |= (cwd & ((1ULL << avail) - 1)) << msp->used_bits;
-        msp->used_bits = 64;
-        ms_drain(msp);
-        cwd >>= avail;
-        cwd_len -= avail;
-      }
     }
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
     ms_encode(ms_struct* msp, ui64 cwd, int cwd_len)
     {
-      int avail = 64 - msp->used_bits;
-      if (likely(cwd_len <= avail)) {
-        msp->tmp |= cwd << msp->used_bits;
-        msp->used_bits += cwd_len;
-      } else {
-        msp->tmp |= (cwd & ((1ULL << avail) - 1)) << msp->used_bits;
-        msp->used_bits = 64;
-        ms_drain(msp);
-        cwd >>= avail;
-        cwd_len -= avail;
-        msp->tmp |= cwd << msp->used_bits;
-        msp->used_bits += cwd_len;
+      while (cwd_len > 0)
+      {
+        if (msp->pos >= msp->buf_size)
+          OJPH_ERROR(0x00020005, "magnitude sign encoder's buffer is full");
+        int t = ojph_min(msp->max_bits - msp->used_bits, cwd_len);
+        msp->tmp |= ((ui32)(cwd & ((1U << t) - 1))) << msp->used_bits;
+        msp->used_bits += t;
+        cwd >>= t;
+        cwd_len -= t;
+        if (msp->used_bits >= msp->max_bits)
+        {
+          msp->buf[msp->pos++] = (ui8)msp->tmp;
+          msp->max_bits = (msp->tmp == 0xFF) ? 7 : 8;
+          msp->tmp = 0;
+          msp->used_bits = 0;
+        }
       }
-      ms_drain(msp);
     }
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
     ms_terminate(ms_struct* msp)
     {
-      ms_drain(msp);
       if (msp->used_bits)
       {
-        int max_bits = msp->last_was_ff ? 7 : 8;
-        int t = max_bits - msp->used_bits;
-        ui32 byte = (ui32)(msp->tmp & ((1ULL << msp->used_bits) - 1));
-        byte |= (0xFFu & ((1u << t) - 1)) << msp->used_bits;
-        if (byte != 0xFF)
+        int t = msp->max_bits - msp->used_bits; //unused bits
+        msp->tmp |= (0xFF & ((1U << t) - 1)) << msp->used_bits;
+        msp->used_bits += t;
+        if (msp->tmp != 0xFF)
         {
           if (msp->pos >= msp->buf_size)
             OJPH_ERROR(0x00020006, "magnitude sign encoder's buffer is full");
-          msp->buf[msp->pos++] = (ui8)byte;
+          msp->buf[msp->pos++] = (ui8)msp->tmp;
         }
       }
-      else if (msp->last_was_ff)
+      else if (msp->max_bits == 7)
         msp->pos--;
     }
 
@@ -835,10 +666,23 @@ static void proc_ms_encode(ms_struct *msp,
     m_vec[3] = _mm256_and_si256(mask, tmp);
 
     rotate_matrix(m_vec);
+    /* s_vec from
+     * s_vec[0]:[0, 0], [0, 2] ... [0,14], [0, 16], [0, 18] ... [0,30]
+     * s_vec[1]:[1, 0], [1, 2] ... [1,14], [1, 16], [1, 18] ... [1,30]
+     * s_vec[2]:[0, 1], [0, 3] ... [0,15], [0, 17], [0, 19] ... [0,31]
+     * s_vec[3]:[1, 1], [1, 3] ... [1,15], [1, 17], [1, 19] ... [1,31]
+     * to
+     * s_vec[0]:[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]...[0, 7], [1, 7]
+     * s_vec[1]:[0, 8], [1, 8], [0, 9], [1, 9], [0,10], [1,10]...[0,15], [1,15]
+     * s_vec[2]:[0,16], [1,16], [0,17], [1,17], [0,18], [1,18]...[0,23], [1,23]
+     * s_vec[3]:[0,24], [1,24], [0,25], [1,25], [0,26], [1,26]...[0,31], [1,31]
+     */
     rotate_matrix(s_vec);
 
     ui32 cwd[8];
     int cwd_len[8];
+    ui64 _cwd = 0;
+    int _cwd_len = 0;
 
     /* Each iteration process 8 bytes * 2 lines */
     for (ui32 i = 0; i < 4; ++i) {
@@ -851,32 +695,15 @@ static void proc_ms_encode(ms_struct *msp,
         tmp = _mm256_and_si256(tmp, s_vec[i]);
         _mm256_storeu_si256((__m256i*)cwd, tmp);
 
-        for (ui32 j = 0; j < 4; j += 2) {
-            ui32 idx0 = j * 2;
-            ui64 _cwd     = cwd[idx0];
-            int  _cwd_len = cwd_len[idx0];
-            _cwd     |= ((ui64)cwd[idx0 + 1]) << _cwd_len;
-            _cwd_len += cwd_len[idx0 + 1];
-
-            ui32 idx1 = (j + 1) * 2;
-            int len1 = cwd_len[idx1] + cwd_len[idx1 + 1];
-            if (likely(_cwd_len + len1 <= 64)) {
-                _cwd     |= ((ui64)cwd[idx1]) << _cwd_len;
-                _cwd_len += cwd_len[idx1];
-                _cwd     |= ((ui64)cwd[idx1 + 1]) << _cwd_len;
-                _cwd_len += cwd_len[idx1 + 1];
-                ms_encode_nodefer(msp, _cwd, _cwd_len);
-            } else {
-                ms_encode_nodefer(msp, _cwd, _cwd_len);
-                _cwd     = cwd[idx1];
-                _cwd_len = cwd_len[idx1];
-                _cwd     |= ((ui64)cwd[idx1 + 1]) << _cwd_len;
-                _cwd_len += cwd_len[idx1 + 1];
-                ms_encode_nodefer(msp, _cwd, _cwd_len);
-            }
+        for (ui32 j = 0; j < 4; ++j) {
+            ui32 idx = j * 2;
+            _cwd     = cwd[idx];
+            _cwd_len = cwd_len[idx];
+            _cwd     |= ((ui64)cwd[idx + 1]) << _cwd_len;
+            _cwd_len += cwd_len[idx + 1];
+            ms_encode(msp, _cwd, _cwd_len);
         }
     }
-    ms_drain(msp);
 }
 
 static __m256i cal_eps_vec(__m256i *eq_vec, __m256i &u_q_vec,
@@ -980,7 +807,7 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
     auto tmp = _mm256_permutevar8x32_epi32(lcxp1_vec, right_shift);
 
 #ifdef OJPH_ARCH_X86_64
-    tmp = _mm256_insert_epi64(tmp,
+    tmp = _mm256_insert_epi64(tmp, 
       _mm_cvtsi128_si64(_mm256_castsi256_si128(cx_val_vec[x + 1])), 3);
 #elif (defined OJPH_ARCH_I386)
     int lsb = _mm_cvtsi128_si32(_mm256_castsi256_si128(cx_val_vec[x + 1]));
@@ -991,7 +818,7 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
     #error Error unsupport compiler
 #endif
     tmp = _mm256_slli_epi32(tmp, 2);
-    auto tmp1 = _mm256_insert_epi32(lcxp1_vec,
+    auto tmp1 = _mm256_insert_epi32(lcxp1_vec, 
       _mm_cvtsi128_si32(_mm256_castsi256_si128(cx_val_vec[x + 1])), 7);
     tmp = _mm256_add_epi32(tmp1, tmp);
 
@@ -1004,6 +831,8 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
 
     return _mm256_or_si256(tmp, tmp1);
 }
+
+using fn_proc_cq = __m256i (*)(ui32, __m256i *, __m256i &, const __m256i);
 
 static void proc_mel_encode1(mel_struct *melp, __m256i &cq_vec,
                              __m256i &rho_vec, __m256i u_q_vec, ui32 ignore,
@@ -1054,183 +883,133 @@ static void proc_mel_encode2(mel_struct *melp, __m256i &cq_vec,
 {
     ojph_unused(u_q_vec);
     ojph_unused(right_shift);
+    int32_t mel_need_encode[8];
+    int32_t mel_bit[8];
 
-    __m256i need = _mm256_cmpeq_epi32(cq_vec, ZERO);
-    ui32 mask = (ui32)_mm256_movemask_epi8(need);
-    mask &= 0x88888888;
+    /* Prepare mel_encode params */
+    /* if (c_q[i] == 0) { */
+    _mm256_storeu_si256((__m256i*)mel_need_encode, _mm256_cmpeq_epi32(cq_vec, ZERO));
+    /*   mel_encode(&mel, rho[i] != 0); */
+    _mm256_storeu_si256((__m256i*)mel_bit, _mm256_srli_epi32(avx2_cmpneq_epi32(rho_vec, ZERO), 31));
+    /* } */
 
     ui32 i_max = 8 - (ignore / 2);
-    if (i_max < 8)
-        mask &= (1u << (i_max * 4)) - 1;
 
-    if (mask == 0)
-        return;
-
-    int32_t mel_bit[8];
-    _mm256_storeu_si256((__m256i*)mel_bit,
-        _mm256_srli_epi32(avx2_cmpneq_epi32(rho_vec, ZERO), 31));
-
-    while (mask) {
-        ui32 bit_pos = (ui32)count_trailing_zeros(mask);
-        ui32 i = bit_pos / 4;
-        mel_encode(melp, mel_bit[i]);
-        mask &= mask - 1;
+    for (ui32 i = 0; i < i_max; ++i) {
+        if (mel_need_encode[i]) {
+            mel_encode(melp, mel_bit[i]);
+        }
     }
 }
 
 using fn_proc_mel_encode = void (*)(mel_struct *, __m256i &, __m256i &,
                                     __m256i, ui32, const __m256i);
 
-static inline void
-build_vlc_uvlc_pair(ui32 *tuple, ui32 *u_q, ui32 i,
-                    const ui32 *uvlc_tbl, ui64 &val, int &size)
-{
-    val = tuple[i + 0] >> 4;
-    size = tuple[i + 0] & 7;
-
-    val |= (ui64)(tuple[i + 1] >> 4) << size;
-    size += tuple[i + 1] & 7;
-
-    ui32 entry = uvlc_tbl[u_q[i] * 33 + u_q[i + 1]];
-    val |= (ui64)(entry >> 5) << size;
-    size += entry & 0x1F;
-}
-
-static void proc_vlc_encode(vlc_struct *vlcp, ui32 *tuple,
-                            ui32 *u_q, ui32 ignore, const ui32 *uvlc_tbl)
+static void proc_vlc_encode1(vlc_struct_avx2 *vlcp, ui32 *tuple,
+                             ui32 *u_q, ui32 ignore)
 {
     ui32 i_max = 8 - (ignore / 2);
 
-    ui32 i = 0;
-    for (; i + 2 < i_max; i += 4) {
-        ui64 val1; int size1;
-        build_vlc_uvlc_pair(tuple, u_q, i, uvlc_tbl, val1, size1);
-        ui64 val2; int size2;
-        build_vlc_uvlc_pair(tuple, u_q, i + 2, uvlc_tbl, val2, size2);
-        vlc_encode(vlcp, val1 | (val2 << size1), size1 + size2);
-    }
-    if (i < i_max) {
-        ui64 val; int size;
-        build_vlc_uvlc_pair(tuple, u_q, i, uvlc_tbl, val, size);
+    for (ui32 i = 0; i < i_max; i += 2) {
+        /* 7 bits */
+        ui32 val = tuple[i + 0] >> 4;
+        int size = tuple[i + 0] & 7;
+
+        if (i + 1 < i_max) {
+            /* 7 bits */
+            val |= (tuple[i + 1] >> 4) << size;
+            size += tuple[i + 1] & 7;
+        }
+
+        if (u_q[i] > 2 && u_q[i + 1] > 2) {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i] - 2]) << size;
+            size += ulvc_cwd_pre_len[u_q[i] - 2];
+
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i + 1] - 2]) << size;
+            size += ulvc_cwd_pre_len[u_q[i + 1] - 2];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i] - 2]) << size;
+            size += ulvc_cwd_suf_len[u_q[i] - 2];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i + 1] - 2]) << size;
+            size += ulvc_cwd_suf_len[u_q[i + 1] - 2];
+
+        } else if (u_q[i] > 2 && u_q[i + 1] > 0) {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i]];
+
+            /* 1 bit */
+            val |= (u_q[i + 1] - 1) << size;
+            size += 1;
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i]];
+
+        } else {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i]];
+
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i + 1]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i + 1]];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i]];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i + 1]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i + 1]];
+        }
+
         vlc_encode(vlcp, val, size);
     }
 }
 
-template<int PASS>
-OJPH_FORCE_INLINE void encode_x_loop(
-    ui32 *sp, ui32 stride, ui32 height, ui32 y,
-    ui32 n_loop, ui32 _width, ui32 ignore, ui32 p,
-    mel_struct &mel, vlc_struct &vlc, ms_struct &ms,
-    __m256i *e_val_vec, __m256i &prev_e_val_vec,
-    __m256i *cx_val_vec, __m256i &prev_cx_val_vec,
-    ui32 &prev_cq,
-    const __m256i &right_shift, const __m256i &left_shift)
+static void proc_vlc_encode2(vlc_struct_avx2 *vlcp, ui32 *tuple,
+                             ui32 *u_q, ui32 ignore)
 {
-    ui32 *vlc_tbl = (PASS == 1) ? vlc_tbl0 : vlc_tbl1;
+    ui32 i_max = 8 - (ignore / 2);
 
-    __m256i tmp, tmp1;
-    __m256i eq_vec[4];
-    __m256i s_vec[4];
-    __m256i src_vec[4];
+    for (ui32 i = 0; i < i_max; i += 2) {
+        /* 7 bits */
+        ui32 val = tuple[i + 0] >> 4;
+        int size = tuple[i + 0] & 7;
 
-    /* 16 bytes per iteration */
-    for (ui32 x = 0; x < n_loop; ++x) {
-
-        /* t = sp[i]; */
-        if ((x == (n_loop - 1)) && (_width % 16)) {
-            ui32 tmp_buf[16] = { 0 };
-            memcpy(tmp_buf, sp, (_width % 16) * sizeof(ui32));
-            src_vec[0] = _mm256_loadu_si256((__m256i*)(tmp_buf));
-            src_vec[2] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
-            if (y + 1 < height) {
-                memcpy(tmp_buf, sp + stride, (_width % 16) * sizeof(ui32));
-                src_vec[1] = _mm256_loadu_si256((__m256i*)(tmp_buf));
-                src_vec[3] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
-            }
-            else {
-                src_vec[1] = ZERO;
-                src_vec[3] = ZERO;
-            }
-        }
-        else {
-            src_vec[0] = _mm256_loadu_si256((__m256i*)(sp));
-            src_vec[2] = _mm256_loadu_si256((__m256i*)(sp + 8));
-
-            if (y + 1 < height) {
-                src_vec[1] = _mm256_loadu_si256((__m256i*)(sp + stride));
-                src_vec[3] = _mm256_loadu_si256((__m256i*)(sp + 8 + stride));
-            }
-            else {
-                src_vec[1] = ZERO;
-                src_vec[3] = ZERO;
-            }
-            sp += 16;
+        if (i + 1 < i_max) {
+            /* 7 bits */
+            val |= (tuple[i + 1] >> 4) << size;
+            size += tuple[i + 1] & 7;
         }
 
-        __m256i rho_vec, e_qmax_vec;
-        proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
+        /* 3 bits */
+        val |= ulvc_cwd_pre[u_q[i]] << size;
+        size += ulvc_cwd_pre_len[u_q[i]];
 
-        // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
-        tmp = _mm256_permutevar8x32_epi32(e_val_vec[x], right_shift);
-        tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(e_val_vec[x + 1])), 7);
+        /* 3 bits */
+        val |= (ulvc_cwd_pre[u_q[i + 1]]) << size;
+        size += ulvc_cwd_pre_len[u_q[i + 1]];
 
-        auto max_e_vec = _mm256_max_epi32(tmp, e_val_vec[x]);
-        max_e_vec = _mm256_sub_epi32(max_e_vec, ONE);
+        /* 5 bits */
+        val |= (ulvc_cwd_suf[u_q[i + 0]]) << size;
+        size += ulvc_cwd_suf_len[u_q[i + 0]];
 
-        // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
-        tmp = _mm256_max_epi32(max_e_vec, ONE);
-        tmp1 = _mm256_sub_epi32(rho_vec, ONE);
-        tmp1 = _mm256_and_si256(rho_vec, tmp1);
+        /* 5 bits */
+        val |= (ulvc_cwd_suf[u_q[i + 1]]) << size;
+        size += ulvc_cwd_suf_len[u_q[i + 1]];
 
-        auto cmp = _mm256_cmpeq_epi32(tmp1, ZERO);
-        auto kappa_vec1_ = _mm256_and_si256(cmp, ONE);
-        auto kappa_vec2_ = _mm256_and_si256(_mm256_xor_si256(cmp, _mm256_set1_epi32((int32_t)0xffffffff)), tmp);
-        const __m256i kappa_vec = _mm256_max_epi32(kappa_vec1_, kappa_vec2_);
-
-        if (PASS == 1)
-            tmp = proc_cq1(x, cx_val_vec, rho_vec, right_shift);
-        else
-            tmp = proc_cq2(x, cx_val_vec, rho_vec, right_shift);
-
-        auto cq_vec = _mm256_permutevar8x32_epi32(tmp, left_shift);
-        cq_vec = _mm256_insert_epi32(cq_vec, prev_cq, 0);
-        prev_cq = (ui32)_mm256_extract_epi32(tmp, 7);
-
-        update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
-        update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
-
-        /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
-        /* u_q[i] = Uq[i] - kappa[i]; */
-        auto uq_vec = _mm256_max_epi32(kappa_vec, e_qmax_vec);
-        auto u_q_vec = _mm256_sub_epi32(uq_vec, kappa_vec);
-
-        auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
-        __m256i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
-        ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
-
-        if (PASS == 1)
-            proc_mel_encode1(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
-                             right_shift);
-        else
-            proc_mel_encode2(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
-                             right_shift);
-
-        proc_ms_encode(&ms, tuple_vec, uq_vec, rho_vec, s_vec);
-
-        ui32 u_q[10];
-        ui32 tuple[10];
-        tuple_vec = _mm256_srli_epi32(tuple_vec, 4);
-        _mm256_storeu_si256((__m256i*)tuple, tuple_vec);
-        _mm256_storeu_si256((__m256i*)u_q, u_q_vec);
-        {
-            ui32 i_max = 8 - (_ignore / 2);
-            if (i_max & 1) { tuple[i_max] = 0; u_q[i_max] = 0; }
-            tuple[8] = 0; u_q[8] = 0;
-        }
-        proc_vlc_encode(&vlc, tuple, u_q, _ignore,
-            (PASS == 1) ? uvlc_tbl_pair1 : uvlc_tbl_pair2);
+        vlc_encode(vlcp, val, size);
     }
 }
+
+using fn_proc_vlc_encode = void (*)(vlc_struct_avx2 *, ui32 *, ui32 *, ui32);
 
 void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
                                 ui32 num_passes, ui32 _width, ui32 height,
@@ -1254,7 +1033,7 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
     mel_struct mel;
     mel_init(&mel, mel_size, mel_buf);
-    vlc_struct vlc;
+    vlc_struct_avx2 vlc;
     vlc_init(&vlc, vlc_size, vlc_buf);
     ms_struct ms;
     ms_init(&ms, ms_size, ms_buf);
@@ -1291,14 +1070,21 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
     ui32 prev_cq = 0;
 
-    __m256i tmp;
+    __m256i eq_vec[4];
+    __m256i s_vec[4];
+    __m256i src_vec[4];
+
+    ui32 *vlc_tbl = vlc_tbl0;
+    fn_proc_cq proc_cq = proc_cq1;
+    fn_proc_mel_encode proc_mel_encode = proc_mel_encode1;
+    fn_proc_vlc_encode proc_vlc_encode = proc_vlc_encode1;
 
     /* 2 lines per iteration */
     for (ui32 y = 0; y < height; y += 2)
     {
         e_val_vec[n_loop] = prev_e_val_vec;
         /* lcxp[0] = (ui8)((rho[0] & 8) >> 3); */
-        tmp = _mm256_and_si256(prev_cx_val_vec, _mm256_set1_epi32(8));
+        __m256i tmp = _mm256_and_si256(prev_cx_val_vec, _mm256_set1_epi32(8));
         cx_val_vec[n_loop] = _mm256_srli_epi32(tmp, 3);
 
         prev_e_val_vec = ZERO;
@@ -1306,27 +1092,119 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
         ui32 *sp = buf + y * stride;
 
-        if (y == 0)
-            encode_x_loop<1>(sp, stride, height, y, n_loop, _width,
-                             ignore, p, mel, vlc, ms,
-                             e_val_vec, prev_e_val_vec,
-                             cx_val_vec, prev_cx_val_vec, prev_cq,
-                             right_shift, left_shift);
-        else
-            encode_x_loop<2>(sp, stride, height, y, n_loop, _width,
-                             ignore, p, mel, vlc, ms,
-                             e_val_vec, prev_e_val_vec,
-                             cx_val_vec, prev_cx_val_vec, prev_cq,
-                             right_shift, left_shift);
+        /* 16 bytes per iteration */
+        for (ui32 x = 0; x < n_loop; ++x) {
+
+            /* t = sp[i]; */
+            if ((x == (n_loop - 1)) && (_width % 16)) {
+                ui32 tmp_buf[16] = { 0 };
+                memcpy(tmp_buf, sp, (_width % 16) * sizeof(ui32));
+                src_vec[0] = _mm256_loadu_si256((__m256i*)(tmp_buf));
+                src_vec[2] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
+                if (y + 1 < height) {
+                    memcpy(tmp_buf, sp + stride, (_width % 16) * sizeof(ui32));
+                    src_vec[1] = _mm256_loadu_si256((__m256i*)(tmp_buf));
+                    src_vec[3] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
+                }
+                else {
+                    src_vec[1] = ZERO;
+                    src_vec[3] = ZERO;
+                }
+            }
+            else {
+                src_vec[0] = _mm256_loadu_si256((__m256i*)(sp));
+                src_vec[2] = _mm256_loadu_si256((__m256i*)(sp + 8));
+
+                if (y + 1 < height) {
+                    src_vec[1] = _mm256_loadu_si256((__m256i*)(sp + stride));
+                    src_vec[3] = _mm256_loadu_si256((__m256i*)(sp + 8 + stride));
+                }
+                else {
+                    src_vec[1] = ZERO;
+                    src_vec[3] = ZERO;
+                }
+                sp += 16;
+            }
+
+            /* src_vec layout:
+             * src_vec[0]:[0, 0],[0, 1],[0, 2],[0, 3],[0, 4],[0, 5],.[0, 6],.[0, 7]
+             * src_vec[1]:[1, 0],[1, 1],[1, 2],[1, 3],[1, 4],[1, 5],.[1, 6],.[1, 7]
+             * src_vec[2]:[0, 8],[0, 9],[0,10],[0,11],[0,12],[0,13],.[0,14], [0,15]
+             * src_vec[3]:[1, 8],[1, 9],[1,10],[1,11],[1,12],[1,13],.[1,14], [1,15]
+             */
+            __m256i rho_vec, e_qmax_vec;
+            proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
+
+            // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
+            tmp = _mm256_permutevar8x32_epi32(e_val_vec[x], right_shift);
+            tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(e_val_vec[x + 1])), 7);
+
+            auto max_e_vec = _mm256_max_epi32(tmp, e_val_vec[x]);
+            max_e_vec = _mm256_sub_epi32(max_e_vec, ONE);
+
+            // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
+            tmp = _mm256_max_epi32(max_e_vec, ONE);
+            __m256i tmp1 = _mm256_sub_epi32(rho_vec, ONE);
+            tmp1 = _mm256_and_si256(rho_vec, tmp1);
+
+            auto cmp = _mm256_cmpeq_epi32(tmp1, ZERO);
+            auto kappa_vec1_ = _mm256_and_si256(cmp, ONE);
+            auto kappa_vec2_ = _mm256_and_si256(_mm256_xor_si256(cmp, _mm256_set1_epi32((int32_t)0xffffffff)), tmp);
+            const __m256i kappa_vec = _mm256_max_epi32(kappa_vec1_, kappa_vec2_);
+
+            /* cq[1 - 16] = cq_vec
+             * cq[0] = prev_cq_vec[0]
+             */
+            tmp = proc_cq(x, cx_val_vec, rho_vec, right_shift);
+
+            auto cq_vec = _mm256_permutevar8x32_epi32(tmp, left_shift);
+            cq_vec = _mm256_insert_epi32(cq_vec, prev_cq, 0);
+            prev_cq = (ui32)_mm256_extract_epi32(tmp, 7);
+
+            update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
+            update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
+
+            /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
+            /* u_q[i] = Uq[i] - kappa[i]; */
+            auto uq_vec = _mm256_max_epi32(kappa_vec, e_qmax_vec);
+            auto u_q_vec = _mm256_sub_epi32(uq_vec, kappa_vec);
+
+            auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
+            __m256i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
+            ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
+
+            proc_mel_encode(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
+                            right_shift);
+
+            proc_ms_encode(&ms, tuple_vec, uq_vec, rho_vec, s_vec);
+
+            // vlc_encode(&vlc, tuple[i*2+0] >> 8, (tuple[i*2+0] >> 4) & 7);
+            // vlc_encode(&vlc, tuple[i*2+1] >> 8, (tuple[i*2+1] >> 4) & 7);
+            ui32 u_q[8];
+            ui32 tuple[8];
+            /* The tuple is scaled by 4 due to:
+             * vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7, true);
+             * So in the vlc_encode, the tuple will only be scaled by 2.
+             */
+            tuple_vec = _mm256_srli_epi32(tuple_vec, 4);
+            _mm256_storeu_si256((__m256i*)tuple, tuple_vec);
+            _mm256_storeu_si256((__m256i*)u_q, u_q_vec);
+
+            proc_vlc_encode(&vlc, tuple, u_q, _ignore);
+        }
 
         tmp = _mm256_permutevar8x32_epi32(cx_val_vec[0], right_shift);
         tmp = _mm256_slli_epi32(tmp, 2);
         tmp = _mm256_add_epi32(tmp, cx_val_vec[0]);
         prev_cq = (ui32)_mm_cvtsi128_si32(_mm256_castsi256_si128(tmp));
+
+        proc_cq = proc_cq2;
+        vlc_tbl = vlc_tbl1;
+        proc_mel_encode = proc_mel_encode2;
+        proc_vlc_encode = proc_vlc_encode2;
     }
 
     ms_terminate(&ms);
-    vlc_drain(&vlc);
     terminate_mel_vlc(&mel, &vlc);
 
     //copy to elastic
@@ -1350,4 +1228,3 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 } /* namespace ojph */
 
 #endif
-#endif // !defined(__apple_build_version__)

--- a/Native/Common/OpenJPH/coding/ojph_block_encoder_avx512.cpp
+++ b/Native/Common/OpenJPH/coding/ojph_block_encoder_avx512.cpp
@@ -42,36 +42,35 @@
 #include <cstdint>
 #include <climits>
 #include <immintrin.h>
+#include <mutex>
 
 #include "ojph_mem.h"
 #include "ojph_block_encoder.h"
 #include "ojph_message.h"
 
 #ifdef OJPH_COMPILER_MSVC
-#define likely(x) (x)
-#define unlikely(x) (x)
+  #define likely(x)       (x)
+  #define unlikely(x)     (x)
 #else
-#define likely(x) __builtin_expect((x), 1)
-#define unlikely(x) __builtin_expect((x), 0)
+  #define likely(x)       __builtin_expect((x), 1)
+  #define unlikely(x)     __builtin_expect((x), 0)
 #endif
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     /////////////////////////////////////////////////////////////////////////
     // tables
     /////////////////////////////////////////////////////////////////////////
 
-    // VLC encoding
-    //  index is (c_q << 8) + (rho << 4) + eps
-    //  data is  (cwd << 8) + (cwd_len << 4) + eps
-    //  table 0 is for the initial line of quads
+    //VLC encoding
+    // index is (c_q << 8) + (rho << 4) + eps
+    // data is  (cwd << 8) + (cwd_len << 4) + eps
+    // table 0 is for the initial line of quads
     static ui32 vlc_tbl0[2048];
     static ui32 vlc_tbl1[2048];
 
-    // UVLC encoding
+    //UVLC encoding
     static ui32 ulvc_cwd_pre[33];
     static int ulvc_cwd_pre_len[33];
     static ui32 ulvc_cwd_suf[33];
@@ -80,12 +79,9 @@ namespace ojph
     /////////////////////////////////////////////////////////////////////////
     static bool vlc_init_tables()
     {
-      struct vlc_src_table
-      {
-        int c_q, rho, u_off, e_k, e_1, cwd, cwd_len;
-      };
+      struct vlc_src_table { int c_q, rho, u_off, e_k, e_1, cwd, cwd_len; };
       vlc_src_table tbl0[] = {
-#include "table0.h"
+    #include "table0.h"
       };
       size_t tbl0_size = sizeof(tbl0) / sizeof(vlc_src_table);
 
@@ -93,7 +89,7 @@ namespace ojph
       for (ui32 i = 0; i < 16; ++i)
         pattern_popcnt[i] = (si32)population_count(i);
 
-      vlc_src_table *src_tbl = tbl0;
+      vlc_src_table* src_tbl = tbl0;
       ui32 *tgt_tbl = vlc_tbl0;
       size_t tbl_size = tbl0_size;
       for (int i = 0; i < 2048; ++i)
@@ -113,8 +109,8 @@ namespace ojph
                 if (src_tbl[j].u_off == 1)
                   if ((emb & src_tbl[j].e_k) == src_tbl[j].e_1)
                   {
-                    // now we need to find the smallest cwd with the highest
-                    //  number of bits set in e_k
+                    //now we need to find the smallest cwd with the highest
+                    // number of bits set in e_k
                     int ones_count = pattern_popcnt[src_tbl[j].e_k];
                     if (ones_count >= best_e_k)
                     {
@@ -137,12 +133,13 @@ namespace ojph
             }
           }
           assert(best_entry);
-          tgt_tbl[i] = (ui16)((best_entry->cwd << 8) + (best_entry->cwd_len << 4) + best_entry->e_k);
+          tgt_tbl[i] = (ui16)((best_entry->cwd<<8) + (best_entry->cwd_len<<4)
+                             + best_entry->e_k);
         }
       }
 
       vlc_src_table tbl1[] = {
-#include "table1.h"
+    #include "table1.h"
       };
       size_t tbl1_size = sizeof(tbl1) / sizeof(vlc_src_table);
 
@@ -166,8 +163,8 @@ namespace ojph
                 if (src_tbl[j].u_off == 1)
                   if ((emb & src_tbl[j].e_k) == src_tbl[j].e_1)
                   {
-                    // now we need to find the smallest cwd with the highest
-                    //  number of bits set in e_k
+                    //now we need to find the smallest cwd with the highest
+                    // number of bits set in e_k
                     int ones_count = pattern_popcnt[src_tbl[j].e_k];
                     if (ones_count >= best_e_k)
                     {
@@ -190,9 +187,11 @@ namespace ojph
             }
           }
           assert(best_entry);
-          tgt_tbl[i] = (ui16)((best_entry->cwd << 8) + (best_entry->cwd_len << 4) + best_entry->e_k);
+          tgt_tbl[i] = (ui16)((best_entry->cwd<<8) + (best_entry->cwd_len<<4)
+                             + best_entry->e_k);
         }
       }
+
 
       return true;
     }
@@ -200,74 +199,60 @@ namespace ojph
     /////////////////////////////////////////////////////////////////////////
     static bool uvlc_init_tables()
     {
-      // code goes from 0 to 31, extension and 32 are not supported here
-      ulvc_cwd_pre[0] = 0;
-      ulvc_cwd_pre[1] = 1;
-      ulvc_cwd_pre[2] = 2;
-      ulvc_cwd_pre[3] = 4;
-      ulvc_cwd_pre[4] = 4;
-      ulvc_cwd_pre_len[0] = 0;
-      ulvc_cwd_pre_len[1] = 1;
+      //code goes from 0 to 31, extension and 32 are not supported here
+      ulvc_cwd_pre[0] = 0; ulvc_cwd_pre[1] = 1; ulvc_cwd_pre[2] = 2;
+      ulvc_cwd_pre[3] = 4; ulvc_cwd_pre[4] = 4;
+      ulvc_cwd_pre_len[0] = 0; ulvc_cwd_pre_len[1] = 1;
       ulvc_cwd_pre_len[2] = 2;
-      ulvc_cwd_pre_len[3] = 3;
-      ulvc_cwd_pre_len[4] = 3;
-      ulvc_cwd_suf[0] = 0;
-      ulvc_cwd_suf[1] = 0;
-      ulvc_cwd_suf[2] = 0;
-      ulvc_cwd_suf[3] = 0;
-      ulvc_cwd_suf[4] = 1;
-      ulvc_cwd_suf_len[0] = 0;
-      ulvc_cwd_suf_len[1] = 0;
+      ulvc_cwd_pre_len[3] = 3; ulvc_cwd_pre_len[4] = 3;
+      ulvc_cwd_suf[0] = 0; ulvc_cwd_suf[1] = 0; ulvc_cwd_suf[2] = 0;
+      ulvc_cwd_suf[3] = 0; ulvc_cwd_suf[4] = 1;
+      ulvc_cwd_suf_len[0] = 0; ulvc_cwd_suf_len[1] = 0;
       ulvc_cwd_suf_len[2] = 0;
-      ulvc_cwd_suf_len[3] = 1;
-      ulvc_cwd_suf_len[4] = 1;
+      ulvc_cwd_suf_len[3] = 1; ulvc_cwd_suf_len[4] = 1;
       for (int i = 5; i < 33; ++i)
       {
         ulvc_cwd_pre[i] = 0;
         ulvc_cwd_pre_len[i] = 3;
-        ulvc_cwd_suf[i] = (ui32)(i - 5);
+        ulvc_cwd_suf[i] = (ui32)(i-5);
         ulvc_cwd_suf_len[i] = 5;
       }
       return true;
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static bool tables_initialized = false;
-
-    /////////////////////////////////////////////////////////////////////////
-    bool initialize_block_encoder_tables_avx512()
-    {
-      if (!tables_initialized)
-      {
+    bool initialize_block_encoder_tables_avx512() {
+      static bool tables_initialized = false;
+      static std::once_flag tables_initialized_flag;
+      std::call_once(tables_initialized_flag, []() {
         memset(vlc_tbl0, 0, 2048 * sizeof(ui32));
         memset(vlc_tbl1, 0, 2048 * sizeof(ui32));
         tables_initialized = vlc_init_tables();
         tables_initialized = tables_initialized && uvlc_init_tables();
-      }
+      });
       return tables_initialized;
     }
 
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-    struct mel_struct
-    {
-      // storage
-      ui8 *buf;      // pointer to data buffer
-      ui32 pos;      // position of next writing within buf
-      ui32 buf_size; // size of buffer, which we must not exceed
+    struct mel_struct {
+      //storage
+      ui8* buf;      //pointer to data buffer
+      ui32 pos;      //position of next writing within buf
+      ui32 buf_size; //size of buffer, which we must not exceed
 
       // all these can be replaced by bytes
-      int remaining_bits; // number of empty bits in tmp
-      int tmp;            // temporary storage of coded bits
-      int run;            // number of 0 run
-      int k;              // state
-      int threshold;      // threshold where one bit must be coded
+      int remaining_bits; //number of empty bits in tmp
+      int tmp;            //temporary storage of coded bits
+      int run;            //number of 0 run
+      int k;              //state
+      int threshold;      //threshold where one bit must be coded
     };
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_init(mel_struct *melp, ui32 buffer_size, ui8 *data)
+    mel_init(mel_struct* melp, ui32 buffer_size, ui8* data)
     {
       melp->buf = data;
       melp->pos = 0;
@@ -281,12 +266,11 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_emit_bit(mel_struct *melp, int v)
+    mel_emit_bit(mel_struct* melp, int v)
     {
       melp->tmp = (melp->tmp << 1) + v;
       melp->remaining_bits--;
-      if (melp->remaining_bits == 0)
-      {
+      if (melp->remaining_bits == 0) {
         melp->buf[melp->pos++] = (ui8)melp->tmp;
         melp->remaining_bits = (melp->tmp == 0xFF ? 7 : 8);
         melp->tmp = 0;
@@ -295,28 +279,23 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_encode(mel_struct *melp, bool bit)
+    mel_encode(mel_struct* melp, bool bit)
     {
-      // MEL exponent
-      static const int mel_exp[13] = {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5};
+      //MEL exponent
+      static const int mel_exp[13] = {0,0,0,1,1,1,2,2,2,3,3,4,5};
 
-      if (bit == false)
-      {
+      if (bit == false) {
         ++melp->run;
-        if (melp->run >= melp->threshold)
-        {
+        if (melp->run >= melp->threshold) {
           mel_emit_bit(melp, 1);
           melp->run = 0;
           melp->k = ojph_min(12, melp->k + 1);
           melp->threshold = 1 << mel_exp[melp->k];
         }
-      }
-      else
-      {
+      } else {
         mel_emit_bit(melp, 0);
         int t = mel_exp[melp->k];
-        while (t > 0)
-        {
+        while (t > 0) {
           mel_emit_bit(melp, (melp->run >> --t) & 1);
         }
         melp->run = 0;
@@ -328,24 +307,23 @@ namespace ojph
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-    struct vlc_struct_avx512
-    {
-      // storage
-      ui8 *buf;      // pointer to data buffer
-      ui32 pos;      // position of next writing within buf
-      ui32 buf_size; // size of buffer, which we must not exceed
+    struct vlc_struct_avx512 {
+      //storage
+      ui8* buf;      //pointer to data buffer
+      ui32 pos;      //position of next writing within buf
+      ui32 buf_size; //size of buffer, which we must not exceed
 
-      int used_bits;             // number of occupied bits in tmp
-      ui64 tmp;                  // temporary storage of coded bits
-      bool last_greater_than_8F; // true if last byte us greater than 0x8F
+      int used_bits; //number of occupied bits in tmp
+      ui64 tmp;       //temporary storage of coded bits
+      bool last_greater_than_8F; //true if last byte us greater than 0x8F
     };
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_init(vlc_struct_avx512 *vlcp, ui32 buffer_size, ui8 *data)
+    vlc_init(vlc_struct_avx512* vlcp, ui32 buffer_size, ui8* data)
     {
-      vlcp->buf = data + buffer_size - 1; // points to last byte
-      vlcp->pos = 1;                      // locations will be all -pos
+      vlcp->buf = data + buffer_size - 1; //points to last byte
+      vlcp->pos = 1;                      //locations will be all -pos
       vlcp->buf_size = buffer_size;
 
       vlcp->buf[0] = 0xFF;
@@ -356,45 +334,39 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_encode(vlc_struct_avx512 *vlcp, ui32 cwd, int cwd_len)
+    vlc_encode(vlc_struct_avx512* vlcp, ui32 cwd, int cwd_len)
     {
       vlcp->tmp |= (ui64)cwd << vlcp->used_bits;
       vlcp->used_bits += cwd_len;
 
-      while (vlcp->used_bits >= 8)
-      {
-        ui8 tmp;
+      while (vlcp->used_bits >= 8) {
+          ui8 tmp;
 
-        if (unlikely(vlcp->last_greater_than_8F))
-        {
-          tmp = vlcp->tmp & 0x7F;
+          if (unlikely(vlcp->last_greater_than_8F)) {
+              tmp = vlcp->tmp & 0x7F;
 
-          if (likely(tmp != 0x7F))
-          {
-            tmp = vlcp->tmp & 0xFF;
-            *(vlcp->buf - vlcp->pos) = tmp;
-            vlcp->last_greater_than_8F = tmp > 0x8F;
-            vlcp->tmp >>= 8;
-            vlcp->used_bits -= 8;
+              if (likely(tmp != 0x7F)) {
+                  tmp = vlcp->tmp & 0xFF;
+                  *(vlcp->buf - vlcp->pos) = tmp;
+                  vlcp->last_greater_than_8F = tmp > 0x8F;
+                  vlcp->tmp >>= 8;
+                  vlcp->used_bits -= 8;
+              } else {
+                  *(vlcp->buf - vlcp->pos) = tmp;
+                  vlcp->last_greater_than_8F = false;
+                  vlcp->tmp >>= 7;
+                  vlcp->used_bits -= 7;
+              }
+
+          } else {
+              tmp = vlcp->tmp & 0xFF;
+              *(vlcp->buf - vlcp->pos) = tmp;
+              vlcp->last_greater_than_8F = tmp > 0x8F;
+              vlcp->tmp >>= 8;
+              vlcp->used_bits -= 8;
           }
-          else
-          {
-            *(vlcp->buf - vlcp->pos) = tmp;
-            vlcp->last_greater_than_8F = false;
-            vlcp->tmp >>= 7;
-            vlcp->used_bits -= 7;
-          }
-        }
-        else
-        {
-          tmp = vlcp->tmp & 0xFF;
-          *(vlcp->buf - vlcp->pos) = tmp;
-          vlcp->last_greater_than_8F = tmp > 0x8F;
-          vlcp->tmp >>= 8;
-          vlcp->used_bits -= 8;
-        }
 
-        vlcp->pos++;
+          vlcp->pos++;
       }
     }
 
@@ -402,13 +374,12 @@ namespace ojph
     //
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    terminate_mel_vlc(mel_struct *melp, vlc_struct_avx512 *vlcp)
+    terminate_mel_vlc(mel_struct* melp, vlc_struct_avx512* vlcp)
     {
       if (melp->run > 0)
         mel_emit_bit(melp, 1);
 
-      if (vlcp->last_greater_than_8F && (vlcp->tmp & 0x7f) == 0x7f)
-      {
+      if (vlcp->last_greater_than_8F && (vlcp->tmp & 0x7f) == 0x7f) {
         *(vlcp->buf - vlcp->pos) = 0x7f;
         vlcp->pos++;
         vlcp->tmp >>= 7;
@@ -419,13 +390,15 @@ namespace ojph
       int mel_mask = (0xFF << melp->remaining_bits) & 0xFF;
       int vlc_mask = 0xFF >> (8 - vlcp->used_bits);
       if ((mel_mask | vlc_mask) == 0)
-        return; // last mel byte cannot be 0xFF, since then
-                // melp->remaining_bits would be < 8
+        return;  //last mel byte cannot be 0xFF, since then
+                 //melp->remaining_bits would be < 8
       if (melp->pos >= melp->buf_size)
         OJPH_ERROR(0x00020003, "mel encoder's buffer is full");
       ui8 vlcp_tmp = (ui8)vlcp->tmp;
       int fuse = melp->tmp | vlcp_tmp;
-      if ((((fuse ^ melp->tmp) & mel_mask) | ((fuse ^ vlcp_tmp) & vlc_mask)) == 0 && (fuse != 0xFF) && vlcp->pos > 1)
+      if ( ( ((fuse ^ melp->tmp) & mel_mask)
+           | ((fuse ^ vlcp_tmp) & vlc_mask) ) == 0
+          && (fuse != 0xFF) && vlcp->pos > 1)
       {
         melp->buf[melp->pos++] = (ui8)fuse;
       }
@@ -433,30 +406,29 @@ namespace ojph
       {
         if (vlcp->pos >= vlcp->buf_size)
           OJPH_ERROR(0x00020004, "vlc encoder's buffer is full");
-        melp->buf[melp->pos++] = (ui8)melp->tmp; // melp->tmp cannot be 0xFF
+        melp->buf[melp->pos++] = (ui8)melp->tmp; //melp->tmp cannot be 0xFF
         *(vlcp->buf - vlcp->pos) = (ui8)vlcp_tmp;
         vlcp->pos++;
       }
     }
 
-    /////////////////////////////////////////////////////////////////////////
-    //
-    /////////////////////////////////////////////////////////////////////////
-    struct ms_struct
-    {
-      // storage
-      ui8 *buf;      // pointer to data buffer
-      ui32 pos;      // position of next writing within buf
-      ui32 buf_size; // size of buffer, which we must not exceed
+/////////////////////////////////////////////////////////////////////////
+//
+/////////////////////////////////////////////////////////////////////////
+    struct ms_struct {
+      //storage
+      ui8* buf;      //pointer to data buffer
+      ui32 pos;      //position of next writing within buf
+      ui32 buf_size; //size of buffer, which we must not exceed
 
-      int max_bits;  // maximum number of bits that can be store in tmp
-      int used_bits; // number of occupied bits in tmp
-      ui32 tmp;      // temporary storage of coded bits
+      int max_bits;  //maximum number of bits that can be store in tmp
+      int used_bits; //number of occupied bits in tmp
+      ui32 tmp;      //temporary storage of coded bits
     };
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    ms_init(ms_struct *msp, ui32 buffer_size, ui8 *data)
+    ms_init(ms_struct* msp, ui32 buffer_size, ui8* data)
     {
       msp->buf = data;
       msp->pos = 0;
@@ -468,7 +440,7 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    ms_encode(ms_struct *msp, ui64 cwd, int cwd_len)
+    ms_encode(ms_struct* msp, ui64 cwd, int cwd_len)
     {
       while (cwd_len > 0)
       {
@@ -491,11 +463,11 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    ms_terminate(ms_struct *msp)
+    ms_terminate(ms_struct* msp)
     {
       if (msp->used_bits)
       {
-        int t = msp->max_bits - msp->used_bits; // unused bits
+        int t = msp->max_bits - msp->used_bits; //unused bits
         msp->tmp |= (0xFF & ((1U << t) - 1)) << msp->used_bits;
         msp->used_bits += t;
         if (msp->tmp != 0xFF)
@@ -510,7 +482,7 @@ namespace ojph
     }
 
 #define ZERO _mm512_setzero_epi32()
-#define ONE _mm512_set1_epi32(1)
+#define ONE  _mm512_set1_epi32(1)
 
 #if 0
 static void print_epi32(const char *msg, __m512i &val)
@@ -527,18 +499,17 @@ static void print_epi32(const char *msg, __m512i &val)
 }
 #endif
 
-    static void proc_pixel(__m512i *src_vec, ui32 p,
-                           __m512i *eq_vec, __m512i *s_vec,
-                           __m512i &rho_vec, __m512i &e_qmax_vec)
-    {
-      __m512i val_vec[4];
-      __m512i _eq_vec[4];
-      __m512i _s_vec[4];
-      __m512i _rho_vec[4];
-      ui16 val_mask[4];
+static void proc_pixel(__m512i *src_vec, ui32 p,
+                       __m512i *eq_vec, __m512i *s_vec,
+                       __m512i &rho_vec, __m512i &e_qmax_vec)
+{
+    __m512i val_vec[4];
+    __m512i _eq_vec[4];
+    __m512i _s_vec[4];
+    __m512i _rho_vec[4];
+    ui16 val_mask[4];
 
-      for (ui32 i = 0; i < 4; ++i)
-      {
+    for (ui32 i = 0; i < 4; ++i) {
         /* val = t + t; //multiply by 2 and get rid of sign */
         val_vec[i] = _mm512_add_epi32(src_vec[i], src_vec[i]);
 
@@ -569,34 +540,33 @@ static void print_epi32(const char *msg, __m512i &val)
         val_vec[i] = _mm512_mask_sub_epi32(ZERO, val_mask[i], val_vec[i], ONE);
         _s_vec[i] = _mm512_mask_srli_epi32(ZERO, val_mask[i], src_vec[i], 31);
         _s_vec[i] =
-            _mm512_mask_add_epi32(ZERO, val_mask[i], _s_vec[i], val_vec[i]);
+          _mm512_mask_add_epi32(ZERO, val_mask[i], _s_vec[i], val_vec[i]);
         /* } */
-      }
+    }
 
-      val_vec[0] = _mm512_mask_mov_epi32(ZERO, val_mask[0], ONE);
-      val_vec[1] = _mm512_mask_mov_epi32(ZERO, val_mask[1], ONE);
-      val_vec[2] = _mm512_mask_mov_epi32(ZERO, val_mask[2], ONE);
-      val_vec[3] = _mm512_mask_mov_epi32(ZERO, val_mask[3], ONE);
-      e_qmax_vec = ZERO;
+    val_vec[0] = _mm512_mask_mov_epi32(ZERO, val_mask[0], ONE);
+    val_vec[1] = _mm512_mask_mov_epi32(ZERO, val_mask[1], ONE);
+    val_vec[2] = _mm512_mask_mov_epi32(ZERO, val_mask[2], ONE);
+    val_vec[3] = _mm512_mask_mov_epi32(ZERO, val_mask[3], ONE);
+    e_qmax_vec = ZERO;
 
-      const __m512i idx[2] = {
-          _mm512_set_epi32(14, 12, 10, 8, 6, 4, 2, 0, 14, 12, 10, 8, 6, 4, 2, 0),
-          _mm512_set_epi32(15, 13, 11, 9, 7, 5, 3, 1, 15, 13, 11, 9, 7, 5, 3, 1),
-      };
+    const __m512i idx[2] = {
+        _mm512_set_epi32(14, 12, 10, 8, 6, 4, 2, 0, 14, 12, 10, 8, 6, 4, 2, 0),
+        _mm512_set_epi32(15, 13, 11, 9, 7, 5, 3, 1, 15, 13, 11, 9, 7, 5, 3, 1),
+    };
 
-      /* Reorder from
-       * *_vec[0]:[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5]...[0,14], [0,15]
-       * *_vec[1]:[1, 0], [1, 1], [1, 2], [1, 3], [1, 4], [1, 5]...[1,14], [1,15]
-       * *_vec[2]:[0,16], [0,17], [0,18], [0,19], [0,20], [0,21]...[0,30], [0,31]
-       * *_vec[3]:[1,16], [1,17], [1,18], [1,19], [1,20], [1,21]...[1,30], [1,31]
-       * to
-       * *_vec[0]:[0, 0], [0, 2] ... [0,14], [0,16], [0,18] ... [0,30]
-       * *_vec[1]:[1, 0], [1, 2] ... [1,14], [1,16], [1,18] ... [1,30]
-       * *_vec[2]:[0, 1], [0, 3] ... [0,15], [0,17], [0,19] ... [0,31]
-       * *_vec[3]:[1, 1], [1, 3] ... [1,15], [1,17], [1,19] ... [1,31]
-       */
-      for (ui32 i = 0; i < 4; ++i)
-      {
+    /* Reorder from
+     * *_vec[0]:[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5]...[0,14], [0,15]
+     * *_vec[1]:[1, 0], [1, 1], [1, 2], [1, 3], [1, 4], [1, 5]...[1,14], [1,15]
+     * *_vec[2]:[0,16], [0,17], [0,18], [0,19], [0,20], [0,21]...[0,30], [0,31]
+     * *_vec[3]:[1,16], [1,17], [1,18], [1,19], [1,20], [1,21]...[1,30], [1,31]
+     * to
+     * *_vec[0]:[0, 0], [0, 2] ... [0,14], [0,16], [0,18] ... [0,30]
+     * *_vec[1]:[1, 0], [1, 2] ... [1,14], [1,16], [1,18] ... [1,30]
+     * *_vec[2]:[0, 1], [0, 3] ... [0,15], [0,17], [0,19] ... [0,31]
+     * *_vec[3]:[1, 1], [1, 3] ... [1,15], [1,17], [1,19] ... [1,31]
+     */
+    for (ui32 i = 0; i < 4; ++i) {
         ui32 e_idx = i >> 1;
         ui32 o_idx = i & 0x1;
 
@@ -617,416 +587,401 @@ static void print_epi32(const char *msg, __m512i &val)
         _rho_vec[i] = _mm512_slli_epi32(_rho_vec[i], i);
 
         e_qmax_vec = _mm512_max_epi32(e_qmax_vec, eq_vec[i]);
-      }
-
-      rho_vec = _mm512_or_epi32(_rho_vec[0], _rho_vec[1]);
-      rho_vec = _mm512_or_epi32(rho_vec, _rho_vec[2]);
-      rho_vec = _mm512_or_epi32(rho_vec, _rho_vec[3]);
     }
 
-    /* from [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, ...]
-     *      [0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, ...]
-     *      [0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, ...]
-     *      [0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, ...]
-     *
-     * to   [0x00, 0x10, 0x20, 0x30, 0x01, 0x11, 0x21, 0x31,
-     *       0x02, 0x12, 0x22, 0x32, 0x03, 0x13, 0x23, 0x33]
-     *
-     *      [0x04, 0x14, 0x24, 0x34, 0x05, 0x15, 0x25, 0x35,
-     *       0x06, 0x16, 0x26, 0x36, 0x07, 0x17, 0x27, 0x37]
-     *
-     *      [..]
+    rho_vec = _mm512_or_epi32(_rho_vec[0], _rho_vec[1]);
+    rho_vec = _mm512_or_epi32(rho_vec, _rho_vec[2]);
+    rho_vec = _mm512_or_epi32(rho_vec, _rho_vec[3]);
+}
+
+/* from [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, ...]
+ *      [0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, ...]
+ *      [0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, ...]
+ *      [0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, ...]
+ *
+ * to   [0x00, 0x10, 0x20, 0x30, 0x01, 0x11, 0x21, 0x31,
+ *       0x02, 0x12, 0x22, 0x32, 0x03, 0x13, 0x23, 0x33]
+ *
+ *      [0x04, 0x14, 0x24, 0x34, 0x05, 0x15, 0x25, 0x35,
+ *       0x06, 0x16, 0x26, 0x36, 0x07, 0x17, 0x27, 0x37]
+ *
+ *      [..]
+ */
+static void rotate_matrix(__m512i *matrix)
+{
+    __m512i _matrix[4];
+    _matrix[0] = _mm512_unpacklo_epi32(matrix[0], matrix[1]);
+    _matrix[1] = _mm512_unpackhi_epi32(matrix[0], matrix[1]);
+    _matrix[2] = _mm512_unpacklo_epi32(matrix[2], matrix[3]);
+    _matrix[3] = _mm512_unpackhi_epi32(matrix[2], matrix[3]);
+
+    matrix[0] = _mm512_unpacklo_epi64(_matrix[0], _matrix[2]);
+    matrix[1] = _mm512_unpackhi_epi64(_matrix[0], _matrix[2]);
+    matrix[2] = _mm512_unpacklo_epi64(_matrix[1], _matrix[3]);
+    matrix[3] = _mm512_unpackhi_epi64(_matrix[1], _matrix[3]);
+
+    _matrix[0] = _mm512_shuffle_i32x4(matrix[0], matrix[1], 0x88);
+    _matrix[1] = _mm512_shuffle_i32x4(matrix[2], matrix[3], 0x88);
+    _matrix[2] = _mm512_shuffle_i32x4(matrix[0], matrix[1], 0xDD);
+    _matrix[3] = _mm512_shuffle_i32x4(matrix[2], matrix[3], 0xDD);
+
+    matrix[0] = _mm512_shuffle_i32x4(_matrix[0], _matrix[1], 0x88);
+    matrix[1] = _mm512_shuffle_i32x4(_matrix[2], _matrix[3], 0x88);
+    matrix[2] = _mm512_shuffle_i32x4(_matrix[0], _matrix[1], 0xDD);
+    matrix[3] = _mm512_shuffle_i32x4(_matrix[2], _matrix[3], 0xDD);
+}
+
+static void proc_ms_encode(ms_struct *msp,
+                           __m512i &tuple_vec,
+                           __m512i &uq_vec,
+                           __m512i &rho_vec,
+                           __m512i *s_vec)
+{
+    __m512i m_vec[4];
+
+    /* Prepare parameters for ms_encode */
+    /* m = (rho[i] & 1) ? Uq[i] - ((tuple[i] & 1) >> 0) : 0; */
+    auto tmp = _mm512_and_epi32(tuple_vec, ONE);
+    tmp = _mm512_sub_epi32(uq_vec, tmp);
+    auto tmp1 = _mm512_and_epi32(rho_vec, ONE);
+    auto mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
+    m_vec[0] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
+
+    /* m = (rho[i] & 2) ? Uq[i] - ((tuple[i] & 2) >> 1) : 0; */
+    tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(2));
+    tmp = _mm512_srli_epi32(tmp, 1);
+    tmp = _mm512_sub_epi32(uq_vec, tmp);
+    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(2));
+    mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
+    m_vec[1] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
+
+    /* m = (rho[i] & 4) ? Uq[i] - ((tuple[i] & 4) >> 2) : 0; */
+    tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(4));
+    tmp = _mm512_srli_epi32(tmp, 2);
+    tmp = _mm512_sub_epi32(uq_vec, tmp);
+    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(4));
+    mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
+    m_vec[2] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
+
+    /* m = (rho[i] & 8) ? Uq[i] - ((tuple[i] & 8) >> 3) : 0; */
+    tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(8));
+    tmp = _mm512_srli_epi32(tmp, 3);
+    tmp = _mm512_sub_epi32(uq_vec, tmp);
+    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(8));
+    mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
+    m_vec[3] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
+
+    rotate_matrix(m_vec);
+    /* s_vec from
+     * s_vec[0]:[0, 0], [0, 2] ... [0,14], [0, 16], [0, 18] ... [0,30]
+     * s_vec[1]:[1, 0], [1, 2] ... [1,14], [1, 16], [1, 18] ... [1,30]
+     * s_vec[2]:[0, 1], [0, 3] ... [0,15], [0, 17], [0, 19] ... [0,31]
+     * s_vec[3]:[1, 1], [1, 3] ... [1,15], [1, 17], [1, 19] ... [1,31]
+     * to
+     * s_vec[0]:[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]...[0, 7], [1, 7]
+     * s_vec[1]:[0, 8], [1, 8], [0, 9], [1, 9], [0,10], [1,10]...[0,15], [1,15]
+     * s_vec[2]:[0,16], [1,16], [0,17], [1,17], [0,18], [1,18]...[0,23], [1,23]
+     * s_vec[3]:[0,24], [1,24], [0,25], [1,25], [0,26], [1,26]...[0,31], [1,31]
      */
-    static void rotate_matrix(__m512i *matrix)
-    {
-      __m512i _matrix[4];
-      _matrix[0] = _mm512_unpacklo_epi32(matrix[0], matrix[1]);
-      _matrix[1] = _mm512_unpackhi_epi32(matrix[0], matrix[1]);
-      _matrix[2] = _mm512_unpacklo_epi32(matrix[2], matrix[3]);
-      _matrix[3] = _mm512_unpackhi_epi32(matrix[2], matrix[3]);
+    rotate_matrix(s_vec);
 
-      matrix[0] = _mm512_unpacklo_epi64(_matrix[0], _matrix[2]);
-      matrix[1] = _mm512_unpackhi_epi64(_matrix[0], _matrix[2]);
-      matrix[2] = _mm512_unpacklo_epi64(_matrix[1], _matrix[3]);
-      matrix[3] = _mm512_unpackhi_epi64(_matrix[1], _matrix[3]);
+    ui32 cwd[16];
+    int cwd_len[16];
+    ui64 _cwd = 0;
+    int _cwd_len = 0;
 
-      _matrix[0] = _mm512_shuffle_i32x4(matrix[0], matrix[1], 0x88);
-      _matrix[1] = _mm512_shuffle_i32x4(matrix[2], matrix[3], 0x88);
-      _matrix[2] = _mm512_shuffle_i32x4(matrix[0], matrix[1], 0xDD);
-      _matrix[3] = _mm512_shuffle_i32x4(matrix[2], matrix[3], 0xDD);
-
-      matrix[0] = _mm512_shuffle_i32x4(_matrix[0], _matrix[1], 0x88);
-      matrix[1] = _mm512_shuffle_i32x4(_matrix[2], _matrix[3], 0x88);
-      matrix[2] = _mm512_shuffle_i32x4(_matrix[0], _matrix[1], 0xDD);
-      matrix[3] = _mm512_shuffle_i32x4(_matrix[2], _matrix[3], 0xDD);
-    }
-
-    static void proc_ms_encode(ms_struct *msp,
-                               __m512i &tuple_vec,
-                               __m512i &uq_vec,
-                               __m512i &rho_vec,
-                               __m512i *s_vec)
-    {
-      __m512i m_vec[4];
-
-      /* Prepare parameters for ms_encode */
-      /* m = (rho[i] & 1) ? Uq[i] - ((tuple[i] & 1) >> 0) : 0; */
-      auto tmp = _mm512_and_epi32(tuple_vec, ONE);
-      tmp = _mm512_sub_epi32(uq_vec, tmp);
-      auto tmp1 = _mm512_and_epi32(rho_vec, ONE);
-      auto mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-      m_vec[0] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
-
-      /* m = (rho[i] & 2) ? Uq[i] - ((tuple[i] & 2) >> 1) : 0; */
-      tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(2));
-      tmp = _mm512_srli_epi32(tmp, 1);
-      tmp = _mm512_sub_epi32(uq_vec, tmp);
-      tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(2));
-      mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-      m_vec[1] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
-
-      /* m = (rho[i] & 4) ? Uq[i] - ((tuple[i] & 4) >> 2) : 0; */
-      tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(4));
-      tmp = _mm512_srli_epi32(tmp, 2);
-      tmp = _mm512_sub_epi32(uq_vec, tmp);
-      tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(4));
-      mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-      m_vec[2] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
-
-      /* m = (rho[i] & 8) ? Uq[i] - ((tuple[i] & 8) >> 3) : 0; */
-      tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(8));
-      tmp = _mm512_srli_epi32(tmp, 3);
-      tmp = _mm512_sub_epi32(uq_vec, tmp);
-      tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(8));
-      mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-      m_vec[3] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
-
-      rotate_matrix(m_vec);
-      /* s_vec from
-       * s_vec[0]:[0, 0], [0, 2] ... [0,14], [0, 16], [0, 18] ... [0,30]
-       * s_vec[1]:[1, 0], [1, 2] ... [1,14], [1, 16], [1, 18] ... [1,30]
-       * s_vec[2]:[0, 1], [0, 3] ... [0,15], [0, 17], [0, 19] ... [0,31]
-       * s_vec[3]:[1, 1], [1, 3] ... [1,15], [1, 17], [1, 19] ... [1,31]
-       * to
-       * s_vec[0]:[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]...[0, 7], [1, 7]
-       * s_vec[1]:[0, 8], [1, 8], [0, 9], [1, 9], [0,10], [1,10]...[0,15], [1,15]
-       * s_vec[2]:[0,16], [1,16], [0,17], [1,17], [0,18], [1,18]...[0,23], [1,23]
-       * s_vec[3]:[0,24], [1,24], [0,25], [1,25], [0,26], [1,26]...[0,31], [1,31]
-       */
-      rotate_matrix(s_vec);
-
-      ui32 cwd[16];
-      int cwd_len[16];
-      ui64 _cwd = 0;
-      int _cwd_len = 0;
-
-      /* Each iteration process 8 bytes * 2 lines */
-      for (ui32 i = 0; i < 4; ++i)
-      {
+    /* Each iteration process 8 bytes * 2 lines */
+    for (ui32 i = 0; i < 4; ++i) {
         /* cwd = s[i * 4 + 0] & ((1U << m) - 1)
          * cwd_len = m
          */
-        _mm512_store_epi32(cwd_len, m_vec[i]);
+        _mm512_storeu_si512(cwd_len, m_vec[i]);
         tmp = _mm512_sllv_epi32(ONE, m_vec[i]);
         tmp = _mm512_sub_epi32(tmp, ONE);
         tmp = _mm512_and_epi32(tmp, s_vec[i]);
-        _mm512_store_epi32(cwd, tmp);
+        _mm512_storeu_si512(cwd, tmp);
 
-        for (ui32 j = 0; j < 8; ++j)
-        {
-          ui32 idx = j * 2;
-          _cwd = cwd[idx];
-          _cwd_len = cwd_len[idx];
-          _cwd |= ((ui64)cwd[idx + 1]) << _cwd_len;
-          _cwd_len += cwd_len[idx + 1];
-          ms_encode(msp, _cwd, _cwd_len);
+        for (ui32 j = 0; j < 8; ++j) {
+            ui32 idx = j * 2;
+            _cwd     = cwd[idx];
+            _cwd_len = cwd_len[idx];
+            _cwd     |= ((ui64)cwd[idx + 1]) << _cwd_len;
+            _cwd_len += cwd_len[idx + 1];
+            ms_encode(msp, _cwd, _cwd_len);
         }
-      }
     }
+}
 
-    static __m512i cal_eps_vec(__m512i *eq_vec, __m512i &u_q_vec,
-                               __m512i &e_qmax_vec)
-    {
-      /* if (u_q[i] > 0) {
-       *     eps[i] |= (e_q[i * 4 + 0] == e_qmax[i]);
-       *     eps[i] |= (e_q[i * 4 + 1] == e_qmax[i]) << 1;
-       *     eps[i] |= (e_q[i * 4 + 2] == e_qmax[i]) << 2;
-       *     eps[i] |= (e_q[i * 4 + 3] == e_qmax[i]) << 3;
-       * }
-       */
-      auto u_q_mask = _mm512_cmpgt_epi32_mask(u_q_vec, ZERO);
+static __m512i cal_eps_vec(__m512i *eq_vec, __m512i &u_q_vec,
+                           __m512i &e_qmax_vec)
+{
+    /* if (u_q[i] > 0) {
+     *     eps[i] |= (e_q[i * 4 + 0] == e_qmax[i]);
+     *     eps[i] |= (e_q[i * 4 + 1] == e_qmax[i]) << 1;
+     *     eps[i] |= (e_q[i * 4 + 2] == e_qmax[i]) << 2;
+     *     eps[i] |= (e_q[i * 4 + 3] == e_qmax[i]) << 3;
+     * }
+     */
+    auto u_q_mask = _mm512_cmpgt_epi32_mask(u_q_vec, ZERO);
 
-      auto mask = _mm512_cmpeq_epi32_mask(eq_vec[0], e_qmax_vec);
-      auto tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
-      auto eps_vec = _mm512_mask_mov_epi32(ZERO, u_q_mask, tmp);
+    auto mask = _mm512_cmpeq_epi32_mask(eq_vec[0], e_qmax_vec);
+    auto tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
+    auto eps_vec = _mm512_mask_mov_epi32(ZERO, u_q_mask, tmp);
 
-      mask = _mm512_cmpeq_epi32_mask(eq_vec[1], e_qmax_vec);
-      tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
-      tmp = _mm512_slli_epi32(tmp, 1);
-      eps_vec = _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
+    mask = _mm512_cmpeq_epi32_mask(eq_vec[1], e_qmax_vec);
+    tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
+    tmp = _mm512_slli_epi32(tmp, 1);
+    eps_vec = _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
 
-      mask = _mm512_cmpeq_epi32_mask(eq_vec[2], e_qmax_vec);
-      tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
-      tmp = _mm512_slli_epi32(tmp, 2);
-      eps_vec = _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
+    mask = _mm512_cmpeq_epi32_mask(eq_vec[2], e_qmax_vec);
+    tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
+    tmp = _mm512_slli_epi32(tmp, 2);
+    eps_vec = _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
 
-      mask = _mm512_cmpeq_epi32_mask(eq_vec[3], e_qmax_vec);
-      tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
-      tmp = _mm512_slli_epi32(tmp, 3);
+    mask = _mm512_cmpeq_epi32_mask(eq_vec[3], e_qmax_vec);
+    tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
+    tmp = _mm512_slli_epi32(tmp, 3);
 
-      return _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
-    }
+    return  _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
+}
 
-    static void update_lep(ui32 x, __m512i &prev_e_val_vec,
-                           __m512i *eq_vec, __m512i *e_val_vec,
-                           const __m512i left_shift)
-    {
-      /* lep[0] = ojph_max(lep[0], (ui8)e_q[1]); lep++;
-       * lep[0] = (ui8)e_q[3];
-       * Compare e_q[1] with e_q[3] of the prevous round.
-       */
-      auto tmp = _mm512_mask_permutexvar_epi32(prev_e_val_vec, 0xFFFE,
-                                               left_shift, eq_vec[3]);
-      prev_e_val_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
-                                                     eq_vec[3]);
-      e_val_vec[x] = _mm512_max_epi32(eq_vec[1], tmp);
-    }
+static void update_lep(ui32 x, __m512i &prev_e_val_vec,
+                       __m512i *eq_vec, __m512i *e_val_vec,
+                       const __m512i left_shift)
+{
+    /* lep[0] = ojph_max(lep[0], (ui8)e_q[1]); lep++;
+     * lep[0] = (ui8)e_q[3];
+     * Compare e_q[1] with e_q[3] of the prevous round.
+     */
+    auto tmp = _mm512_mask_permutexvar_epi32(prev_e_val_vec, 0xFFFE,
+                                             left_shift, eq_vec[3]);
+    prev_e_val_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
+                                                   eq_vec[3]);
+    e_val_vec[x] = _mm512_max_epi32(eq_vec[1], tmp);
+}
 
-    static void update_lcxp(ui32 x, __m512i &prev_cx_val_vec,
-                            __m512i &rho_vec, __m512i *cx_val_vec,
-                            const __m512i left_shift)
-    {
-      /* lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1)); lcxp++;
-       * lcxp[0] = (ui8)((rho[0] & 8) >> 3);
-       * Or (rho[0] & 2) and (rho[0] of the previous round & 8).
-       */
-      auto tmp = _mm512_mask_permutexvar_epi32(prev_cx_val_vec, 0xFFFE,
-                                               left_shift, rho_vec);
-      prev_cx_val_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
-                                                      rho_vec);
 
-      tmp = _mm512_and_epi32(tmp, _mm512_set1_epi32(8));
-      tmp = _mm512_srli_epi32(tmp, 3);
+static void update_lcxp(ui32 x, __m512i &prev_cx_val_vec,
+                        __m512i &rho_vec, __m512i *cx_val_vec,
+                        const __m512i left_shift)
+{
+    /* lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1)); lcxp++;
+     * lcxp[0] = (ui8)((rho[0] & 8) >> 3);
+     * Or (rho[0] & 2) and (rho[0] of the previous round & 8).
+     */
+    auto tmp = _mm512_mask_permutexvar_epi32(prev_cx_val_vec, 0xFFFE,
+                                             left_shift, rho_vec);
+    prev_cx_val_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
+                                                    rho_vec);
 
-      auto tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(2));
-      tmp1 = _mm512_srli_epi32(tmp1, 1);
-      cx_val_vec[x] = _mm512_or_epi32(tmp, tmp1);
-    }
+    tmp = _mm512_and_epi32(tmp, _mm512_set1_epi32(8));
+    tmp = _mm512_srli_epi32(tmp, 3);
 
-    static __m512i cal_tuple(__m512i &cq_vec, __m512i &rho_vec,
-                             __m512i &eps_vec, ui32 *vlc_tbl)
-    {
-      /* tuple[i] = vlc_tbl1[(c_q[i] << 8) + (rho[i] << 4) + eps[i]]; */
-      auto tmp = _mm512_slli_epi32(cq_vec, 8);
-      auto tmp1 = _mm512_slli_epi32(rho_vec, 4);
-      tmp = _mm512_add_epi32(tmp, tmp1);
-      tmp = _mm512_add_epi32(tmp, eps_vec);
-      return _mm512_i32gather_epi32(tmp, vlc_tbl, 4);
-    }
+    auto tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(2));
+    tmp1 = _mm512_srli_epi32(tmp1, 1);
+    cx_val_vec[x] = _mm512_or_epi32(tmp, tmp1);
+}
 
-    static __m512i proc_cq1(ui32 x, __m512i *cx_val_vec, __m512i &rho_vec,
-                            const __m512i right_shift)
-    {
-      ojph_unused(x);
-      ojph_unused(cx_val_vec);
-      ojph_unused(right_shift);
+static __m512i cal_tuple(__m512i &cq_vec, __m512i &rho_vec,
+                         __m512i &eps_vec, ui32 *vlc_tbl)
+{
+    /* tuple[i] = vlc_tbl1[(c_q[i] << 8) + (rho[i] << 4) + eps[i]]; */
+    auto tmp = _mm512_slli_epi32(cq_vec, 8);
+    auto tmp1 = _mm512_slli_epi32(rho_vec, 4);
+    tmp = _mm512_add_epi32(tmp, tmp1);
+    tmp = _mm512_add_epi32(tmp, eps_vec);
+    return _mm512_i32gather_epi32(tmp, vlc_tbl, 4);
+}
 
-      /* c_q[i + 1] = (rho[i] >> 1) | (rho[i] & 1); */
-      auto tmp = _mm512_srli_epi32(rho_vec, 1);
-      auto tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(1));
-      return _mm512_or_epi32(tmp, tmp1);
-    }
+static __m512i proc_cq1(ui32 x, __m512i *cx_val_vec, __m512i &rho_vec,
+                        const __m512i right_shift)
+{
+    ojph_unused(x);
+    ojph_unused(cx_val_vec);
+    ojph_unused(right_shift);
 
-    static __m512i proc_cq2(ui32 x, __m512i *cx_val_vec, __m512i &rho_vec,
-                            const __m512i right_shift)
-    {
-      // c_q[i + 1] = (lcxp[i + 1] + (lcxp[i + 2] << 2))
-      //            | (((rho[i] & 4) >> 1) | ((rho[i] & 8) >> 2));
-      auto lcxp1_vec = _mm512_permutexvar_epi32(right_shift, cx_val_vec[x]);
-      auto lcxp2_vec = _mm512_permutexvar_epi32(right_shift, cx_val_vec[x + 1]);
-      auto tmp = _mm512_permutexvar_epi32(right_shift, lcxp1_vec);
-      tmp = _mm512_mask_permutexvar_epi32(tmp, 0xC000, right_shift, lcxp2_vec);
-      tmp = _mm512_slli_epi32(tmp, 2);
-      auto tmp1 = _mm512_mask_mov_epi32(lcxp1_vec, 0x8000, lcxp2_vec);
-      tmp = _mm512_add_epi32(tmp1, tmp);
+    /* c_q[i + 1] = (rho[i] >> 1) | (rho[i] & 1); */
+    auto tmp = _mm512_srli_epi32(rho_vec, 1);
+    auto tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(1));
+    return _mm512_or_epi32(tmp, tmp1);
+}
 
-      tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(4));
-      tmp1 = _mm512_srli_epi32(tmp1, 1);
-      tmp = _mm512_or_epi32(tmp, tmp1);
+static __m512i proc_cq2(ui32 x, __m512i *cx_val_vec, __m512i &rho_vec,
+                        const __m512i right_shift)
+{
+    // c_q[i + 1] = (lcxp[i + 1] + (lcxp[i + 2] << 2))
+    //            | (((rho[i] & 4) >> 1) | ((rho[i] & 8) >> 2));
+    auto lcxp1_vec = _mm512_permutexvar_epi32(right_shift, cx_val_vec[x]);
+    auto lcxp2_vec = _mm512_permutexvar_epi32(right_shift, cx_val_vec[x + 1]);
+    auto tmp = _mm512_permutexvar_epi32(right_shift, lcxp1_vec);
+    tmp = _mm512_mask_permutexvar_epi32(tmp, 0xC000, right_shift, lcxp2_vec);
+    tmp = _mm512_slli_epi32(tmp, 2);
+    auto tmp1 = _mm512_mask_mov_epi32(lcxp1_vec, 0x8000, lcxp2_vec);
+    tmp = _mm512_add_epi32(tmp1, tmp);
 
-      tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(8));
-      tmp1 = _mm512_srli_epi32(tmp1, 2);
+    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(4));
+    tmp1 = _mm512_srli_epi32(tmp1, 1);
+    tmp = _mm512_or_epi32(tmp, tmp1);
 
-      return _mm512_or_epi32(tmp, tmp1);
-    }
+    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(8));
+    tmp1 = _mm512_srli_epi32(tmp1, 2);
 
-    using fn_proc_cq = __m512i (*)(ui32, __m512i *, __m512i &, const __m512i);
+    return _mm512_or_epi32(tmp, tmp1);
+}
 
-    static void proc_mel_encode1(mel_struct *melp, __m512i &cq_vec,
-                                 __m512i &rho_vec, __m512i u_q_vec, ui32 ignore,
-                                 const __m512i right_shift)
-    {
-      /* Prepare mel_encode params */
-      /* if (c_q[i] == 0) { */
-      auto mel_need_encode = _mm512_cmpeq_epi32_mask(cq_vec, ZERO);
-      /*   mel_encode(&mel, rho[i] != 0); */
-      auto mel_bit = _mm512_cmpneq_epi32_mask(rho_vec, ZERO);
-      /* } */
+using fn_proc_cq = __m512i (*)(ui32, __m512i *, __m512i &, const __m512i);
 
-      /*   mel_encode(&mel, ojph_min(u_q[i], u_q[i + 1]) > 2); */
-      auto tmp = _mm512_permutexvar_epi32(right_shift, u_q_vec);
-      auto tmp1 = _mm512_min_epi32(u_q_vec, tmp);
-      auto mel_bit2 = (ui16)_mm512_cmpgt_epi32_mask(tmp1, _mm512_set1_epi32(2));
+static void proc_mel_encode1(mel_struct *melp, __m512i &cq_vec,
+                             __m512i &rho_vec, __m512i u_q_vec, ui32 ignore,
+                             const __m512i right_shift)
+{
+    /* Prepare mel_encode params */
+    /* if (c_q[i] == 0) { */
+    auto mel_need_encode = _mm512_cmpeq_epi32_mask(cq_vec, ZERO);
+    /*   mel_encode(&mel, rho[i] != 0); */
+    auto mel_bit = _mm512_cmpneq_epi32_mask(rho_vec, ZERO);
+    /* } */
 
-      /* if (u_q[i] > 0 && u_q[i + 1] > 0) { } */
-      auto mel_need_encode2 = (ui16)_mm512_cmpgt_epi32_mask(u_q_vec, ZERO);
-      mel_need_encode2 =
-          mel_need_encode2 & (ui16)_mm512_cmpgt_epi32_mask(tmp, ZERO);
+    /*   mel_encode(&mel, ojph_min(u_q[i], u_q[i + 1]) > 2); */
+    auto tmp = _mm512_permutexvar_epi32(right_shift, u_q_vec);
+    auto tmp1 = _mm512_min_epi32(u_q_vec, tmp);
+    auto mel_bit2 = (ui16)_mm512_cmpgt_epi32_mask(tmp1, _mm512_set1_epi32(2));
 
-      ui32 i_max = 16 - (ignore / 2);
+    /* if (u_q[i] > 0 && u_q[i + 1] > 0) { } */
+    auto mel_need_encode2 = (ui16)_mm512_cmpgt_epi32_mask(u_q_vec, ZERO);
+    mel_need_encode2 =
+      mel_need_encode2 & (ui16)_mm512_cmpgt_epi32_mask(tmp, ZERO);
 
-      for (ui32 i = 0; i < i_max; i += 2)
-      {
+    ui32 i_max = 16 - (ignore / 2);
+
+    for (ui32 i = 0; i < i_max; i += 2) {
         auto mask = 1 << i;
-        if (0 != (mel_need_encode & mask))
-        {
-          mel_encode(melp, mel_bit & mask);
-        }
-
-        if (i + 1 < i_max)
-        {
-          auto mask = 1 << (i + 1);
-          if (0 != (mel_need_encode & mask))
-          {
+        if (0 != (mel_need_encode & mask)) {
             mel_encode(melp, mel_bit & mask);
-          }
         }
 
-        if (0 != (mel_need_encode2 & mask))
-        {
-          mel_encode(melp, mel_bit2 & mask);
+        if (i + 1 < i_max) {
+            auto mask = 1 << (i + 1);
+            if (0 != (mel_need_encode & mask)) {
+                mel_encode(melp, mel_bit & mask);
+            }
         }
-      }
+
+        if (0 != (mel_need_encode2 & mask)) {
+            mel_encode(melp, mel_bit2 & mask);
+        }
     }
+}
 
-    static void proc_mel_encode2(mel_struct *melp, __m512i &cq_vec,
-                                 __m512i &rho_vec, __m512i u_q_vec, ui32 ignore,
-                                 const __m512i right_shift)
-    {
-      ojph_unused(u_q_vec);
-      ojph_unused(right_shift);
+static void proc_mel_encode2(mel_struct *melp, __m512i &cq_vec,
+                             __m512i &rho_vec, __m512i u_q_vec, ui32 ignore,
+                             const __m512i right_shift)
+{
+    ojph_unused(u_q_vec);
+    ojph_unused(right_shift);
 
-      /* Prepare mel_encode params */
-      /* if (c_q[i] == 0) { */
-      auto mel_need_encode = _mm512_cmpeq_epi32_mask(cq_vec, ZERO);
-      /*   mel_encode(&mel, rho[i] != 0); */
-      auto mel_bit = _mm512_cmpneq_epi32_mask(rho_vec, ZERO);
-      /* } */
+    /* Prepare mel_encode params */
+    /* if (c_q[i] == 0) { */
+    auto mel_need_encode = _mm512_cmpeq_epi32_mask(cq_vec, ZERO);
+    /*   mel_encode(&mel, rho[i] != 0); */
+    auto mel_bit = _mm512_cmpneq_epi32_mask(rho_vec, ZERO);
+    /* } */
 
-      ui32 i_max = 16 - (ignore / 2);
+    ui32 i_max = 16 - (ignore / 2);
 
-      for (ui32 i = 0; i < i_max; ++i)
-      {
+    for (ui32 i = 0; i < i_max; ++i) {
         auto mask = 1 << i;
-        if (0 != (mel_need_encode & mask))
-        {
-          mel_encode(melp, mel_bit & mask);
+        if (0 != (mel_need_encode & mask)) {
+            mel_encode(melp, mel_bit & mask);
         }
-      }
     }
+}
 
-    using fn_proc_mel_encode = void (*)(mel_struct *, __m512i &, __m512i &,
-                                        __m512i, ui32, const __m512i);
+using fn_proc_mel_encode = void (*)(mel_struct *, __m512i &, __m512i &,
+                                    __m512i, ui32, const __m512i);
 
-    static void proc_vlc_encode1(vlc_struct_avx512 *vlcp, ui32 *tuple,
-                                 ui32 *u_q, ui32 ignore)
-    {
-      ui32 i_max = 16 - (ignore / 2);
+static void proc_vlc_encode1(vlc_struct_avx512 *vlcp, ui32 *tuple,
+                             ui32 *u_q, ui32 ignore)
+{
+    ui32 i_max = 16 - (ignore / 2);
 
-      for (ui32 i = 0; i < i_max; i += 2)
-      {
+    for (ui32 i = 0; i < i_max; i += 2) {
         /* 7 bits */
         ui32 val = tuple[i + 0] >> 4;
         int size = tuple[i + 0] & 7;
 
-        if (i + 1 < i_max)
-        {
-          /* 7 bits */
-          val |= (tuple[i + 1] >> 4) << size;
-          size += tuple[i + 1] & 7;
+        if (i + 1 < i_max) {
+            /* 7 bits */
+            val |= (tuple[i + 1] >> 4) << size;
+            size += tuple[i + 1] & 7;
         }
 
-        if (u_q[i] > 2 && u_q[i + 1] > 2)
-        {
-          /* 3 bits */
-          val |= (ulvc_cwd_pre[u_q[i] - 2]) << size;
-          size += ulvc_cwd_pre_len[u_q[i] - 2];
+        if (u_q[i] > 2 && u_q[i + 1] > 2) {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i] - 2]) << size;
+            size += ulvc_cwd_pre_len[u_q[i] - 2];
 
-          /* 3 bits */
-          val |= (ulvc_cwd_pre[u_q[i + 1] - 2]) << size;
-          size += ulvc_cwd_pre_len[u_q[i + 1] - 2];
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i + 1] - 2]) << size;
+            size += ulvc_cwd_pre_len[u_q[i + 1] - 2];
 
-          /* 5 bits */
-          val |= (ulvc_cwd_suf[u_q[i] - 2]) << size;
-          size += ulvc_cwd_suf_len[u_q[i] - 2];
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i] - 2]) << size;
+            size += ulvc_cwd_suf_len[u_q[i] - 2];
 
-          /* 5 bits */
-          val |= (ulvc_cwd_suf[u_q[i + 1] - 2]) << size;
-          size += ulvc_cwd_suf_len[u_q[i + 1] - 2];
-        }
-        else if (u_q[i] > 2 && u_q[i + 1] > 0)
-        {
-          /* 3 bits */
-          val |= (ulvc_cwd_pre[u_q[i]]) << size;
-          size += ulvc_cwd_pre_len[u_q[i]];
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i + 1] - 2]) << size;
+            size += ulvc_cwd_suf_len[u_q[i + 1] - 2];
 
-          /* 1 bit */
-          val |= (u_q[i + 1] - 1) << size;
-          size += 1;
+        } else if (u_q[i] > 2 && u_q[i + 1] > 0) {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i]];
 
-          /* 5 bits */
-          val |= (ulvc_cwd_suf[u_q[i]]) << size;
-          size += ulvc_cwd_suf_len[u_q[i]];
-        }
-        else
-        {
-          /* 3 bits */
-          val |= (ulvc_cwd_pre[u_q[i]]) << size;
-          size += ulvc_cwd_pre_len[u_q[i]];
+            /* 1 bit */
+            val |= (u_q[i + 1] - 1) << size;
+            size += 1;
 
-          /* 3 bits */
-          val |= (ulvc_cwd_pre[u_q[i + 1]]) << size;
-          size += ulvc_cwd_pre_len[u_q[i + 1]];
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i]];
 
-          /* 5 bits */
-          val |= (ulvc_cwd_suf[u_q[i]]) << size;
-          size += ulvc_cwd_suf_len[u_q[i]];
+        } else {
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i]];
 
-          /* 5 bits */
-          val |= (ulvc_cwd_suf[u_q[i + 1]]) << size;
-          size += ulvc_cwd_suf_len[u_q[i + 1]];
+            /* 3 bits */
+            val |= (ulvc_cwd_pre[u_q[i + 1]]) << size;
+            size += ulvc_cwd_pre_len[u_q[i + 1]];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i]];
+
+            /* 5 bits */
+            val |= (ulvc_cwd_suf[u_q[i + 1]]) << size;
+            size += ulvc_cwd_suf_len[u_q[i + 1]];
         }
 
         vlc_encode(vlcp, val, size);
-      }
     }
+}
 
-    static void proc_vlc_encode2(vlc_struct_avx512 *vlcp, ui32 *tuple,
-                                 ui32 *u_q, ui32 ignore)
-    {
-      ui32 i_max = 16 - (ignore / 2);
+static void proc_vlc_encode2(vlc_struct_avx512 *vlcp, ui32 *tuple,
+                             ui32 *u_q, ui32 ignore)
+{
+    ui32 i_max = 16 - (ignore / 2);
 
-      for (ui32 i = 0; i < i_max; i += 2)
-      {
+    for (ui32 i = 0; i < i_max; i += 2) {
         /* 7 bits */
         ui32 val = tuple[i + 0] >> 4;
         int size = tuple[i + 0] & 7;
 
-        if (i + 1 < i_max)
-        {
-          /* 7 bits */
-          val |= (tuple[i + 1] >> 4) << size;
-          size += tuple[i + 1] & 7;
+        if (i + 1 < i_max) {
+            /* 7 bits */
+            val |= (tuple[i + 1] >> 4) << size;
+            size += tuple[i + 1] & 7;
         }
 
         /* 3 bits */
@@ -1046,87 +1001,88 @@ static void print_epi32(const char *msg, __m512i &val)
         size += ulvc_cwd_suf_len[u_q[i + 1]];
 
         vlc_encode(vlcp, val, size);
-      }
     }
+}
 
-    using fn_proc_vlc_encode = void (*)(vlc_struct_avx512 *, ui32 *, ui32 *, ui32);
+using fn_proc_vlc_encode = void (*)(vlc_struct_avx512 *, ui32 *, ui32 *, ui32);
 
-    void ojph_encode_codeblock_avx512(ui32 *buf, ui32 missing_msbs,
-                                      ui32 num_passes, ui32 _width, ui32 height,
-                                      ui32 stride, ui32 *lengths,
-                                      ojph::mem_elastic_allocator *elastic,
-                                      ojph::coded_lists *&coded)
-    {
-      ojph_unused(num_passes); // currently not used
+void ojph_encode_codeblock_avx512(ui32* buf, ui32 missing_msbs,
+                                  ui32 num_passes, ui32 _width, ui32 height,
+                                  ui32 stride, ui32* lengths,
+                                  ojph::mem_elastic_allocator *elastic,
+                                  ojph::coded_lists *& coded)
+{
+    ojph_unused(num_passes);                      //currently not used
 
-      ui32 width = (_width + 31) & ~31u;
-      ui32 ignore = width - _width;
-      const int ms_size = (16384 * 16 + 14) / 15; // more than enough
-      const int mel_vlc_size = 3072;              // more than enough
-      const int mel_size = 192;
-      const int vlc_size = mel_vlc_size - mel_size;
+    ui32 width = (_width + 31) & ~31u;
+    ui32 ignore = width - _width;
+    const int ms_size = (16384 * 16 + 14) / 15; //more than enough
+    const int mel_vlc_size = 3072;              //more than enough
+    const int mel_size = 192;
+    const int vlc_size = mel_vlc_size - mel_size;
 
-      ui8 ms_buf[ms_size];
-      ui8 mel_vlc_buf[mel_vlc_size];
-      ui8 *mel_buf = mel_vlc_buf;
-      ui8 *vlc_buf = mel_vlc_buf + mel_size;
+    ui8 ms_buf[ms_size];
+    ui8 mel_vlc_buf[mel_vlc_size];
+    ui8 *mel_buf = mel_vlc_buf;
+    ui8 *vlc_buf = mel_vlc_buf + mel_size;
 
-      mel_struct mel;
-      mel_init(&mel, mel_size, mel_buf);
-      vlc_struct_avx512 vlc;
-      vlc_init(&vlc, vlc_size, vlc_buf);
-      ms_struct ms;
-      ms_init(&ms, ms_size, ms_buf);
+    mel_struct mel;
+    mel_init(&mel, mel_size, mel_buf);
+    vlc_struct_avx512 vlc;
+    vlc_init(&vlc, vlc_size, vlc_buf);
+    ms_struct ms;
+    ms_init(&ms, ms_size, ms_buf);
 
-      ui32 p = 30 - missing_msbs;
+    ui32 p = 30 - missing_msbs;
 
-      // e_val: E values for a line (these are the highest set bit)
-      // cx_val: is the context values
-      // Each byte stores the info for the 2 sample. For E, it is maximum
-      //  of the two samples, while for cx, it is the OR of these two samples.
-      // The maximum is between the pixel at the bottom left of one quad
-      //  and the bottom right of the earlier quad. The same is true for cx.
-      // For a 1024 pixels, we need 512 bytes, the 2 extra,
-      //  one for the non-existing earlier quad, and one for beyond the
-      //  the end
-      const __m512i right_shift = _mm512_set_epi32(
-          0, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
+    //e_val: E values for a line (these are the highest set bit)
+    //cx_val: is the context values
+    //Each byte stores the info for the 2 sample. For E, it is maximum
+    // of the two samples, while for cx, it is the OR of these two samples.
+    //The maximum is between the pixel at the bottom left of one quad
+    // and the bottom right of the earlier quad. The same is true for cx.
+    //For a 1024 pixels, we need 512 bytes, the 2 extra,
+    // one for the non-existing earlier quad, and one for beyond the
+    // the end
+    const __m512i right_shift = _mm512_set_epi32(
+      0, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
+    );
 
-      const __m512i left_shift = _mm512_set_epi32(
-          14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 15);
+    const __m512i left_shift = _mm512_set_epi32(
+      14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 15
+    );
 
-      __m512i e_val_vec[33];
-      for (ui32 i = 0; i < 32; ++i)
-      {
+    __m512i e_val_vec[33];
+    for (ui32 i = 0; i < 32; ++i) {
         e_val_vec[i] = ZERO;
-      }
-      __m512i prev_e_val_vec = ZERO;
+    }
+    __m512i prev_e_val_vec = ZERO;
 
-      __m512i cx_val_vec[33];
-      __m512i prev_cx_val_vec = ZERO;
+    __m512i cx_val_vec[33];
+    __m512i prev_cx_val_vec = ZERO;
 
-      __m512i prev_cq_vec = ZERO;
+    __m512i prev_cq_vec = ZERO;
 
-      __m512i tmp;
-      __m512i tmp1;
+    __m512i tmp;
+    __m512i tmp1;
 
-      __m512i eq_vec[4];
-      __m512i s_vec[4];
-      __m512i src_vec[4];
-      __m512i rho_vec;
-      __m512i e_qmax_vec;
-      __m512i kappa_vec;
+    __m512i eq_vec[4];
+    __m512i s_vec[4];
+    __m512i src_vec[4];
+    __m512i rho_vec;
+    __m512i e_qmax_vec;
+    __m512i kappa_vec;
 
-      ui32 n_loop = (width + 31) / 32;
+    ui32 n_loop = (width + 31) / 32;
 
-      ui32 *vlc_tbl = vlc_tbl0;
-      fn_proc_cq proc_cq = proc_cq1;
-      fn_proc_mel_encode proc_mel_encode = proc_mel_encode1;
-      fn_proc_vlc_encode proc_vlc_encode = proc_vlc_encode1;
+    ui32 *vlc_tbl = vlc_tbl0;
+    fn_proc_cq proc_cq = proc_cq1;
+    fn_proc_mel_encode proc_mel_encode = proc_mel_encode1;
+    fn_proc_vlc_encode proc_vlc_encode = proc_vlc_encode1;
 
-      /* 2 lines per iteration */
-      for (ui32 y = 0; y < height; y += 2)
-      {
+    /* 2 lines per iteration */
+    for (ui32 y = 0; y < height; y += 2)
+    {
         e_val_vec[n_loop] = prev_e_val_vec;
         /* lcxp[0] = (ui8)((rho[0] & 8) >> 3); */
         tmp = _mm512_and_epi32(prev_cx_val_vec, _mm512_set1_epi32(8));
@@ -1139,95 +1095,91 @@ static void print_epi32(const char *msg, __m512i &val)
         ui32 *sp = buf + y * stride;
 
         /* 32 bytes per iteration */
-        for (ui32 x = 0; x < n_loop; ++x)
-        {
+        for (ui32 x = 0; x < n_loop; ++x) {
 
-          // mask to stop loading unnecessary data
-          si32 true_x = (si32)x << 5;
-          ui32 mask32 = 0xFFFFFFFFu;
-          si32 entries = true_x + 32 - (si32)_width;
-          mask32 >>= ((entries >= 0) ? entries : 0);
-          __mmask16 load_mask0 = _cvtu32_mask16(mask32);
-          __mmask16 load_mask1 = _cvtu32_mask16(mask32 >> 16);
+            // mask to stop loading unnecessary data
+            si32 true_x = (si32)x << 5;
+            ui32 mask32 = 0xFFFFFFFFu;
+            si32 entries = true_x + 32 - (si32)_width;
+            mask32 >>= ((entries >= 0) ? entries : 0);
+            __mmask16 load_mask0 = _cvtu32_mask16(mask32);
+            __mmask16 load_mask1 = _cvtu32_mask16(mask32 >> 16);
 
-          /* t = sp[i]; */
-          src_vec[0] = _mm512_maskz_loadu_epi32(load_mask0, sp);
-          src_vec[2] = _mm512_maskz_loadu_epi32(load_mask1, sp + 16);
+            /* t = sp[i]; */
+            src_vec[0] = _mm512_maskz_loadu_epi32(load_mask0, sp);
+            src_vec[2] = _mm512_maskz_loadu_epi32(load_mask1, sp + 16);
 
-          if (y + 1 < height)
-          {
-            src_vec[1] = _mm512_maskz_loadu_epi32(load_mask0, sp + stride);
-            src_vec[3] =
-                _mm512_maskz_loadu_epi32(load_mask1, sp + 16 + stride);
-          }
-          else
-          {
-            src_vec[1] = ZERO;
-            src_vec[3] = ZERO;
-          }
-          sp += 32;
+            if (y + 1 < height) {
+                src_vec[1] = _mm512_maskz_loadu_epi32(load_mask0, sp + stride);
+                src_vec[3] =
+                  _mm512_maskz_loadu_epi32(load_mask1, sp + 16 + stride);
+            } else {
+                src_vec[1] = ZERO;
+                src_vec[3] = ZERO;
+            }
+            sp += 32;
 
-          /* src_vec layout:
-           * src_vec[0]:[0, 0],[0, 1],[0, 2],[0, 3],[0, 4],[0, 5]...[0,15]
-           * src_vec[1]:[1, 0],[1, 1],[1, 2],[1, 3],[1, 4],[1, 5]...[1,15]
-           * src_vec[2]:[0,16],[0,17],[0,18],[0,19],[0,20],[0,21]...[0,31]
-           * src_vec[3]:[1,16],[1,17],[1,18],[1,19],[1,20],[1,21]...[1,31]
-           */
-          proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
+            /* src_vec layout:
+             * src_vec[0]:[0, 0],[0, 1],[0, 2],[0, 3],[0, 4],[0, 5]...[0,15]
+             * src_vec[1]:[1, 0],[1, 1],[1, 2],[1, 3],[1, 4],[1, 5]...[1,15]
+             * src_vec[2]:[0,16],[0,17],[0,18],[0,19],[0,20],[0,21]...[0,31]
+             * src_vec[3]:[1,16],[1,17],[1,18],[1,19],[1,20],[1,21]...[1,31]
+             */
+            proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
 
-          // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
-          tmp = _mm512_permutexvar_epi32(right_shift, e_val_vec[x]);
-          tmp = _mm512_mask_permutexvar_epi32(tmp, 0x8000, right_shift,
-                                              e_val_vec[x + 1]);
-          auto mask = _mm512_cmpgt_epi32_mask(e_val_vec[x], tmp);
-          auto max_e_vec = _mm512_mask_mov_epi32(tmp, mask, e_val_vec[x]);
-          max_e_vec = _mm512_sub_epi32(max_e_vec, ONE);
+            // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
+            tmp = _mm512_permutexvar_epi32(right_shift, e_val_vec[x]);
+            tmp = _mm512_mask_permutexvar_epi32(tmp, 0x8000, right_shift,
+                                                e_val_vec[x + 1]);
+            auto mask = _mm512_cmpgt_epi32_mask(e_val_vec[x], tmp);
+            auto max_e_vec = _mm512_mask_mov_epi32(tmp, mask, e_val_vec[x]);
+            max_e_vec = _mm512_sub_epi32(max_e_vec, ONE);
 
-          // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
-          tmp = _mm512_max_epi32(max_e_vec, ONE);
-          tmp1 = _mm512_sub_epi32(rho_vec, ONE);
-          tmp1 = _mm512_and_epi32(rho_vec, tmp1);
-          mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-          kappa_vec = _mm512_mask_mov_epi32(ONE, mask, tmp);
+            // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
+            tmp = _mm512_max_epi32(max_e_vec, ONE);
+            tmp1 = _mm512_sub_epi32(rho_vec, ONE);
+            tmp1 = _mm512_and_epi32(rho_vec, tmp1);
+            mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
+            kappa_vec = _mm512_mask_mov_epi32(ONE, mask, tmp);
 
-          /* cq[1 - 16] = cq_vec
-           * cq[0] = prev_cq_vec[0]
-           */
-          tmp = proc_cq(x, cx_val_vec, rho_vec, right_shift);
-          auto cq_vec = _mm512_mask_permutexvar_epi32(prev_cq_vec, 0xFFFE,
-                                                      left_shift, tmp);
-          prev_cq_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
-                                                      tmp);
+            /* cq[1 - 16] = cq_vec
+             * cq[0] = prev_cq_vec[0]
+             */
+            tmp = proc_cq(x, cx_val_vec, rho_vec, right_shift);
+            auto cq_vec = _mm512_mask_permutexvar_epi32(prev_cq_vec, 0xFFFE,
+                                                        left_shift, tmp);
+            prev_cq_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
+                                                        tmp);
 
-          update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
-          update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
+            update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
+            update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
 
-          /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
-          /* u_q[i] = Uq[i] - kappa[i]; */
-          auto uq_vec = _mm512_max_epi32(kappa_vec, e_qmax_vec);
-          auto u_q_vec = _mm512_sub_epi32(uq_vec, kappa_vec);
+            /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
+            /* u_q[i] = Uq[i] - kappa[i]; */
+            auto uq_vec = _mm512_max_epi32(kappa_vec, e_qmax_vec);
+            auto u_q_vec = _mm512_sub_epi32(uq_vec, kappa_vec);
 
-          auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
-          __m512i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
-          ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
+            auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
+            __m512i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
+            ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
 
-          proc_mel_encode(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
-                          right_shift);
+            proc_mel_encode(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
+                            right_shift);
 
-          proc_ms_encode(&ms, tuple_vec, uq_vec, rho_vec, s_vec);
+            proc_ms_encode(&ms, tuple_vec, uq_vec, rho_vec, s_vec);
 
-          // vlc_encode(&vlc, tuple[i*2+0] >> 8, (tuple[i*2+0] >> 4) & 7);
-          // vlc_encode(&vlc, tuple[i*2+1] >> 8, (tuple[i*2+1] >> 4) & 7);
-          ui32 u_q[16];
-          ui32 tuple[16];
-          /* The tuple is scaled by 4 due to:
-           * vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7, true);
-           * So in the vlc_encode, the tuple will only be scaled by 2.
-           */
-          tuple_vec = _mm512_srli_epi32(tuple_vec, 4);
-          _mm512_store_epi32(tuple, tuple_vec);
-          _mm512_store_epi32(u_q, u_q_vec);
-          proc_vlc_encode(&vlc, tuple, u_q, _ignore);
+            // vlc_encode(&vlc, tuple[i*2+0] >> 8, (tuple[i*2+0] >> 4) & 7);
+            // vlc_encode(&vlc, tuple[i*2+1] >> 8, (tuple[i*2+1] >> 4) & 7);
+            ui32 u_q[16];
+            ui32 tuple[16];
+            /* The tuple is scaled by 4 due to:
+             * vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7, true);
+             * So in the vlc_encode, the tuple will only be scaled by 2.
+             */
+            tuple_vec = _mm512_srli_epi32(tuple_vec, 4);
+            _mm512_storeu_si512(tuple, tuple_vec);
+            _mm512_storeu_si512(u_q, u_q_vec);
+            proc_vlc_encode(&vlc, tuple, u_q, _ignore);
         }
 
         tmp = _mm512_permutexvar_epi32(right_shift, cx_val_vec[0]);
@@ -1238,29 +1190,29 @@ static void print_epi32(const char *msg, __m512i &val)
         vlc_tbl = vlc_tbl1;
         proc_mel_encode = proc_mel_encode2;
         proc_vlc_encode = proc_vlc_encode2;
-      }
-
-      ms_terminate(&ms);
-      terminate_mel_vlc(&mel, &vlc);
-
-      // copy to elastic
-      lengths[0] = mel.pos + vlc.pos + ms.pos;
-      elastic->get_buffer(mel.pos + vlc.pos + ms.pos, coded);
-      memcpy(coded->buf, ms.buf, ms.pos);
-      memcpy(coded->buf + ms.pos, mel.buf, mel.pos);
-      memcpy(coded->buf + ms.pos + mel.pos, vlc.buf - vlc.pos + 1, vlc.pos);
-
-      // put in the interface locator word
-      ui32 num_bytes = mel.pos + vlc.pos;
-      coded->buf[lengths[0] - 1] = (ui8)(num_bytes >> 4);
-      coded->buf[lengths[0] - 2] = coded->buf[lengths[0] - 2] & 0xF0;
-      coded->buf[lengths[0] - 2] =
-          (ui8)(coded->buf[lengths[0] - 2] | (num_bytes & 0xF));
-
-      coded->avail_size -= lengths[0];
     }
 
-  } /* namespace local */
+    ms_terminate(&ms);
+    terminate_mel_vlc(&mel, &vlc);
+
+    //copy to elastic
+    lengths[0] = mel.pos + vlc.pos + ms.pos;
+    elastic->get_buffer(mel.pos + vlc.pos + ms.pos, coded);
+    memcpy(coded->buf, ms.buf, ms.pos);
+    memcpy(coded->buf + ms.pos, mel.buf, mel.pos);
+    memcpy(coded->buf + ms.pos + mel.pos, vlc.buf - vlc.pos + 1, vlc.pos);
+
+    // put in the interface locator word
+    ui32 num_bytes = mel.pos + vlc.pos;
+    coded->buf[lengths[0]-1] = (ui8)(num_bytes >> 4);
+    coded->buf[lengths[0]-2] = coded->buf[lengths[0]-2] & 0xF0;
+    coded->buf[lengths[0]-2] =
+        (ui8)(coded->buf[lengths[0]-2] | (num_bytes & 0xF));
+
+    coded->avail_size -= lengths[0];
+}
+
+} /* namespace local */
 } /* namespace ojph */
 
 #endif

--- a/Native/Common/OpenJPH/common/ojph_arch.h
+++ b/Native/Common/OpenJPH/common/ojph_arch.h
@@ -2,21 +2,22 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+// Copyright (c) 2026, Osamu Watanabe
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -63,11 +64,22 @@
 #include <intrin.h>
 #endif
 
+  /////////////////////////////////////////////////////////////////////////////
+  // portable force-inline / no-inline function qualifiers
+  /////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_COMPILER_MSVC
+  #define OJPH_FORCE_INLINE static __forceinline
+  #define OJPH_NO_INLINE    static __declspec(noinline)
+#else
+  #define OJPH_FORCE_INLINE static inline __attribute__((always_inline))
+  #define OJPH_NO_INLINE    static __attribute__((noinline))
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // preprocessor directives for architecture
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(__arm__) || defined(__TARGET_ARCH_ARM)  \
-  || defined(__aarch64__) || defined(_M_ARM64)
+  || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
   #define OJPH_ARCH_ARM
 #elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
   #define OJPH_ARCH_I386
@@ -84,7 +96,7 @@
   #else
     #define OJPH_ARCH_PPC
   #endif
-#else  
+#else
   #define OJPH_ARCH_UNKNOWN
 #endif
 
@@ -108,6 +120,10 @@ namespace ojph {
 #define OJPH_OS_ANDROID
 #elif (defined __linux)
 #define OJPH_OS_LINUX
+#elif (defined __FreeBSD__)
+#define OJPH_OS_FREEBSD
+#elif (defined __OpenBSD__)
+#define OJPH_OS_OPENBSD
 #endif
 
   /////////////////////////////////////////////////////////////////////////////
@@ -188,19 +204,21 @@ namespace ojph {
   #endif
   }
 
-  /////////////////////////////////////////////////////////////////////////////  
+  /////////////////////////////////////////////////////////////////////////////
 #ifdef OJPH_COMPILER_MSVC
-  #if (defined OJPH_ARCH_X86_64)
+  #if (defined OJPH_ARCH_X86_64 || defined OJPH_ARCH_ARM)
     #pragma intrinsic(_BitScanReverse64)
   #elif (defined OJPH_ARCH_I386)
     #pragma intrinsic(_BitScanReverse)
+  #else
+    #error Error unsupport MSVC version
   #endif
 #endif
   static inline ui32 count_leading_zeros(ui64 val)
   {
   #ifdef OJPH_COMPILER_MSVC
     unsigned long result = 0;
-    #ifdef OJPH_ARCH_X86_64
+    #if (defined OJPH_ARCH_X86_64) || (defined OJPH_ARCH_ARM)
       _BitScanReverse64(&result, val);
     #elif (defined OJPH_ARCH_I386)
       ui32 msb = (ui32)(val >> 32), lsb = (ui32)val;
@@ -210,6 +228,8 @@ namespace ojph {
         _BitScanReverse(&result, msb);
         result += 32;
       }
+    #else
+      #error Error unsupport MSVC version
     #endif
     return 63 ^ (ui32)result;
   #elif (defined OJPH_COMPILER_GNUC)
@@ -223,7 +243,7 @@ namespace ojph {
     val |= (val >> 32);
     return 64 - population_count64(val);
   #endif
-  }  
+  }
 
   /////////////////////////////////////////////////////////////////////////////
 #ifdef OJPH_COMPILER_MSVC
@@ -244,6 +264,35 @@ namespace ojph {
     val |= (val << 8);
     val |= (val << 16);
     return 32 - population_count(val);
+  #endif
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_COMPILER_MSVC
+  #pragma intrinsic(_BitScanForward64)
+#endif
+  static inline ui32 count_trailing_zeros(ui64 val)
+  {
+  #ifdef OJPH_COMPILER_MSVC
+    unsigned long result = 0;
+    #if (defined OJPH_ARCH_X86_64) || (defined OJPH_ARCH_ARM)
+      _BitScanForward64(&result, val);
+    #elif (defined OJPH_ARCH_I386)
+      ui32 lsb = (ui32)val, msb = (ui32)(val >> 32);
+      if (lsb != 0)
+        _BitScanForward(&result, lsb);
+      else {
+        _BitScanForward(&result, msb);
+        result += 32;
+      }
+    #endif
+    return (ui32)result;
+  #elif (defined OJPH_COMPILER_GNUC)
+    return (ui32)__builtin_ctzll(val);
+  #else
+    if ((ui32)val != 0)
+      return count_trailing_zeros((ui32)val);
+    return 32 + count_trailing_zeros((ui32)(val >> 32));
   #endif
   }
 
@@ -308,6 +357,118 @@ namespace ojph {
     return reinterpret_cast<T *>(p);
   }
 
+  ////////////////////////////////////////////////////////////////////////////
+  // Determine the byte order of the target at compile time when possible,
+  // so that the compiler can remove the branches for the other byte order.
+  // __BYTE_ORDER__ is a predefined macro that describes the target
+  // architecture, not the machine running the compiler, so it is also
+  // correct when cross-compiling.
+  // All MSVC targets (x86, x64, ARM64 Windows) are little endian.
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+  constexpr bool is_machine_little_endian = false;
+#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  constexpr bool is_machine_little_endian = true;
+#elif defined(OJPH_COMPILER_MSVC)
+  constexpr bool is_machine_little_endian = true;
+#else
+  // fallback in case macro __BYTE_ORDER__ is not defined
+  // If the first byte in memory is 0x01, the machine is Little Endian.
+  // If the first byte in memory is 0x00, the machine is Big Endian.
+  static bool check_if_machine_is_little_endian()
+  {
+    const uint16_t n = 0x0001;
+    bool is_machine_little_endian = (*((uint8_t *)&n) == 0x01);
+    return is_machine_little_endian;
+  }
+  const bool is_machine_little_endian = check_if_machine_is_little_endian();
+#endif
+
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 --> 2 1 on big-endian machines
+  static inline ui16 swap_bytes_if_be(ui16 t)
+  {
+    if (is_machine_little_endian)
+      return t;
+    else
+      return (ui16)((t << 8) | (t >> 8));
+  }
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 --> 2 1 on little-endian machines
+  static inline ui16 swap_bytes_if_le(ui16 t)
+  {
+    if (is_machine_little_endian)
+      return (ui16)((t << 8) | (t >> 8));
+    else
+      return t;
+  }
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 3 4 --> 4 3 2 1 on big-endian machines
+  static inline ui32 swap_bytes_if_be(ui32 t)
+  {
+    if (is_machine_little_endian)
+      return t;
+    else
+    {
+      ui32 u = swap_bytes_if_be((ui16)(t & 0xFFFFu));
+      u <<= 16;
+      u |= swap_bytes_if_be((ui16)(t >> 16));
+      return u;
+    }
+  }
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 3 4 --> 4 3 2 1 on little-endian machines
+  static inline ui32 swap_bytes_if_le(ui32 t)
+  {
+    if (is_machine_little_endian)
+    {
+      ui32 u = swap_bytes_if_le((ui16)(t & 0xFFFFu));
+      u <<= 16;
+      u |= swap_bytes_if_le((ui16)(t >> 16));
+      return u;
+    }
+    else
+      return t;
+  }
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 3 4 5 6 7 8 --> 8 7 6 5 4 3 2 1 on little-endian machines
+  static inline ui64 swap_bytes_if_le(ui64 t)
+  {
+    if (is_machine_little_endian)
+    {
+      ui64 u =
+        swap_bytes_if_le((ui32)(t & 0xFFFFFFFFu));
+      u <<= 32;
+      u |= swap_bytes_if_le((ui32)(t >> 32));
+      return u;
+    }
+    else
+      return t;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // loads 4 bytes from p as a little-endian 32-bit integer; that is, the
+  // byte at the lowest address goes into the least-significant byte of the
+  // result, irrespective of the machine's endianness
+  static inline ui32 load_le_ui32(const ui8 *p)
+  {
+    if (is_machine_little_endian)
+      return *(const ui32 *)p;
+    else
+      return (ui32)p[0] | ((ui32)p[1] << 8)
+        | ((ui32)p[2] << 16) | ((ui32)p[3] << 24);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // loads two consecutive ui16 values from p, placing the one at the lower
+  // address in the least-significant 16 bits of the result, irrespective
+  // of the machine's endianness
+  static inline ui32 load_le_ui16x2(const ui16 *p)
+  {
+    if (is_machine_little_endian)
+      return *(const ui32 *)p;
+    else
+      return (ui32)p[0] | ((ui32)p[1] << 16);
+  }
 }
 
 #endif // !OJPH_ARCH_H

--- a/Native/Common/OpenJPH/common/ojph_arg.h
+++ b/Native/Common/OpenJPH/common/ojph_arg.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_ARG_H
 #define OJPH_ARG_H
 
@@ -44,21 +45,17 @@
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   /////////////////////////////////////////////////////////////////////////////
   //
   /////////////////////////////////////////////////////////////////////////////
-  class argument
-  {
+  class argument {
     friend class cli_interpreter;
-
   public:
     argument() : arg(NULL), index(0) {}
     char *arg;
     bool is_valid() { return (arg != NULL); }
-
   private:
     int index;
   };
@@ -66,24 +63,19 @@ namespace ojph
   /////////////////////////////////////////////////////////////////////////////
   //
   /////////////////////////////////////////////////////////////////////////////
-  class cli_interpreter
-  {
+  class cli_interpreter {
   public:
-    cli_interpreter() : argv(NULL), argc(0), avail(avail_store) {}
+    cli_interpreter() : argv(NULL), argc(0), avail(avail_store) { }
     ~cli_interpreter()
-    {
-      if (avail != avail_store)
-        delete[] avail;
-    }
+    { if (avail != avail_store) delete[] avail; }
 
     ///////////////////////////////////////////////////////////////////////////
-    void init(int argc, char *argv[])
-    {
+    void init(int argc, char *argv[]) {
       assert(avail == avail_store);
       if (argc > 128)
         avail = new ui8[((ui32)argc + 7u) >> 3];
-      memset(avail, 0,
-             ojph_max(sizeof(avail_store), (size_t)((argc + 7) >> 3)));
+      memset(avail, 0, 
+        ojph_max(sizeof(avail_store), (size_t)((argc + 7) >> 3)));
       this->argv = argv;
       this->argc = argc;
       for (int i = 0; i < argc; ++i)
@@ -91,12 +83,10 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    argument get_next_value(const argument &current)
-    {
+    argument get_next_value(const argument& current) {
       argument t;
       int idx = current.index + 1;
-      if (idx < argc && (avail[idx >> 3] & (1 << (idx & 0x7))))
-      {
+      if (idx < argc && (avail[idx >> 3] & (1 << (idx & 0x7)))) {
         t.arg = argv[idx];
         t.index = idx;
       }
@@ -104,13 +94,11 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    argument find_argument(const char *str)
-    {
+    argument find_argument(const char *str) {
       argument t;
       for (int index = 1; index < argc; ++index)
         if (avail[index >> 3] & (1 << (index & 0x7)))
-          if (strcmp(str, argv[index]) == 0)
-          {
+          if (strcmp(str, argv[index]) == 0) {
             t.arg = argv[index];
             t.index = index;
             return t;
@@ -119,18 +107,15 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void release_argument(const argument &arg)
-    {
-      if (arg.index != 0)
-      {
+    void release_argument(const argument& arg) {
+      if (arg.index != 0) {
         assert(arg.index < argc);
         avail[arg.index >> 3] &= (ui8)(~(1 << (arg.index & 0x7)));
       }
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool is_exhausted()
-    {
+    bool is_exhausted() {
       for (int i = 1; i < argc; ++i)
         if (avail[i >> 3] & (1 << (i & 0x7)))
           return false;
@@ -138,22 +123,19 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    argument get_argument_zero()
-    {
+    argument get_argument_zero() {
       argument t;
       t.arg = argv[0];
       return t;
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    argument get_next_avail_argument(const argument &arg)
-    {
+    argument get_next_avail_argument(const argument& arg) {
       argument t;
       int idx = arg.index + 1;
       while (idx < argc && (avail[idx >> 3] & (1 << (idx & 0x7))) == 0)
         ++idx;
-      if (idx < argc)
-      {
+      if (idx < argc) {
         t.arg = argv[idx];
         t.index = idx;
       }
@@ -161,14 +143,11 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void reinterpret(const char *str, int &val)
-    {
+    void reinterpret(const char *str, int& val) {
       argument t = find_argument(str);
-      if (t.is_valid())
-      {
+      if (t.is_valid()) {
         argument t2 = get_next_value(t);
-        if (t2.is_valid())
-        {
+        if (t2.is_valid()) {
           val = atoi(t2.arg);
           release_argument(t);
           release_argument(t2);
@@ -177,14 +156,11 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void reinterpret(const char *str, ui32 &val)
-    {
+    void reinterpret(const char* str, ui32& val) {
       argument t = find_argument(str);
-      if (t.is_valid())
-      {
+      if (t.is_valid()) {
         argument t2 = get_next_value(t);
-        if (t2.is_valid())
-        {
+        if (t2.is_valid()) {
           val = (ui32)strtoul(t2.arg, NULL, 10);
           release_argument(t);
           release_argument(t2);
@@ -193,14 +169,11 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void reinterpret(const char *str, float &val)
-    {
+    void reinterpret(const char *str, float& val) {
       argument t = find_argument(str);
-      if (t.is_valid())
-      {
+      if (t.is_valid()) {
         argument t2 = get_next_value(t);
-        if (t2.is_valid())
-        {
+        if (t2.is_valid()) {
           val = strtof(t2.arg, NULL);
           release_argument(t);
           release_argument(t2);
@@ -209,22 +182,17 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void reinterpret(const char *str, bool &val)
-    {
+    void reinterpret(const char *str, bool& val) {
       argument t = find_argument(str);
-      if (t.is_valid())
-      {
+      if (t.is_valid()) {
         argument t2 = get_next_value(t);
-        if (t2.is_valid())
-        {
-          if (strcmp(t2.arg, "false") == 0)
-          {
+        if (t2.is_valid()) {
+          if (strcmp(t2.arg, "false") == 0) {
             val = false;
             release_argument(t);
             release_argument(t2);
           }
-          else if (strcmp(t2.arg, "true") == 0)
-          {
+          else if (strcmp(t2.arg, "true") == 0) {
             val = true;
             release_argument(t);
             release_argument(t2);
@@ -234,35 +202,28 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool reinterpret(const char *str)
-    {
+    bool reinterpret(const char *str) {
       argument t = find_argument(str);
-      if (t.is_valid())
-      {
+      if (t.is_valid()) {
         release_argument(t);
         return true;
       }
       else
         return false;
-    }
+    }    
 
     ///////////////////////////////////////////////////////////////////////////
-    void reinterpret_to_bool(const char *str, int &val)
-    {
+    void reinterpret_to_bool(const char *str, int& val) {
       argument t = find_argument(str);
-      if (t.is_valid())
-      {
+      if (t.is_valid()) {
         argument t2 = get_next_value(t);
-        if (t2.is_valid())
-        {
-          if (strcmp(t2.arg, "false") == 0)
-          {
+        if (t2.is_valid()) {
+          if (strcmp(t2.arg, "false") == 0) {
             val = 0;
             release_argument(t);
             release_argument(t2);
           }
-          else if (strcmp(t2.arg, "true") == 0)
-          {
+          else if (strcmp(t2.arg, "true") == 0) {
             val = 1;
             release_argument(t);
             release_argument(t2);
@@ -272,14 +233,11 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void reinterpret(const char *str, char *&val)
-    {
+    void reinterpret(const char *str, char *& val) {
       argument t = find_argument(str);
-      if (t.is_valid())
-      {
+      if (t.is_valid()) {
         argument t2 = get_next_value(t);
-        if (t2.is_valid())
-        {
+        if (t2.is_valid()) {
           val = t2.arg;
           release_argument(t);
           release_argument(t2);
@@ -288,20 +246,14 @@ namespace ojph
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    struct arg_inter_base
-    {
-      virtual void operate(const char *) = 0;
-    };
+    struct arg_inter_base { virtual void operate(const char *) = 0; };
 
     ///////////////////////////////////////////////////////////////////////////
-    void reinterpret(const char *str, arg_inter_base *fun)
-    {
+    void reinterpret(const char *str, arg_inter_base* fun) {
       argument t = find_argument(str);
-      if (t.is_valid())
-      {
+      if (t.is_valid()) {
         argument t2 = get_next_value(t);
-        if (t2.is_valid())
-        {
+        if (t2.is_valid()) {
           fun->operate(t2.arg);
           release_argument(t);
           release_argument(t2);
@@ -312,7 +264,7 @@ namespace ojph
   private:
     char **argv;
     int argc;
-    ui8 avail_store[16]; // this should be enough for 128 command line arguments
+    ui8 avail_store[16];//this should be enough for 128 command line arguments
     ui8 *avail;
   };
 }

--- a/Native/Common/OpenJPH/common/ojph_base.h
+++ b/Native/Common/OpenJPH/common/ojph_base.h
@@ -35,20 +35,20 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_BASE_H
 #define OJPH_BASE_H
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   /////////////////////////////////////////////////////////////////////////////
   struct size
   {
     explicit size(ui32 w = 0, ui32 h = 0) : w(w), h(h) {}
-    ui32 w; // width
-    ui32 h; // height
+    ui32 w; //width
+    ui32 h; //height
 
     ui64 area() const { return (ui64)w * (ui64)h; }
   };
@@ -65,7 +65,17 @@ namespace ojph
   {
     point org;
     size siz;
+
+    bool operator==(const rect& a) const {
+      return a.org.x == org.x && a.org.y == org.y
+        && a.siz.w == siz.w && a.siz.h == siz.h;
+    }
+
+    bool operator!=(const rect& a) const
+    { return !(a == *this); }
   };
+
+  /////////////////////////////////////////////////////////////////////////////
 
 }
 

--- a/Native/Common/OpenJPH/common/ojph_codestream.h
+++ b/Native/Common/OpenJPH/common/ojph_codestream.h
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_CODESTREAM_H
 #define OJPH_CODESTREAM_H
 
@@ -43,18 +44,16 @@
 #include "ojph_arch.h"
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  // local prototyping
-  namespace local
-  {
+  //local prototyping
+  namespace local {
     class codestream;
   };
 
   ////////////////////////////////////////////////////////////////////////////
-  // defined elsewhere
+  //defined elsewhere
   class param_siz;
   class param_cod;
   class param_qcd;
@@ -92,18 +91,35 @@ namespace ojph
     /**
      *  @brief default constructor
      *
-     *  This object instantiate the actual implementation object
+     *  This function instantiate the actual implementation object
      *  local::codestream, using new.
      *
      */
     codestream();
+
     /**
      *  @brief default destructor
      *
-     *  This object destroys the internal local::codestream object.
+     *  This function destroys the internal local::codestream object.
      *
      */
     ~codestream();
+
+    /**
+     *  @brief Restarts the codestream.
+     *
+     *  This function restarts the codestream; after this call, the
+     *  codestream object behaves like it has never been used before,
+     *  except that all memory allocations are preserved.  Thus, after
+     *  restart(), there is no need to allocate memory, unless the new
+     *  codestream needs more storage to store codeblocks, or has a
+     *  different structure.
+     *
+     *  restart() is useful if we are decoding multiple codestreams that
+     *  have largely the same structure and byte length.
+     *
+     */
+    void restart();
 
     /**
      *  @brief Sets the sequence of pushing or pull rows from the machinery.
@@ -132,7 +148,7 @@ namespace ojph
      *           OJPH_PN_STRING_XXXX, where only IMF and BROADCAST
      *           are currently supported.
      */
-    void set_profile(const char *s);
+    void set_profile(const char* s);
 
     /**
      *  @brief Sets the locations where a tile is partitioned into tile parts.
@@ -211,7 +227,7 @@ namespace ojph
      *
      */
     void write_headers(outfile_base *file,
-                       const comment_exchange *comments = NULL,
+                       const comment_exchange* comments = NULL,
                        ui32 num_comments = 0);
 
     /**
@@ -236,7 +252,7 @@ namespace ojph
      *                    exchange again to pass this line.
      */
 
-    line_buf *exchange(line_buf *line, ui32 &next_component);
+    line_buf* exchange(line_buf* line, ui32& next_component);
 
     /**
      * @brief This is the last call to a writing (encoding) codestream.
@@ -254,7 +270,7 @@ namespace ojph
      *        should be called before all other calls, before
      *        codestream::read_headers().
      */
-    void enable_resilience(); // before read_headers
+    void enable_resilience();             // before read_headers
 
     /**
      * @brief This call reads the headers of a codestream.  It is for a
@@ -287,7 +303,7 @@ namespace ojph
      *                              make sense otherwise.
      */
     void restrict_input_resolution(ui32 skipped_res_for_data,
-                                   ui32 skipped_res_for_recon); // before create
+                                   ui32 skipped_res_for_recon); //before create
 
     /**
      * @brief This call is for a decoding (or reading) codestream.  Call this
@@ -307,7 +323,7 @@ namespace ojph
      * @return line_buf* this object holds one row of the component indexed
      *                   by comp_num.
      */
-    line_buf *pull(ui32 &comp_num);
+    line_buf* pull(ui32 &comp_num);
 
     /**
      * @brief Call this function to close the underlying file; works for both
@@ -363,7 +379,7 @@ namespace ojph
     bool is_planar() const;
 
   private:
-    local::codestream *state;
+    local::codestream* state;
   };
 
 }

--- a/Native/Common/OpenJPH/common/ojph_defs.h
+++ b/Native/Common/OpenJPH/common/ojph_defs.h
@@ -35,36 +35,36 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_TYPES_H
 #define OJPH_TYPES_H
 
 #include <cstdint>
 #include "ojph_version.h"
 
-namespace ojph
-{
+namespace ojph {
 
-    /////////////////////////////////////////////////////////////////////////////
-    //                               types
-    /////////////////////////////////////////////////////////////////////////////
-    typedef uint8_t ui8;
-    typedef int8_t si8;
-    typedef uint16_t ui16;
-    typedef int16_t si16;
-    typedef uint32_t ui32;
-    typedef int32_t si32;
-    typedef uint64_t ui64;
-    typedef int64_t si64;
+/////////////////////////////////////////////////////////////////////////////
+//                               types
+/////////////////////////////////////////////////////////////////////////////
+typedef uint8_t ui8;
+typedef int8_t si8;
+typedef uint16_t ui16;
+typedef int16_t si16;
+typedef uint32_t ui32;
+typedef int32_t si32;
+typedef uint64_t ui64;
+typedef int64_t si64;
 
 /////////////////////////////////////////////////////////////////////////////
 #define OJPH_INT_STRINGIFY(I) #I
 #define OJPH_INT_TO_STRING(I) OJPH_INT_STRINGIFY(I)
 
-    /////////////////////////////////////////////////////////////////////////////
-    // number of fractional bits for 16 bit representation
-    // for 32 bits, it is NUM_FRAC_BITS + 16
-    // All numbers are in the range of [-0.5, 0.5)
-    const int NUM_FRAC_BITS = 13;
+/////////////////////////////////////////////////////////////////////////////
+// number of fractional bits for 16 bit representation
+// for 32 bits, it is NUM_FRAC_BITS + 16
+// All numbers are in the range of [-0.5, 0.5)
+const int NUM_FRAC_BITS = 13;
 
 /////////////////////////////////////////////////////////////////////////////
 #define ojph_div_ceil(a, b) (((a) + (b) - 1) / (b))
@@ -76,6 +76,7 @@ namespace ojph
 #define ojph_min(a, b) (((a) < (b)) ? (a) : (b))
 
 #define ojph_unused(x) (void)(x)
+
 
 }
 

--- a/Native/Common/OpenJPH/common/ojph_file.h
+++ b/Native/Common/OpenJPH/common/ojph_file.h
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_FILE_H
 #define OJPH_FILE_H
 
@@ -43,39 +44,38 @@
 
 #include "ojph_arch.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
 #ifdef OJPH_OS_WINDOWS
-  int inline ojph_fseek(FILE *stream, si64 offset, int origin)
+  int inline ojph_fseek(FILE* stream, si64 offset, int origin)
   {
     return _fseeki64(stream, offset, origin);
   }
 
-  si64 inline ojph_ftell(FILE *stream)
+  si64 inline ojph_ftell(FILE* stream)
   {
     return _ftelli64(stream);
   }
 #else
-  int inline ojph_fseek(FILE *stream, si64 offset, int origin)
+  int inline ojph_fseek(FILE* stream, si64 offset, int origin)
   {
     return fseeko(stream, offset, origin);
   }
 
-  si64 inline ojph_ftell(FILE *stream)
+  si64 inline ojph_ftell(FILE* stream)
   {
     return ftello(stream);
   }
 #endif
+
 
   ////////////////////////////////////////////////////////////////////////////
   class OJPH_EXPORT outfile_base
   {
   public:
   public:
-    enum seek : int
-    {
+    enum seek : int {
       OJPH_SEEK_SET = SEEK_SET,
       OJPH_SEEK_CUR = SEEK_CUR,
       OJPH_SEEK_END = SEEK_END
@@ -86,8 +86,7 @@ namespace ojph
     virtual si64 tell() { return 0; }
     virtual int seek(si64 offset, enum outfile_base::seek origin)
     {
-      ojph_unused(offset);
-      ojph_unused(origin);
+      ojph_unused(offset); ojph_unused(origin);
       return -1; /* always fail, to remind you to write an implementation */
     }
     virtual void flush() {}
@@ -99,11 +98,7 @@ namespace ojph
   {
   public:
     j2c_outfile() { fh = 0; }
-    ~j2c_outfile() override
-    {
-      if (fh)
-        fclose(fh);
-    }
+    ~j2c_outfile() override { if (fh) fclose(fh); }
 
     void open(const char *filename);
     size_t write(const void *ptr, size_t size) override;
@@ -136,9 +131,23 @@ namespace ojph
     /**  A destructor */
     ~mem_outfile() override;
 
+    mem_outfile(mem_outfile const&) = delete;
+    mem_outfile& operator=(mem_outfile const&) = delete;
+
+    /**
+     * Move construction leaves the moved-from value in default constructed state
+     * and transfers ownership of the internal state to the moved-to instance.
+     **/
+    mem_outfile(mem_outfile &&) noexcept;
+    /**
+     * move assignment with the same ownership transfer semantics as
+     * move construction.
+     **/
+    mem_outfile& operator=(mem_outfile&&) noexcept;
+
     /**
      *  @brief Call this function to open a memory file.
-     *
+	   *
      *  This function creates a memory buffer to be used for storing
      *  the generated j2k codestream.
      *
@@ -150,7 +159,7 @@ namespace ojph
 
     /**
      *  @brief Call this function to write data to the memory file.
-     *
+	   *
      *  This function adds new data to the memory file.  The memory buffer
      *  of the file grows as needed.
      *
@@ -176,39 +185,60 @@ namespace ojph
     int seek(si64 offset, enum outfile_base::seek origin) override;
 
     /** Call this function to close the file and deallocate memory
-     *
+	   *
      *  The object can be used again after calling close
      */
     void close() override;
 
     /**
      *  @brief Call this function to access memory file data.
-     *
+	   *
      *  It is not recommended to store the returned value because buffer
      *  storage address can change between write calls.
      *
      *  @return a constant pointer to the data.
      */
-    const ui8 *get_data() { return buf; }
+    const ui8* get_data() { return buf; }
 
     /**
      *  @brief Call this function to access memory file data (for const
      *         objects)
-     *
+	   *
      *  This is similar to the above function, except that it can be used
      *  with constant objects.
      *
      *  @return a constant pointer to the data.
      */
-    const ui8 *get_data() const { return buf; }
+    const ui8* get_data() const { return buf; }
 
     /**
      *  @brief Call this function to write the memory file data to a file
-     *
+	   *
      */
     void write_to_file(const char *file_name) const;
 
+    /**
+     *  @brief Call this function to get the used size of the memory file.
+     *
+     *  @return the used size of the memory file in bytes.
+     */
+    size_t get_used_size() const { return used_size; }
+
+    /**
+     *  @brief Call this function to get the total buffer size of the memory
+     *         file including unused space (this is the allocated memory).
+     *
+     *  @return the full size of the memory file in bytes.
+     */
+     size_t get_buf_size() const { return buf_size; }
+
   private:
+
+    /**
+     * @brief A utility function to swap the contents of two instances
+     */
+    void swap(mem_outfile& other) noexcept;
+  
     /**
      *  @brief This function expands storage by x1.5 needed space.
      *
@@ -227,14 +257,16 @@ namespace ojph
     size_t used_size;
     ui8 *buf;
     ui8 *cur_ptr;
+
+  private:
+    static const size_t ALIGNED_ALLOC_MASK = 4096 - 1;
   };
 
   ////////////////////////////////////////////////////////////////////////////
   class OJPH_EXPORT infile_base
   {
   public:
-    enum seek : int
-    {
+    enum seek : int {
       OJPH_SEEK_SET = SEEK_SET,
       OJPH_SEEK_CUR = SEEK_CUR,
       OJPH_SEEK_END = SEEK_END
@@ -242,9 +274,9 @@ namespace ojph
 
     virtual ~infile_base() {}
 
-    // read reads size bytes, returns the number of bytes read
+    //read reads size bytes, returns the number of bytes read
     virtual size_t read(void *ptr, size_t size) = 0;
-    // seek returns 0 on success
+    //seek returns 0 on success
     virtual int seek(si64 offset, enum infile_base::seek origin) = 0;
     virtual si64 tell() = 0;
     virtual bool eof() = 0;
@@ -256,17 +288,13 @@ namespace ojph
   {
   public:
     j2c_infile() { fh = 0; }
-    ~j2c_infile() override
-    {
-      if (fh)
-        fclose(fh);
-    }
+    ~j2c_infile() override { if (fh) fclose(fh); }
 
     void open(const char *filename);
 
-    // read reads size bytes, returns the number of bytes read
+    //read reads size bytes, returns the number of bytes read
     size_t read(void *ptr, size_t size) override;
-    // seek returns 0 on success
+    //seek returns 0 on success
     int seek(si64 offset, enum infile_base::seek origin) override;
     si64 tell() override;
     bool eof() override { return feof(fh) != 0; }
@@ -281,26 +309,40 @@ namespace ojph
   {
   public:
     mem_infile() { close(); }
-    ~mem_infile() override {}
+    ~mem_infile() override { }
 
-    void open(const ui8 *data, size_t size);
+    mem_infile(mem_infile const&) = delete;
+    mem_infile& operator=(mem_infile const&) = delete;
 
-    // read reads size bytes, returns the number of bytes read
+    /**
+     * Move construction leaves the moved-from value in default constructed state
+     * and transfers ownership of the internal state to the moved-to instance.
+     **/
+    mem_infile(mem_infile &&) noexcept;
+    /**
+     * move assignment with the same ownership transfer semantics as
+     * move construction.
+     **/
+    mem_infile& operator=(mem_infile&&) noexcept;
+
+    void open(const ui8* data, size_t size);
+
+    //read reads size bytes, returns the number of bytes read
     size_t read(void *ptr, size_t size) override;
-    // seek returns 0 on success
+    //seek returns 0 on success
     int seek(si64 offset, enum infile_base::seek origin) override;
     si64 tell() override { return cur_ptr - data; }
     bool eof() override { return cur_ptr >= data + size; }
-    void close() override
-    {
-      data = cur_ptr = NULL;
-      size = 0;
-    }
+    void close() override { data = cur_ptr = NULL; size = 0; }
 
   private:
+    // swap the contents of two instances
+    void swap(mem_infile&) noexcept;
+
     const ui8 *data, *cur_ptr;
     size_t size;
   };
+
 
 }
 

--- a/Native/Common/OpenJPH/common/ojph_mem.h
+++ b/Native/Common/OpenJPH/common/ojph_mem.h
@@ -35,6 +35,7 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_MEM_H
 #define OJPH_MEM_H
 
@@ -44,9 +45,14 @@
 #include <type_traits>
 
 #include "ojph_arch.h"
+#include "ojph_message.h"
 
-namespace ojph
-{
+namespace ojph {
+
+  extern "C" {
+    void* ojph_aligned_malloc(size_t alignment, size_t size);
+    void ojph_aligned_free(void* pointer);
+  }
 
   /////////////////////////////////////////////////////////////////////////////
   class mem_fixed_allocator
@@ -54,22 +60,21 @@ namespace ojph
   public:
     mem_fixed_allocator()
     {
-      avail_obj = avail_data = store = NULL;
-      avail_size_obj = avail_size_data = size_obj = size_data = 0;
+      store = NULL; allocated_data = 0;
+      restart();
     }
     ~mem_fixed_allocator()
     {
-      if (store)
-        free(store);
+      if (store) free(store);
     }
 
-    template <typename T>
+    template<typename T>
     void pre_alloc_data(size_t num_ele, ui32 pre_size)
     {
       pre_alloc_local<T, byte_alignment>(num_ele, pre_size, size_data);
     }
 
-    template <typename T>
+    template<typename T>
     void pre_alloc_obj(size_t num_ele)
     {
       pre_alloc_local<T, object_alignment>(num_ele, 0, size_obj);
@@ -77,50 +82,69 @@ namespace ojph
 
     void alloc()
     {
-      assert(store == NULL);
-      avail_obj = store = malloc(size_data + size_obj);
-      avail_data = (ui8 *)store + size_obj;
-      if (store == NULL)
-        throw "malloc failed";
+      assert(preallocation);
+      if (size_data + size_obj > allocated_data)
+      {
+        // We should be here once only, because, in subsequent, calls we
+        // should have size_data + size_obj <= allocated_data
+        free(store);
+        allocated_data = size_data + size_obj;
+        allocated_data = allocated_data + (allocated_data + 19) / 20; // 5%
+        store = malloc(allocated_data);
+        if (store == NULL)
+          OJPH_ERROR(0x00090001, "malloc failed");
+      }
+      avail_obj = store;
+      avail_data = (ui8*)store + size_obj;
       avail_size_obj = size_obj;
       avail_size_data = size_data;
+      preallocation = false;
     }
 
-    template <typename T>
-    T *post_alloc_data(size_t num_ele, ui32 pre_size)
+    void restart()
     {
-      return post_alloc_local<T, byte_alignment>(num_ele, pre_size, avail_size_data, avail_data);
+      avail_obj = avail_data = NULL;
+      avail_size_obj = avail_size_data = size_obj = size_data = 0;
+      preallocation = true;
     }
 
-    template <typename T>
-    T *post_alloc_obj(size_t num_ele)
+    template<typename T>
+    T* post_alloc_data(size_t num_ele, ui32 pre_size)
     {
-      return post_alloc_local<T, object_alignment>(num_ele, 0, avail_size_obj, avail_obj);
+      return post_alloc_local<T, byte_alignment>
+        (num_ele, pre_size, avail_size_data, avail_data);
+    }
+
+    template<typename T>
+    T* post_alloc_obj(size_t num_ele)
+    {
+      return post_alloc_local<T, object_alignment>
+        (num_ele, 0, avail_size_obj, avail_obj);
     }
 
   private:
-    template <typename T, int N>
-    void pre_alloc_local(size_t num_ele, ui32 pre_size, size_t &sz)
+    template<typename T, int N>
+    void pre_alloc_local(size_t num_ele, ui32 pre_size, size_t& sz)
     {
-      assert(store == NULL);
+      assert(preallocation);
       num_ele = calc_aligned_size<T, N>(num_ele);
       size_t total = (num_ele + pre_size) * sizeof(T);
-      total += 2 * N - 1;
+      total += 2*N - 1;
 
       sz += total;
     }
 
-    template <typename T, int N>
-    T *post_alloc_local(size_t num_ele, ui32 pre_size,
-                        size_t &avail_sz, void *&avail_p)
+    template<typename T, int N>
+    T* post_alloc_local(size_t num_ele, ui32 pre_size,
+                        size_t& avail_sz, void*& avail_p)
     {
-      assert(store != NULL);
+      assert(!preallocation);
       num_ele = calc_aligned_size<T, N>(num_ele);
       size_t total = (num_ele + pre_size) * sizeof(T);
-      total += 2 * N - 1;
+      total += 2*N - 1;
 
-      T *p = align_ptr<T, N>((T *)avail_p + pre_size);
-      avail_p = (ui8 *)avail_p + total;
+      T* p = align_ptr<T, N>((T*)avail_p + pre_size);
+      avail_p = (ui8*)avail_p + total;
       avail_sz -= total;
       assert((avail_sz & 0x8000000000000000llu) == 0);
       return p;
@@ -128,51 +152,47 @@ namespace ojph
 
     void *store, *avail_data, *avail_obj;
     size_t size_data, size_obj, avail_size_obj, avail_size_data;
+    size_t allocated_data;
+    bool preallocation;
   };
 
   /////////////////////////////////////////////////////////////////////////////
   class line_buf
   {
   public:
-    enum : ui32
-    {
-      LFT_UNDEFINED = 0x00, // Type is undefined/uninitialized
-                            // These flags reflects data size in bytes
-      LFT_BYTE = 0x01,      // Set when data is 1 byte  (not used)
-      LFT_16BIT = 0x02,     // Set when data is 2 bytes (not used)
-      LFT_32BIT = 0x04,     // Set when data is 4 bytes
-      LFT_64BIT = 0x08,     // Set when data is 8 bytes
-      LFT_INTEGER = 0x10,   // Set when data is an integer, in other words
-                            // 32bit integer, not 32bit float
-      LFT_SIZE_MASK = 0x0F, // To extract data size
+    enum : ui32 {
+      LFT_UNDEFINED  = 0x00, // Type is undefined/uninitialized
+                             // These flags reflects data size in bytes
+      LFT_BYTE       = 0x01, // Set when data is 1 byte  (not used)
+      LFT_16BIT      = 0x02, // Set when data is 2 bytes (not used)
+      LFT_32BIT      = 0x04, // Set when data is 4 bytes
+      LFT_64BIT      = 0x08, // Set when data is 8 bytes
+      LFT_INTEGER    = 0x10, // Set when data is an integer, in other words
+                             // 32bit integer, not 32bit float
+      LFT_SIZE_MASK  = 0x0F, // To extract data size
     };
 
   public:
     line_buf() : size(0), pre_size(0), flags(LFT_UNDEFINED), i32(0) {}
 
-    template <typename T>
+    template<typename T>
     void wrap(T *buffer, size_t num_ele, ui32 pre_size);
 
     size_t size;
     ui32 pre_size;
     ui32 flags;
-    union
-    {
-      si32 *i32;  // 32bit integer type, used for lossless compression
-      si64 *i64;  // 64bit integer type, used for lossless compression
-      float *f32; // float type, used for lossy compression
-      void *p;    // no type is associated with the pointer
+    union {
+      si32* i32;  // 32bit integer type, used for lossless compression
+      si64* i64;  // 64bit integer type, used for lossless compression
+      float* f32; // float type, used for lossy compression
+      void* p;    // no type is associated with the pointer
     };
   };
 
   /////////////////////////////////////////////////////////////////////////////
   struct lifting_buf
   {
-    lifting_buf()
-    {
-      line = NULL;
-      active = false;
-    }
+    lifting_buf() { line = NULL;  active = false; }
     line_buf *line;
     bool active;
   };
@@ -184,13 +204,13 @@ namespace ojph
     {
       next_list = NULL;
       avail_size = buf_size = size;
-      this->buf = (ui8 *)this + sizeof(coded_lists);
+      this->buf = (ui8*)this + sizeof(coded_lists);
     }
 
-    coded_lists *next_list;
+    coded_lists* next_list;
     ui32 buf_size;
     ui32 avail_size;
-    ui8 *buf;
+    ui8* buf;
   };
 
   /////////////////////////////////////////////////////////////////////////////
@@ -202,47 +222,69 @@ namespace ojph
 
   public:
     mem_elastic_allocator(ui32 chunk_size)
-        : chunk_size(chunk_size)
-    {
-      cur_store = store = NULL;
-      total_allocated = 0;
-    }
+    : chunk_size(chunk_size)
+    { cur_store = store = avail = NULL; total_allocated = 0; }
 
     ~mem_elastic_allocator()
     {
-      while (store)
-      {
-        stores_list *t = store->next_store;
+      while (store) { // stores in use
+        stores_list* t = store->next_store;
         free(store);
         store = t;
       }
+      while (avail) { // available stores
+        stores_list* t = avail->next_store;
+        free(avail);
+        avail = t;
+      }
     }
 
-    void get_buffer(ui32 needed_bytes, coded_lists *&p);
+    void get_buffer(ui32 needed_bytes, coded_lists*& p);
+    void restart();
 
   private:
     struct stores_list
     {
+      // Payload (coded_lists + bitstream) must start at a multiple of 16 bytes.
+      // Otherwise coded_lists::buf can be 4 mod 8, which causes misalignment
+      // on 32-bit architectures. So round sizeof(stores_list) to next
+      // multiple of 16.
+      static constexpr ui32 stores_list_size16()
+      {
+        return (ui32) ((sizeof (stores_list) + 15u) & ~15u);
+      }
       stores_list(ui32 available_bytes)
       {
         this->next_store = NULL;
-        this->available = available_bytes;
-        this->data = (ui8 *)this + sizeof(stores_list);
+        this->orig_size = this->available = available_bytes;
+        this->orig_data = this->data = (ui8*)this + stores_list_size16();
+      }
+      void restart()
+      {
+        this->next_store = NULL;
+        this->available = this->orig_size;
+        this->data = this->orig_data;
       }
       static ui32 eval_store_bytes(ui32 available_bytes)
       { // calculates how many bytes need to be allocated
-        return available_bytes + (ui32)sizeof(stores_list);
+        return available_bytes + stores_list_size16();
       }
       stores_list *next_store;
-      ui32 available;
-      ui8 *data;
+      ui8 *orig_data, *data;
+      ui32 orig_size, available;
     };
 
-    stores_list *store, *cur_store;
+    stores_list* allocate(stores_list** list, ui32 extended_bytes);
+
+    stores_list *store;
+    stores_list *cur_store;
+    stores_list *avail;
     size_t total_allocated;
     const ui32 chunk_size;
   };
 
+
 }
+
 
 #endif // !OJPH_MEM_H

--- a/Native/Common/OpenJPH/common/ojph_message.h
+++ b/Native/Common/OpenJPH/common/ojph_message.h
@@ -41,8 +41,7 @@
 #include <cstring>
 #include "ojph_arch.h"
 
-namespace ojph
-{
+namespace ojph {
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -52,11 +51,12 @@ namespace ojph
    */
   enum OJPH_MSG_LEVEL : int
   {
-    ALL_MSG = 0, // uninitialized or print all message
-    INFO = 1,    // info message
-    WARN = 2,    // warning message
-    ERROR = 3,   // error message (the highest severity)
-    NO_MSG = 4,  // no message (higher severity for message printing only)
+    OJPH_MSG_ALL_MSG = 0,  // uninitialized or print all message
+    OJPH_MSG_INFO = 1,     // info message
+    OJPH_MSG_WARN = 2,     // warning message
+    OJPH_MSG_ERROR = 3,    // error message (the highest severity)
+    OJPH_MSG_NO_MSG = 4,   // no message (higher severity for message printing
+                           // only)
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -89,8 +89,7 @@ namespace ojph
    *  Importantly it defined the base virtual operator() that must be defined
    *  in all derived classes.
    */
-  class OJPH_EXPORT message_base
-  {
+  class OJPH_EXPORT message_base {
   public:
     /**
      * @brief Prints a message and for errors throws an exception.
@@ -103,8 +102,8 @@ namespace ojph
      * @param ...       A variable number of parameters to print.  This is
      *                  the parameters you would pass to printf.
      */
-    virtual void operator()(int warn_code, const char *file_name,
-                            int line_num, const char *fmt, ...) = 0;
+      virtual void operator() (int warn_code, const char* file_name,
+        int line_num, const char *fmt, ...) = 0;
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -113,13 +112,13 @@ namespace ojph
    */
   class OJPH_EXPORT message_info : public message_base
   {
-  public:
-    /**
-     * @brief See the base message_base::operator() for details about
-     *        parameters
-     */
-    virtual void operator()(int info_code, const char *file_name,
-                            int line_num, const char *fmt, ...);
+    public:
+      /**
+       * @brief See the base message_base::operator() for details about
+       *        parameters
+       */
+      virtual void operator() (int info_code, const char* file_name,
+        int line_num, const char* fmt, ...);
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -131,7 +130,7 @@ namespace ojph
    *          a log file, or NULL if no info messages are desired.
    */
   OJPH_EXPORT
-  void set_info_stream(FILE *s);
+    void set_info_stream(FILE* s);
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -141,7 +140,7 @@ namespace ojph
    *             behaviour.
    */
   OJPH_EXPORT
-  void configure_info(message_info *info);
+    void configure_info(message_info* info);
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -154,7 +153,7 @@ namespace ojph
    *         below.
    */
   OJPH_EXPORT
-  message_info *get_info();
+    message_info* get_info();
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -162,13 +161,13 @@ namespace ojph
    */
   class OJPH_EXPORT message_warning : public message_base
   {
-  public:
-    /**
-     * @brief See the base message_base::operator() for details about
-     *        parameters
-     */
-    virtual void operator()(int warn_code, const char *file_name,
-                            int line_num, const char *fmt, ...);
+    public:
+      /**
+       * @brief See the base message_base::operator() for details about
+       *        parameters
+       */
+      virtual void operator() (int warn_code, const char* file_name,
+        int line_num, const char* fmt, ...);
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -180,7 +179,7 @@ namespace ojph
    *          a log file, or NULL if no warning messages are desired.
    */
   OJPH_EXPORT
-  void set_warning_stream(FILE *s);
+    void set_warning_stream(FILE* s);
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -190,7 +189,7 @@ namespace ojph
    *             desired behaviour.
    */
   OJPH_EXPORT
-  void configure_warning(message_warning *warn);
+    void configure_warning(message_warning* warn);
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -203,7 +202,7 @@ namespace ojph
    *         the macros below.
    */
   OJPH_EXPORT
-  message_warning *get_warning();
+    message_warning* get_warning();
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -211,13 +210,13 @@ namespace ojph
    */
   class OJPH_EXPORT message_error : public message_base
   {
-  public:
-    /**
-     * @brief See the base message_base::operator() for details about
-     *        parameters
-     */
-    virtual void operator()(int warn_code, const char *file_name,
-                            int line_num, const char *fmt, ...);
+    public:
+      /**
+       * @brief See the base message_base::operator() for details about
+       *        parameters
+       */
+      virtual void operator() (int warn_code, const char* file_name,
+        int line_num, const char *fmt, ...);
   };
 
   //////////////////////////////////////////////////////////////////////////////
@@ -229,7 +228,7 @@ namespace ojph
    *          a log file, or NULL if no error messages are desired.
    */
   OJPH_EXPORT
-  void set_error_stream(FILE *s);
+    void set_error_stream(FILE *s);
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -240,7 +239,7 @@ namespace ojph
    *              at the end.
    */
   OJPH_EXPORT
-  void configure_error(message_error *error);
+    void configure_error(message_error* error);
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -253,7 +252,7 @@ namespace ojph
    *         the macros below.
    */
   OJPH_EXPORT
-  message_error *get_error();
+    message_error* get_error();
 
   //////////////////////////////////////////////////////////////////////////////
   /**
@@ -263,7 +262,7 @@ namespace ojph
    *              OJPH_MSG_LEVEL.
    */
   OJPH_EXPORT
-  void set_message_level(OJPH_MSG_LEVEL level);
+    void set_message_level(OJPH_MSG_LEVEL level);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -271,28 +270,23 @@ namespace ojph
  * @brief MACROS to remove the directory name from the file name
  */
 #if (defined OJPH_OS_WINDOWS)
-#define __OJPHFILE__ \
-  (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+  #define __OJPHFILE__ \
+    (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
 #else
-#define __OJPHFILE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+  #define __OJPHFILE__ \
+    (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
 /**
  * @brief MACROs to insert file and line number for info, warning, and error
  */
-#define OJPH_INFO(t, ...)                                        \
-  {                                                              \
-    ojph::get_info()[0](t, __OJPHFILE__, __LINE__, __VA_ARGS__); \
-  }
-#define OJPH_WARN(t, ...)                                           \
-  {                                                                 \
-    ojph::get_warning()[0](t, __OJPHFILE__, __LINE__, __VA_ARGS__); \
-  }
-#define OJPH_ERROR(t, ...)                                        \
-  {                                                               \
-    ojph::get_error()[0](t, __OJPHFILE__, __LINE__, __VA_ARGS__); \
-  }
+#define OJPH_INFO(t, ...) \
+  { ojph::get_info()[0](t, __OJPHFILE__, __LINE__, __VA_ARGS__); }
+#define OJPH_WARN(t, ...) \
+  { ojph::get_warning()[0](t, __OJPHFILE__, __LINE__, __VA_ARGS__); }
+#define OJPH_ERROR(t, ...) \
+  { ojph::get_error()[0](t, __OJPHFILE__, __LINE__,__VA_ARGS__); }
+
 
 #endif // !OJPH_MESSAGE_H

--- a/Native/Common/OpenJPH/common/ojph_params.h
+++ b/Native/Common/OpenJPH/common/ojph_params.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,14 +35,14 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_PARAMS_H
 #define OJPH_PARAMS_H
 
 #include "ojph_arch.h"
 #include "ojph_base.h"
 
-namespace ojph
-{
+namespace ojph {
 
   /***************************************************************************/
   // defined here
@@ -56,8 +56,7 @@ namespace ojph
 
   /***************************************************************************/
   // prototyping from local
-  namespace local
-  {
+  namespace local {
     struct param_siz;
     struct param_cod;
     struct param_coc;
@@ -73,16 +72,16 @@ namespace ojph
   public:
     param_siz(local::param_siz *p) : state(p) {}
 
-    // setters
+    //setters
     void set_image_extent(point extent);
     void set_tile_size(size s);
     void set_image_offset(point offset);
     void set_tile_offset(point offset);
     void set_num_components(ui32 num_comps);
-    void set_component(ui32 comp_num, const point &downsampling,
+    void set_component(ui32 comp_num, const point& downsampling,
                        ui32 bit_depth, bool is_signed);
 
-    // getters
+    //getters
     point get_image_extent() const;
     point get_image_offset() const;
     size get_tile_size() const;
@@ -92,23 +91,23 @@ namespace ojph
     bool is_signed(ui32 comp_num) const;
     point get_downsampling(ui32 comp_num) const;
 
-    // deeper getters
+    //deeper getters
     ui32 get_recon_width(ui32 comp_num) const;
     ui32 get_recon_height(ui32 comp_num) const;
 
   private:
-    local::param_siz *state;
+    local::param_siz* state;
   };
 
   /***************************************************************************/
   class OJPH_EXPORT param_cod
   {
   public:
-    param_cod(local::param_cod *p) : state(p) {}
+    param_cod(local::param_cod* p) : state(p) {}
 
     void set_num_decomposition(ui32 num_decompositions);
     void set_block_dims(ui32 width, ui32 height);
-    void set_precinct_size(int num_levels, size *precinct_size);
+    void set_precinct_size(int num_levels, size* precinct_size);
     void set_progression_order(const char *name);
     void set_color_transform(bool color_transform);
     void set_reversible(bool reversible);
@@ -121,7 +120,7 @@ namespace ojph
     size get_precinct_size(ui32 level_num) const;
     size get_log_precinct_size(ui32 level_num) const;
     int get_progression_order() const;
-    const char *get_progression_order_as_string() const;
+    const char* get_progression_order_as_string() const;
     int get_num_layers() const;
     bool is_using_color_transform() const;
     bool packets_may_use_sop() const;
@@ -129,18 +128,18 @@ namespace ojph
     bool get_block_vertical_causality() const;
 
   private:
-    local::param_cod *state;
+    local::param_cod* state;
   };
 
   /***************************************************************************/
   class OJPH_EXPORT param_coc
   {
   public:
-    param_coc(local::param_cod *p) : state(p) {}
+    param_coc(local::param_cod* p) : state(p) {}
 
     void set_num_decomposition(ui32 num_decompositions);
     void set_block_dims(ui32 width, ui32 height);
-    void set_precinct_size(int num_levels, size *precinct_size);
+    void set_precinct_size(int num_levels, size* precinct_size);
     void set_reversible(bool reversible);
 
     ui32 get_num_decompositions() const;
@@ -152,158 +151,152 @@ namespace ojph
     bool get_block_vertical_causality() const;
 
   private:
-    local::param_cod *state;
+    local::param_cod* state;
   };
 
   /***************************************************************************/
   /**
-   * @brief Quantization parameters object
-   *
-   */
+    * @brief Quantization parameters object
+    * 
+    */
   class OJPH_EXPORT param_qcd
   {
   public:
-    param_qcd(local::param_qcd *p) : state(p) {}
+    param_qcd(local::param_qcd* p) : state(p) {}
 
     /**
-     * @brief Set the irreversible quantization base delta.
-     *
-     * This represents the default base delta and influences QCD marker
+     * @brief Set the irreversible quantization base delta.  
+     *  
+     * This represents the default base delta and influences QCD marker 
      * segment
-     *
-     * @param delta
+     * 
+     * @param delta 
      */
     void set_irrev_quant(float delta);
 
     /**
-     * @brief Set the irreversible quantization base delta for a specific
+     * @brief Set the irreversible quantization base delta for a specific 
      *        component
-     *
-     * This represents the default base delta for component comp_idx, and
+     * 
+     * This represents the default base delta for component comp_idx, and 
      * influences QCC marker segment for the component, inserting one
      * if needed, which is usually the case.
-     *
-     * @param comp_idx
-     * @param delta
+     * 
+     * @param comp_idx 
+     * @param delta 
      */
     void set_irrev_quant(ui32 comp_idx, float delta);
 
   private:
-    local::param_qcd *state;
+    local::param_qcd* state;
   };
 
   /*************************************************************************/
   /**
     * @brief non-linearity point transformation object
     *        (implements NLT marker segment)
-    *
-    *  There are a few things to know here.
-      * The NLT marker segment contains the nonlinearity type and the
+    * 
+    *  There are a few things to know here.  
+      * The NLT marker segment contains the nonlinearity type and the 
       * bit depth and signedness of the component to which it applies.
-      * There is the default component ALL_COMPS which applies to all
+      * There is the default component ALL_COMPS which applies to all 
       * components unless it is overridden by another NLT segment marker.
       * The library checks that the settings make sense, and also make
       * sure that bit depth and signedness are correct, creating any missing
       * NLT marker segments in the process.
       * If all components have the same bit depth and signedness, and need
-      * nonlinearity type 3 (Binary Complement to Sign Magnitude Conversion),
+      * nonlinearity type 3 (Binary Complement to Sign Magnitude Conversion), 
       * then the best option is to set ALL_COMPS to type 3.
-      * Otherwise, the best option is to set type 3 only to components that
+      * Otherwise, the best option is to set type 3 only to components that 
       * need it, leaving out the default ALL_COMPS nonlinearity not set.
-      * Another option is for the end-user can set the ALL_COMPS to type 3,
-      * and then put exception for the components that does not need type 3,
+      * Another option is for the end-user can set the ALL_COMPS to type 3, 
+      * and then put exception for the components that does not need type 3, 
       * by setting them to type 0.
-      *
+      * 
       * The library, during validity check, which is run when the codestream
       * is created for writing, will do the following:
-      * -- If ALL_COMPS is set to type 0, it will be ignored, and the
+      * -- If ALL_COMPS is set to type 0, it will be ignored, and the 
       * codestream will NOT have the corresponding NLT marker segment.
       * -- If ALL_COMPS is set to type 3, then the following will happen:
-      *   - If all the components (except those with type 0 set for them) have
-      *   the same bit depth and signedness, then the ALL_COMPS NLT marker
+      *   - If all the components (except those with type 0 set for them) have 
+      *   the same bit depth and signedness, then the ALL_COMPS NLT marker 
       *   segment will be respected and inserted into the codestream.
       *   Of course, components with NLT 0 will also have the corresponding
       *   NLT marker segment inserted.
       *   - If components, for which no NTL type 0 is specified, have differing
-      *   bit depth or signedness, then the ALL_COMPS will be ignored, and
+      *   bit depth or signedness, then the ALL_COMPS will be ignored, and 
       *   NLT markers are inserted for each component that needs type 3.
       * Components that have their component field larger than the number of
       * components in the codestream are removed.
-      *
-      * It also worth noting that type 3 nonlinearity has no effect on
-      * positive image samples.  It is also not recommended for integer-valued
-      * types. It is only recommended for floating-point image samples, for
-      * which some of the samples are negative, where type 3 nonlinearity
-      * should be beneficial.  This is because the encoding engine expects
-      * two-complement representation for negative values while floating point
-      * numbers have a sign bit followed by an exponent, which has a biased
+      * 
+      * It also worth noting that type 3 nonlinearity has no effect on 
+      * positive image samples.  It is also not recommended for integer-valued 
+      * types. It is only recommended for floating-point image samples, for 
+      * which some of the samples are negative, where type 3 nonlinearity 
+      * should be beneficial.  This is because the encoding engine expects 
+      * two-complement representation for negative values while floating point 
+      * numbers have a sign bit followed by an exponent, which has a biased 
       * integer representation.  The core idea is to make floating-point
       * representation more compatible with integer representation.
 
-    *
+    * 
     */
   class OJPH_EXPORT param_nlt
   {
   public:
-    enum special_comp_num : ui16
-    {
-      ALL_COMPS = 65535
-    };
-    enum nonlinearity : ui8
-    {
+    enum special_comp_num : ui16 { ALL_COMPS = 65535 };
+    enum nonlinearity : ui8 { 
       OJPH_NLT_NO_NLT = 0,                // supported
       OJPH_NLT_GAMMA_STYLE_NLT = 1,       // not supported
       OJPH_NLT_LUT_STYLE_NLT = 2,         // not supported
       OJPH_NLT_BINARY_COMPLEMENT_NLT = 3, // supported
-      OJPH_NLT_UNDEFINED = 255            // This is used internally and is
-                                          // not part of the standard
+      OJPH_NLT_UNDEFINED = 255          // This is used internally and is 
+                                          // not part of the standard 
     };
-
   public:
-    param_nlt(local::param_nlt *p) : state(p) {}
+    param_nlt(local::param_nlt* p) : state(p) {}
 
     /**
-     * @brief enables or disables type 3 nonlinearity for a component
-     *        or the default setting
-     *
-     * When creating a codestream for writing, call this function before
-     * you call codestream::write_headers.
-     *
-     *
-     * @param comp_num: component number, or 65535 for the default setting
-     * @param type: desired non-linearity from enum nonlinearity
-     */
+      * @brief enables or disables type 3 nonlinearity for a component 
+      *        or the default setting
+      * 
+      * When creating a codestream for writing, call this function before
+      * you call codestream::write_headers.
+      * 
+      * 
+      * @param comp_num: component number, or 65535 for the default setting
+      * @param type: desired non-linearity from enum nonlinearity
+      */
     void set_nonlinear_transform(ui32 comp_num, ui8 nl_type);
 
     /**
-     * @brief get the nonlinearity type associated with comp_num, which
-     *        should be one from enum nonlinearity
-     *
-     * @param comp_num: component number, or 65535 for the default setting
-     * @param bit_depth: returns the bit depth of the component/default
-     * @param is_signed: returns true if the component/default is signed
-     * @param type: nonlinearity type
-     * @return true if the nonlinearity for comp_num is set
-     */
-    bool get_nonlinear_transform(ui32 comp_num, ui8 &bit_depth,
-                                 bool &is_signed, ui8 &nl_type) const;
+      * @brief get the nonlinearity type associated with comp_num, which 
+      *        should be one from enum nonlinearity
+      *
+      * @param comp_num: component number, or 65535 for the default setting
+      * @param bit_depth: returns the bit depth of the component/default
+      * @param is_signed: returns true if the component/default is signed
+      * @param type: nonlinearity type
+      * @return true if the nonlinearity for comp_num is set
+      */
+    bool get_nonlinear_transform(ui32 comp_num, ui8& bit_depth, 
+                                 bool& is_signed, ui8& nl_type) const;
 
   private:
-    local::param_nlt *state;
+    local::param_nlt* state;
   };
 
   /***************************************************************************/
   class OJPH_EXPORT comment_exchange
   {
     friend class local::codestream;
-
   public:
     comment_exchange() : data(NULL), len(0), Rcom(0) {}
-    void set_string(const char *str);
-    void set_data(const char *data, ui16 len);
+    void set_string(const char* str);
+    void set_data(const char* data, ui16 len);
 
   private:
-    const char *data;
+    const char* data;
     ui16 len;
     ui16 Rcom;
   };

--- a/Native/Common/OpenJPH/common/ojph_version.h
+++ b/Native/Common/OpenJPH/common/ojph_version.h
@@ -34,5 +34,5 @@
 //***************************************************************************/
 
 #define OPENJPH_VERSION_MAJOR 0
-#define OPENJPH_VERSION_MINOR 21
-#define OPENJPH_VERSION_PATCH 2
+#define OPENJPH_VERSION_MINOR 29
+#define OPENJPH_VERSION_PATCH 0

--- a/Native/Common/OpenJPH/others/ojph_arch.cpp
+++ b/Native/Common/OpenJPH/others/ojph_arch.cpp
@@ -2,21 +2,22 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -39,52 +40,48 @@
 
 #include "ojph_arch.h"
 
-namespace ojph
-{
+namespace ojph {
 
 #ifndef OJPH_DISABLE_SIMD
 
-#if (defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
+  #if (defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
   ////////////////////////////////////////////////////////////////////////////
   // This snippet is borrowed from Intel; see for example
   // https://software.intel.com/en-us/articles/
   // how-to-detect-knl-instruction-support
-  bool run_cpuid(uint32_t eax, uint32_t ecx, uint32_t *abcd)
+  bool run_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd)
   {
-#ifdef OJPH_COMPILER_MSVC
+  #ifdef OJPH_COMPILER_MSVC
     __cpuidex((int *)abcd, eax, ecx);
-#else
+  #else
     uint32_t ebx = 0, edx = 0;
-#if defined(__i386__) && defined(__PIC__)
+  #if defined( __i386__ ) && defined ( __PIC__ )
     /* in case of PIC under 32-bit EBX cannot be clobbered */
-    __asm__("movl %%ebx, %%edi \n\t cpuid \n\t xchgl %%ebx, %%edi"
-            : "=D"(ebx), "+a"(eax), "+c"(ecx), "=d"(edx));
-#else
-    __asm__("cpuid" : "+b"(ebx), "+a"(eax), "+c"(ecx), "=d"(edx));
-#endif
-    abcd[0] = eax;
-    abcd[1] = ebx;
-    abcd[2] = ecx;
-    abcd[3] = edx;
-#endif
+    __asm__ ( "movl %%ebx, %%edi \n\t cpuid \n\t xchgl %%ebx, %%edi"
+              : "=D" (ebx), "+a" (eax), "+c" (ecx), "=d" (edx) );
+  #else
+    __asm__ ( "cpuid" : "+b" (ebx), "+a" (eax), "+c" (ecx), "=d" (edx) );
+  #endif
+    abcd[0] = eax; abcd[1] = ebx; abcd[2] = ecx; abcd[3] = edx;
+  #endif
     return true;
   }
 
   ////////////////////////////////////////////////////////////////////////////
   uint64_t read_xcr(uint32_t index)
   {
-#ifdef OJPH_COMPILER_MSVC
+  #ifdef OJPH_COMPILER_MSVC
     return _xgetbv(index);
-#else
+  #else
     uint32_t eax = 0, edx = 0;
-    __asm__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
+    __asm__ ( "xgetbv" : "=a" (eax), "=d" (edx) : "c" (index) );
     return ((uint64_t)edx << 32) | eax;
-#endif
+  #endif
   }
 
   /////////////////////////////////////////////////////////////////////////////
-  bool init_cpu_ext_level(int &level)
+  bool init_cpu_ext_level(int& level)
   {
     uint32_t mmx_abcd[4];
     run_cpuid(1, 0, mmx_abcd);
@@ -111,14 +108,13 @@ namespace ojph
             {
               level = X86_CPU_EXT_LEVEL_SSSE3;
               bool sse41_avail = ((mmx_abcd[2] & 0x00080000) == 0x00080000);
-              if (sse41_avail)
-              {
+              if (sse41_avail) {
                 level = X86_CPU_EXT_LEVEL_SSE41;
                 bool sse42_avail = ((mmx_abcd[2] & 0x00100000) == 0x00100000);
                 if (sse42_avail)
                 {
                   level = X86_CPU_EXT_LEVEL_SSE42;
-
+                  
                   uint64_t xcr_val = 0;
                   bool osxsave_avail, ymm_avail, avx_avail = false;
                   osxsave_avail = ((mmx_abcd[2] & 0x08000000) == 0x08000000);
@@ -139,17 +135,21 @@ namespace ojph
                     {
                       level = X86_CPU_EXT_LEVEL_AVX2;
                       bool avx2fma_avail =
-                          avx2_avail && ((mmx_abcd[2] & 0x1000) == 0x1000);
+                        avx2_avail && ((mmx_abcd[2] & 0x1000) == 0x1000);
                       if (avx2fma_avail)
                       {
                         level = X86_CPU_EXT_LEVEL_AVX2FMA;
 
                         bool zmm_avail =
-                            osxsave_avail && ((xcr_val & 0xE0) == 0xE0);
+                          osxsave_avail && ((xcr_val & 0xE0) == 0xE0);
                         bool avx512f_avail = (avx2_abcd[1] & 0x10000) != 0;
                         bool avx512cd_avail = (avx2_abcd[1] & 0x10000000) != 0;
-                        bool avx512_avail =
-                            zmm_avail && avx512f_avail && avx512cd_avail;
+                        bool avx512bw_avail = (avx2_abcd[1] & 0x40000000) != 0;
+                        bool avx512vl_avail =
+                          (avx2_abcd[1] & 0x80000000u) != 0;
+                        bool avx512_avail = zmm_avail && avx512f_avail
+                          && avx512cd_avail && avx512bw_avail
+                          && avx512vl_avail;
                         if (avx512_avail)
                           level = X86_CPU_EXT_LEVEL_AVX512;
                       }
@@ -164,76 +164,85 @@ namespace ojph
     }
     return true;
   }
-#elif defined(OJPH_ARCH_ARM)
+  #elif defined(OJPH_ARCH_ARM)
 
-#ifndef OJPH_OS_LINUX // Windows/Apple/Android
+    #if !defined(OJPH_OS_LINUX) && !defined(OJPH_OS_FREEBSD) && !defined(OJPH_OS_OPENBSD) // Windows/Apple/Android
 
-  bool init_cpu_ext_level(int &level)
-  {
-    level = ARM_CPU_EXT_LEVEL_ASIMD;
-    return true;
-  }
-
-#else // Linux
-
-#if defined(__aarch64__) || defined(_M_ARM64) // 64-bit ARM
-
-#include <sys/auxv.h>
-#include <asm/hwcap.h>
-
-  bool init_cpu_ext_level(int &level)
-  {
-    unsigned long hwcaps = getauxval(AT_HWCAP);
-    unsigned long hwcaps2 = getauxval(AT_HWCAP2);
-
-    level = ARM_CPU_EXT_LEVEL_GENERIC;
-    if (hwcaps & HWCAP_ASIMD)
-    {
+    bool init_cpu_ext_level(int& level) {
       level = ARM_CPU_EXT_LEVEL_ASIMD;
-      if (hwcaps & HWCAP_SVE)
-      {
-        level = ARM_CPU_EXT_LEVEL_SVE;
-        if (hwcaps2 & HWCAP2_SVE2)
-          level = ARM_CPU_EXT_LEVEL_SVE2;
-      }
+      return true;
     }
-    return true;
-  }
 
-#else // 32-bit ARM
+    #else  // Linux/FreeBSD/OpenBSD
 
-#include <sys/auxv.h>
-#include <asm/hwcap.h>
+      #if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) // 64-bit ARM
 
-  bool init_cpu_ext_level(int &level)
-  {
-    unsigned long hwcaps = getauxval(AT_HWCAP);
-    level = ARM_CPU_EXT_LEVEL_GENERIC;
-    if (hwcaps & HWCAP_NEON)
-      level = ARM_CPU_EXT_LEVEL_NEON;
-    return true;
-  }
+        #include <sys/auxv.h>
+        #ifdef OJPH_OS_LINUX
+          #include <asm/hwcap.h>
+        #endif
 
-#endif // end of 64-bit ARM
+        bool init_cpu_ext_level(int& level) {
+          #ifdef OJPH_OS_LINUX
+            unsigned long hwcaps = getauxval(AT_HWCAP);
+            unsigned long hwcaps2 = getauxval(AT_HWCAP2);
+          #else
+            unsigned long hwcaps = 0;
+            unsigned long hwcaps2 = 0;
+            elf_aux_info(AT_HWCAP, &hwcaps, sizeof(hwcaps));
+            elf_aux_info(AT_HWCAP2, &hwcaps2, sizeof(hwcaps2));
+          #endif
 
-#endif
+          level = ARM_CPU_EXT_LEVEL_GENERIC;
+          if (hwcaps & HWCAP_ASIMD) {
+            level = ARM_CPU_EXT_LEVEL_ASIMD;
+            if (hwcaps & HWCAP_SVE) {
+              level = ARM_CPU_EXT_LEVEL_SVE;
+              if (hwcaps2 & HWCAP2_SVE2)
+                level = ARM_CPU_EXT_LEVEL_SVE2;
+            }
+          }
+          return true;          
+        }
 
-#else // architectures other than Intel/AMD and ARM
+      #else // 32-bit ARM
+
+        #include <sys/auxv.h>
+        #ifdef OJPH_OS_LINUX
+          #include <asm/hwcap.h>
+        #endif
+
+        bool init_cpu_ext_level(int& level) {
+          #ifdef OJPH_OS_LINUX
+            unsigned long hwcaps = getauxval(AT_HWCAP);
+          #else
+            unsigned long hwcaps = 0;
+            elf_aux_info(AT_HWCAP, &hwcaps, sizeof(hwcaps));
+          #endif
+          level = ARM_CPU_EXT_LEVEL_GENERIC;
+          if (hwcaps & HWCAP_NEON)
+            level = ARM_CPU_EXT_LEVEL_NEON;
+          return true;
+        }
+
+      #endif // end of 64-bit ARM
+
+    #endif
+
+  #else // architectures other than Intel/AMD and ARM
 
   ////////////////////////////////////////////////////////////////////////////
-  bool init_cpu_ext_level(int &level)
-  {
+  bool init_cpu_ext_level(int& level) {
     level = 0;
     return true;
   }
 
-#endif // !OJPH_DISABLE_SIMD
+  #endif // !OJPH_DISABLE_SIMD
 
 #elif defined(OJPH_ENABLE_WASM_SIMD) && defined(OJPH_EMSCRIPTEN)
 
   ////////////////////////////////////////////////////////////////////////////
-  bool init_cpu_ext_level(int &level)
-  {
+  bool init_cpu_ext_level(int& level) {
     level = 1;
     return true;
   }
@@ -241,8 +250,7 @@ namespace ojph
 #else
 
   ////////////////////////////////////////////////////////////////////////////
-  bool init_cpu_ext_level(int &level)
-  {
+  bool init_cpu_ext_level(int& level) {
     level = 0;
     return true;
   }

--- a/Native/Common/OpenJPH/others/ojph_file.cpp
+++ b/Native/Common/OpenJPH/others/ojph_file.cpp
@@ -1,4 +1,4 @@
-//***************************************************************************/
+//***************************************************************************;
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
@@ -35,18 +35,20 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 /** @file ojph_file.cpp
  *  @brief contains implementations of classes related to file operations
  */
 
 #include <cassert>
 #include <cstddef>
+#include <utility>
 
+#include "ojph_mem.h"
 #include "ojph_file.h"
 #include "ojph_message.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -94,29 +96,59 @@ namespace ojph
     fh = NULL;
   }
 
-  //*************************************************************************/
+  ////////////////////////////////////////////////////////////////////////////
+  //
+  //
   // mem_outfile
-  //*************************************************************************/
+  //
+  //
+  ////////////////////////////////////////////////////////////////////////////
 
-  /**  */
+  ////////////////////////////////////////////////////////////////////////////
   mem_outfile::mem_outfile()
   {
     is_open = clear_mem = false;
     buf_size = used_size = 0;
-    buf = cur_ptr = NULL;
+    buf = cur_ptr = nullptr;
   }
 
-  /**  */
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_outfile::swap(mem_outfile& other) noexcept {
+    std::swap(this->is_open,other.is_open);
+    std::swap(this->clear_mem,other.clear_mem);
+    std::swap(this->buf_size,other.buf_size);
+    std::swap(this->used_size,other.used_size);
+    std::swap(this->buf,other.buf);
+    std::swap(this->cur_ptr,other.cur_ptr);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   mem_outfile::~mem_outfile()
   {
     if (buf)
-      free(buf);
+      ojph_aligned_free(buf);
     is_open = clear_mem = false;
     buf_size = used_size = 0;
     buf = cur_ptr = NULL;
   }
 
-  /**  */
+  ////////////////////////////////////////////////////////////////////////////
+  mem_outfile::mem_outfile(mem_outfile&& rhs) noexcept: mem_outfile()
+  {
+    this->swap(rhs);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  mem_outfile& mem_outfile::operator=(mem_outfile&& rhs) noexcept
+  {
+    if (this != &rhs) {
+      mem_outfile tmp(std::move(rhs));
+      this->swap(tmp);
+    }
+    return *this;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   void mem_outfile::open(size_t initial_size, bool clear_mem)
   {
     assert(this->is_open == false);
@@ -130,13 +162,13 @@ namespace ojph
     this->cur_ptr = this->buf;
   }
 
-  /**  */
-  void mem_outfile::close()
-  {
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_outfile::close() {
     is_open = false;
     cur_ptr = buf;
   }
 
+  ////////////////////////////////////////////////////////////////////////////
   /** The seek function expands the buffer whenever offset goes beyond
    *  the buffer end
    */
@@ -147,22 +179,22 @@ namespace ojph
     else if (origin == OJPH_SEEK_CUR)
       offset += tell();
     else if (origin == OJPH_SEEK_END)
-      offset += (si64)buf_size;
-    else
-    {
+      offset += (si64)used_size;
+    else {
       assert(0);
       return -1;
     }
 
-    if (offset >= 0)
-      expand_storage((size_t)offset, false);
-    else
+    if (offset < 0)  // offset before the start of file
       return -1;
+
+    expand_storage((size_t)offset, false); // See if expansion is needed
 
     cur_ptr = buf + offset;
     return 0;
   }
 
+  ////////////////////////////////////////////////////////////////////////////
   /** Whenever the need arises, the buffer is expanded by a factor approx 1.5x
    */
   size_t mem_outfile::write(const void *ptr, size_t new_size)
@@ -173,7 +205,7 @@ namespace ojph
     assert(this->cur_ptr);
 
     // expand buffer if needed to make sure it has room for this write
-    size_t needed_size = (size_t)tell() + new_size; // needed size
+    size_t needed_size = (size_t)tell() + new_size; //needed size
     expand_storage(needed_size, false);
 
     // copy bytes into buffer and adjust cur_ptr
@@ -184,7 +216,7 @@ namespace ojph
     return new_size;
   }
 
-  /** */
+  ////////////////////////////////////////////////////////////////////////////
   void mem_outfile::write_to_file(const char *file_name) const
   {
     assert(is_open == false);
@@ -197,28 +229,38 @@ namespace ojph
     fclose(f);
   }
 
-  /** */
+  ////////////////////////////////////////////////////////////////////////////
   void mem_outfile::expand_storage(size_t needed_size, bool clear_all)
   {
-    needed_size += (needed_size + 1) >> 1; // x1.5
     if (needed_size > buf_size)
     {
-      si64 used_size = tell(); // current used size
+      needed_size += (needed_size + 1) >> 1; // x1.5
+      // expand buffer to multiples of (ALIGNED_ALLOC_MASK + 1)
+      needed_size = (needed_size + ALIGNED_ALLOC_MASK) & (~ALIGNED_ALLOC_MASK);
 
-      if (this->buf)
-        this->buf = (ui8 *)realloc(this->buf, needed_size);
-      else
-        this->buf = (ui8 *)malloc(needed_size);
+      ui8* new_buf;
+      new_buf = (ui8*)ojph_aligned_malloc(ALIGNED_ALLOC_MASK + 1, needed_size);
+      if (new_buf == NULL)
+        OJPH_ERROR(0x00060005, "failed to allocate memory (%zu bytes)",
+          needed_size);
+
+      if (this->buf != NULL)
+      {
+        if (!clear_all)
+          memcpy(new_buf, this->buf, used_size);
+        ojph_aligned_free(this->buf);
+      }
+      this->cur_ptr = new_buf + tell();
+      this->buf = new_buf;
 
       if (clear_mem && !clear_all) // will be cleared later
         memset(this->buf + buf_size, 0, needed_size - this->buf_size);
-
       this->buf_size = needed_size;
-      this->cur_ptr = this->buf + used_size;
     }
     if (clear_all)
       memset(this->buf, 0, this->buf_size);
   }
+
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -266,6 +308,7 @@ namespace ojph
     fh = NULL;
   }
 
+
   ////////////////////////////////////////////////////////////////////////////
   //
   //
@@ -275,7 +318,23 @@ namespace ojph
   ////////////////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////////////////
-  void mem_infile::open(const ui8 *data, size_t size)
+  mem_infile::mem_infile(mem_infile&& rhs) noexcept: mem_infile()
+  {
+    this->swap(rhs);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  mem_infile& mem_infile::operator=(mem_infile&& rhs) noexcept
+  {
+    if (this != &rhs) {
+      mem_infile tmp(std::move(rhs));
+      this->swap(tmp);
+    }
+    return *this;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_infile::open(const ui8* data, size_t size)
   {
     assert(this->data == NULL);
     cur_ptr = this->data = data;
@@ -331,4 +390,13 @@ namespace ojph
 
     return result;
   }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_infile::swap(mem_infile& other) noexcept
+  {
+    std::swap(this->data,other.data);
+    std::swap(this->cur_ptr,other.cur_ptr);
+    std::swap(this->size,other.size);
+  }
+
 }

--- a/Native/Common/OpenJPH/others/ojph_mem.cpp
+++ b/Native/Common/OpenJPH/others/ojph_mem.cpp
@@ -35,11 +35,11 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #include <new>
 #include "ojph_mem.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -50,7 +50,7 @@ namespace ojph
   ////////////////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////////////////
-  template <>
+  template<>
   void line_buf::wrap(si32 *buffer, size_t num_ele, ui32 pre_size)
   {
     this->i32 = buffer;
@@ -60,7 +60,7 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  template <>
+  template<>
   void line_buf::wrap(float *buffer, size_t num_ele, ui32 pre_size)
   {
     this->f32 = buffer;
@@ -70,7 +70,7 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  template <>
+  template<>
   void line_buf::wrap(si64 *buffer, size_t num_ele, ui32 pre_size)
   {
     this->i64 = buffer;
@@ -88,27 +88,39 @@ namespace ojph
   ////////////////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////////////////
-  void mem_elastic_allocator::get_buffer(ui32 needed_bytes, coded_lists *&p)
+  mem_elastic_allocator::stores_list*
+  mem_elastic_allocator::allocate(mem_elastic_allocator::stores_list** list,
+                                  ui32 extended_bytes)
   {
-    ui32 extended_bytes = needed_bytes + (ui32)sizeof(coded_lists);
+    ui32 bytes = ojph_max(extended_bytes, chunk_size);
+    if (avail != NULL && avail->orig_size >= bytes)
+    {
+      *list = avail;
+      avail = avail->next_store;
+      (*list)->restart();
+      return *list;
+    }
+    else
+    {
+      ui32 store_bytes = stores_list::eval_store_bytes(bytes);
+      *list = (stores_list*) malloc(store_bytes);
+      total_allocated += store_bytes;
+      return new (*list) stores_list(bytes);
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_elastic_allocator::get_buffer(ui32 needed_bytes, coded_lists* &p)
+  {
+    // Round up so each coded_lists (and coded_lists::buf) stays 16-byte aligned
+    // within the store; avoids alignment fault on 32-bit architectures
+    ui32 raw = needed_bytes + (ui32)sizeof (coded_lists);
+    ui32 extended_bytes = (raw + 15u) & ~15u;
 
     if (store == NULL)
-    {
-      ui32 bytes = ojph_max(extended_bytes, chunk_size);
-      ui32 store_bytes = stores_list::eval_store_bytes(bytes);
-      store = (stores_list *)malloc(store_bytes);
-      cur_store = store = new (store) stores_list(bytes);
-      total_allocated += store_bytes;
-    }
-
-    if (cur_store->available < extended_bytes)
-    {
-      ui32 bytes = ojph_max(extended_bytes, chunk_size);
-      ui32 store_bytes = stores_list::eval_store_bytes(bytes);
-      cur_store->next_store = (stores_list *)malloc(store_bytes);
-      cur_store = new (cur_store->next_store) stores_list(bytes);
-      total_allocated += store_bytes;
-    }
+      cur_store = store = allocate(&store, extended_bytes);
+    else if (cur_store->available < extended_bytes)
+      cur_store = allocate(&cur_store->next_store, extended_bytes);
 
     p = new (cur_store->data) coded_lists(needed_bytes);
 
@@ -116,4 +128,16 @@ namespace ojph
     cur_store->available -= extended_bytes;
     cur_store->data += extended_bytes;
   }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_elastic_allocator::restart()
+  {
+    // move to the end of avail
+    stores_list** p = &avail;
+    while (*p != NULL)
+      p = &((*p)->next_store);
+    *p = store;
+    cur_store = store = NULL;
+  }
+
 }

--- a/Native/Common/OpenJPH/others/ojph_mem_c.c
+++ b/Native/Common/OpenJPH/others/ojph_mem_c.c
@@ -1,0 +1,129 @@
+//***************************************************************************/
+// This software is released under the 2-Clause BSD license, included
+// below.
+//
+// Copyright (c) 2025, Aous Naman
+// Copyright (c) 2025, Kakadu Software Pty Ltd, Australia
+// Copyright (c) 2025, The University of New South Wales, Australia
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//***************************************************************************/
+// This file is part of the OpenJPH software implementation.
+// File: ojph_mem_c.c
+// Author: Aous Naman
+// Date: 17 October 2025
+//***************************************************************************/
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+////////////////////////////////////////////////////////////////////////////////
+// OS detection definitions for C only
+////////////////////////////////////////////////////////////////////////////////
+#if (defined WIN32) || (defined _WIN32) || (defined _WIN64)
+#define OJPH_OS_WINDOWS
+#elif (defined __APPLE__)
+#define OJPH_OS_APPLE
+#elif (defined __ANDROID__)
+#define OJPH_OS_ANDROID
+#elif (defined __linux)
+#define OJPH_OS_LINUX
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// Defines for dll in C only
+////////////////////////////////////////////////////////////////////////////////
+#if defined(OJPH_OS_WINDOWS) && defined(OJPH_BUILD_SHARED_LIBRARY)
+#define OJPH_EXPORT __declspec(dllexport)
+#else
+#define OJPH_EXPORT
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_OS_WINDOWS
+  OJPH_EXPORT void* ojph_aligned_malloc(size_t alignment, size_t size)
+  {
+    assert(alignment != 0 && (alignment & (alignment - 1)) == 0);
+    return _aligned_malloc(size, alignment);
+  }
+
+  OJPH_EXPORT void ojph_aligned_free(void* pointer)
+  {
+    _aligned_free(pointer);
+  }
+#elif (defined OJPH_ALIGNED_ALLOC_EXISTS)
+  void* ojph_aligned_malloc(size_t alignment, size_t size)
+  {
+    assert(alignment != 0 && (alignment & (alignment - 1)) == 0);
+    return aligned_alloc(alignment, size);
+  }
+
+  void ojph_aligned_free(void* pointer)
+  {
+    free(pointer);
+  }
+#elif (defined OJPH_POSIX_MEMALIGN_EXISTS)
+  void* ojph_aligned_malloc(size_t alignment, size_t size)
+  {
+    assert(alignment != 0 && (alignment & (alignment - 1)) == 0);
+    void *p = NULL;
+    int e = posix_memalign(&p, alignment, size);
+    return (e ? NULL : p);
+  }
+
+  void ojph_aligned_free(void* pointer)
+  {
+    free(pointer);
+  }
+#else
+  void* ojph_aligned_malloc(size_t alignment, size_t size)
+  {
+    assert(alignment != 0 && (alignment & (alignment - 1)) == 0);
+
+    // emulate aligned_alloc
+    void* orig_ptr = malloc(size + alignment + sizeof(void*));
+    if (orig_ptr == NULL)
+      return NULL; // Allocation failed
+
+    uintptr_t start_of_mem = (uintptr_t)orig_ptr + sizeof(void*);
+    uintptr_t aligned_addr = (start_of_mem + alignment - 1) & ~(alignment - 1);
+
+    void** ptr_to_orig_ptr = (void**)aligned_addr;
+    ptr_to_orig_ptr[-1] = orig_ptr;
+
+    return (void*)aligned_addr;
+  }
+
+  void ojph_aligned_free(void* pointer)
+  {
+    if (pointer) {
+      // Retrieve the original pointer stored just before aligned pointer
+      void** ptr_to_orig_ptr = (void**)pointer;
+      void* orig_ptr = ptr_to_orig_ptr[-1];
+
+      free(orig_ptr);
+    }
+  }
+#endif

--- a/Native/Common/OpenJPH/others/ojph_message.cpp
+++ b/Native/Common/OpenJPH/others/ojph_message.cpp
@@ -42,44 +42,43 @@
 
 #include "ojph_message.h"
 
-namespace ojph
-{
+namespace ojph {
 
   ////////////////////////////////////////////////////////////////////////////
-  FILE *info_stream = stdout;
+  FILE* info_stream = stdout;
 
   ////////////////////////////////////////////////////////////////////////////
   message_info info;
-  message_info *local_info = &info;
-  OJPH_MSG_LEVEL message_level = OJPH_MSG_LEVEL::ALL_MSG;
+  message_info* local_info = &info;
+  OJPH_MSG_LEVEL message_level = OJPH_MSG_ALL_MSG;
 
   ////////////////////////////////////////////////////////////////////////////
-  void configure_info(message_info *info)
+  void configure_info(message_info* info)
   {
     local_info = info;
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  message_info *get_info()
+  message_info* get_info()
   {
     return local_info;
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void set_info_stream(FILE *s)
+  void set_info_stream(FILE* s)
   {
     info_stream = s;
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void message_info::operator()(int info_code, const char *file_name,
-                                int line_num, const char *fmt, ...)
+  void message_info::operator()(int info_code, const char* file_name,
+    int line_num, const char* fmt, ...)
   {
-    if (info_stream == NULL || message_level > OJPH_MSG_LEVEL::INFO)
+    if (info_stream == NULL || message_level > OJPH_MSG_INFO)
       return;
 
     fprintf(info_stream, "ojph info 0x%08X at %s:%d: ",
-            info_code, file_name, line_num);
+      info_code, file_name, line_num);
     va_list args;
     va_start(args, fmt);
     vfprintf(info_stream, fmt, args);
@@ -92,16 +91,16 @@ namespace ojph
 
   ////////////////////////////////////////////////////////////////////////////
   message_warning warn;
-  message_warning *local_warn = &warn;
+  message_warning* local_warn = &warn;
 
   ////////////////////////////////////////////////////////////////////////////
-  void configure_warning(message_warning *warn)
+  void configure_warning(message_warning* warn)
   {
     local_warn = warn;
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  message_warning *get_warning()
+  message_warning* get_warning()
   {
     return local_warn;
   }
@@ -113,14 +112,14 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void message_warning::operator()(int warn_code, const char *file_name,
-                                   int line_num, const char *fmt, ...)
+  void message_warning::operator()(int warn_code, const char* file_name,
+    int line_num, const char *fmt, ...)
   {
-    if (warning_stream == NULL || message_level > OJPH_MSG_LEVEL::WARN)
+    if (warning_stream == NULL || message_level > OJPH_MSG_WARN)
       return;
 
     fprintf(warning_stream, "ojph warning 0x%08X at %s:%d: ",
-            warn_code, file_name, line_num);
+      warn_code, file_name, line_num);
     va_list args;
     va_start(args, fmt);
     vfprintf(warning_stream, fmt, args);
@@ -133,16 +132,16 @@ namespace ojph
 
   ////////////////////////////////////////////////////////////////////////////
   message_error error;
-  message_error *local_error = &error;
+  message_error* local_error = &error;
 
   ////////////////////////////////////////////////////////////////////////////
-  void configure_error(message_error *error)
+  void configure_error(message_error* error)
   {
     local_error = error;
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  message_error *get_error()
+  message_error* get_error()
   {
     return local_error;
   }
@@ -154,13 +153,13 @@ namespace ojph
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  void message_error::operator()(int error_code, const char *file_name,
-                                 int line_num, const char *fmt, ...)
+  void message_error::operator()(int error_code, const char* file_name,
+    int line_num, const char *fmt, ...)
   {
-    if (error_stream != NULL && message_level <= OJPH_MSG_LEVEL::ERROR)
+    if (error_stream != NULL && message_level <= OJPH_MSG_ERROR)
     {
       fprintf(error_stream, "ojph error 0x%08X at %s:%d: ",
-              error_code, file_name, line_num);
+        error_code, file_name, line_num);
       va_list args;
       va_start(args, fmt);
       vfprintf(error_stream, fmt, args);
@@ -174,8 +173,9 @@ namespace ojph
   ////////////////////////////////////////////////////////////////////////////
   void set_message_level(OJPH_MSG_LEVEL level)
   {
-    assert(level >= OJPH_MSG_LEVEL::ALL_MSG &&
-           level <= OJPH_MSG_LEVEL::NO_MSG);
+    assert(level >= OJPH_MSG_ALL_MSG &&
+           level <= OJPH_MSG_NO_MSG);
     message_level = level;
   }
+
 }

--- a/Native/Common/OpenJPH/transform/ojph_colour.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_colour.cpp
@@ -37,6 +37,7 @@
 
 #include <cmath>
 #include <climits>
+#include <mutex>
 
 #include "ojph_defs.h"
 #include "ojph_arch.h"
@@ -44,169 +45,169 @@
 #include "ojph_colour.h"
 #include "ojph_colour_local.h"
 
-namespace ojph
-{
+namespace ojph {
 
   // defined elsewhere
   class line_buf;
 
-  namespace local
-  {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    void (*rev_convert)(const line_buf *src_line, const ui32 src_line_offset,
-                        line_buf *dst_line, const ui32 dst_line_offset,
-                        si64 shift, ui32 width) = NULL;
+    void (*rev_convert)
+      (const line_buf *src_line, const ui32 src_line_offset,
+       line_buf *dst_line, const ui32 dst_line_offset,
+       si64 shift, ui32 width) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    void (*rev_convert_nlt_type3)(const line_buf *src_line, const ui32 src_line_offset,
-                                  line_buf *dst_line, const ui32 dst_line_offset,
-                                  si64 shift, ui32 width) = NULL;
+    void (*rev_convert_nlt_type3)
+      (const line_buf *src_line, const ui32 src_line_offset,
+       line_buf *dst_line, const ui32 dst_line_offset,
+       si64 shift, ui32 width) = NULL;
+
 
     //////////////////////////////////////////////////////////////////////////
-    void (*irv_convert_to_integer)(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width) = NULL;
+    void (*irv_convert_to_integer) (
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    void (*irv_convert_to_float)(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width) = NULL;
+    void (*irv_convert_to_float) (
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    void (*irv_convert_to_integer_nlt_type3)(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width) = NULL;
+    void (*irv_convert_to_integer_nlt_type3) (
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    void (*irv_convert_to_float_nlt_type3)(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width) = NULL;
+    void (*irv_convert_to_float_nlt_type3) (
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    void (*rct_forward)(const line_buf *r, const line_buf *g, const line_buf *b,
-                        line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat) = NULL;
+    void (*rct_forward)
+      (const line_buf* r, const line_buf* g, const line_buf* b,
+       line_buf* y, line_buf* cb, line_buf* cr, ui32 repeat) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    void (*rct_backward)(const line_buf *r, const line_buf *g, const line_buf *b,
-                         line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat) = NULL;
+    void (*rct_backward)
+      (const line_buf* r, const line_buf* g, const line_buf* b,
+       line_buf* y, line_buf* cb, line_buf* cr, ui32 repeat) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    void (*ict_forward)(const float *r, const float *g, const float *b,
-                        float *y, float *cb, float *cr, ui32 repeat) = NULL;
+    void (*ict_forward)
+      (const float *r, const float *g, const float *b,
+       float *y, float *cb, float *cr, ui32 repeat) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    void (*ict_backward)(const float *y, const float *cb, const float *cr,
-                         float *r, float *g, float *b, ui32 repeat) = NULL;
-
-    //////////////////////////////////////////////////////////////////////////
-    static bool colour_transform_functions_initialized = false;
+    void (*ict_backward)
+      (const float *y, const float *cb, const float *cr,
+       float *r, float *g, float *b, ui32 repeat) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
     void init_colour_transform_functions()
     {
-      if (colour_transform_functions_initialized)
-        return;
-
+      static std::once_flag colour_transform_functions_init_flag;
+      std::call_once(colour_transform_functions_init_flag, []() {
 #if !defined(OJPH_ENABLE_WASM_SIMD) || !defined(OJPH_EMSCRIPTEN)
 
-      rev_convert = gen_rev_convert;
-      rev_convert_nlt_type3 = gen_rev_convert_nlt_type3;
-      irv_convert_to_integer = gen_irv_convert_to_integer;
-      irv_convert_to_float = gen_irv_convert_to_float;
-      irv_convert_to_integer_nlt_type3 = gen_irv_convert_to_integer_nlt_type3;
-      irv_convert_to_float_nlt_type3 = gen_irv_convert_to_float_nlt_type3;
-      rct_forward = gen_rct_forward;
-      rct_backward = gen_rct_backward;
-      ict_forward = gen_ict_forward;
-      ict_backward = gen_ict_backward;
+        rev_convert = gen_rev_convert;
+        rev_convert_nlt_type3 = gen_rev_convert_nlt_type3;
+        irv_convert_to_integer = gen_irv_convert_to_integer;
+        irv_convert_to_float = gen_irv_convert_to_float;
+        irv_convert_to_integer_nlt_type3 = gen_irv_convert_to_integer_nlt_type3;
+        irv_convert_to_float_nlt_type3 = gen_irv_convert_to_float_nlt_type3;
+        rct_forward = gen_rct_forward;
+        rct_backward = gen_rct_backward;
+        ict_forward = gen_ict_forward;
+        ict_backward = gen_ict_backward;
 
-#ifndef OJPH_DISABLE_SIMD
+  #ifndef OJPH_DISABLE_SIMD
 
-#if (defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
+    #if (defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
-#ifndef OJPH_DISABLE_SSE
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE)
-      {
-        ict_forward = sse_ict_forward;
-        ict_backward = sse_ict_backward;
-      }
-#endif // !OJPH_DISABLE_SSE
+      #ifndef OJPH_DISABLE_SSE
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE)
+        {
+          ict_forward = sse_ict_forward;
+          ict_backward = sse_ict_backward;
+        }
+      #endif // !OJPH_DISABLE_SSE
 
-#ifndef OJPH_DISABLE_SSE2
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE2)
-      {
-        rev_convert = sse2_rev_convert;
-        rev_convert_nlt_type3 = sse2_rev_convert_nlt_type3;
-        irv_convert_to_integer = sse2_irv_convert_to_integer;
-        irv_convert_to_float = sse2_irv_convert_to_float;
-        irv_convert_to_integer_nlt_type3 =
+      #ifndef OJPH_DISABLE_SSE2
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE2)
+        {
+          rev_convert = sse2_rev_convert;
+          rev_convert_nlt_type3 = sse2_rev_convert_nlt_type3;
+          irv_convert_to_integer = sse2_irv_convert_to_integer;
+          irv_convert_to_float = sse2_irv_convert_to_float;
+          irv_convert_to_integer_nlt_type3 =
             sse2_irv_convert_to_integer_nlt_type3;
-        irv_convert_to_float_nlt_type3 =
+          irv_convert_to_float_nlt_type3 =
             sse2_irv_convert_to_float_nlt_type3;
-        rct_forward = sse2_rct_forward;
-        rct_backward = sse2_rct_backward;
-      }
-#endif // !OJPH_DISABLE_SSE2
+          rct_forward = sse2_rct_forward;
+          rct_backward = sse2_rct_backward;
+        }
+      #endif // !OJPH_DISABLE_SSE2
 
-#ifndef OJPH_DISABLE_AVX
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX)
-      {
-        ict_forward = avx_ict_forward;
-        ict_backward = avx_ict_backward;
-      }
-#endif // !OJPH_DISABLE_AVX
+      #ifndef OJPH_DISABLE_AVX
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX)
+        {
+          ict_forward = avx_ict_forward;
+          ict_backward = avx_ict_backward;
+        }
+      #endif // !OJPH_DISABLE_AVX
 
-#ifndef OJPH_DISABLE_AVX2
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX2)
-      {
-        rev_convert = avx2_rev_convert;
-        rev_convert_nlt_type3 = avx2_rev_convert_nlt_type3;
-        irv_convert_to_integer = avx2_irv_convert_to_integer;
-        irv_convert_to_float = avx2_irv_convert_to_float;
-        irv_convert_to_integer_nlt_type3 =
+      #ifndef OJPH_DISABLE_AVX2
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX2)
+        {
+          rev_convert = avx2_rev_convert;
+          rev_convert_nlt_type3 = avx2_rev_convert_nlt_type3;
+          irv_convert_to_integer = avx2_irv_convert_to_integer;
+          irv_convert_to_float = avx2_irv_convert_to_float;
+          irv_convert_to_integer_nlt_type3 =
             avx2_irv_convert_to_integer_nlt_type3;
-        irv_convert_to_float_nlt_type3 =
+          irv_convert_to_float_nlt_type3 =
             avx2_irv_convert_to_float_nlt_type3;
-        rct_forward = avx2_rct_forward;
-        rct_backward = avx2_rct_backward;
-      }
-#endif // !OJPH_DISABLE_AVX2
+          rct_forward = avx2_rct_forward;
+          rct_backward = avx2_rct_backward;
+        }
+      #endif // !OJPH_DISABLE_AVX2
 
-#elif defined(OJPH_ARCH_ARM)
+    #elif defined(OJPH_ARCH_ARM)
 
-#endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
+    #endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
-#endif // !OJPH_DISABLE_SIMD
+  #endif // !OJPH_DISABLE_SIMD
 
 #else // OJPH_ENABLE_WASM_SIMD
 
-      rev_convert = wasm_rev_convert;
-      rev_convert_nlt_type3 = wasm_rev_convert_nlt_type3;
-      irv_convert_to_integer = wasm_irv_convert_to_integer;
-      irv_convert_to_float = wasm_irv_convert_to_float;
-      irv_convert_to_integer_nlt_type3 = wasm_irv_convert_to_integer_nlt_type3;
-      irv_convert_to_float_nlt_type3 = wasm_irv_convert_to_float_nlt_type3;
-      rct_forward = wasm_rct_forward;
-      rct_backward = wasm_rct_backward;
-      ict_forward = wasm_ict_forward;
-      ict_backward = wasm_ict_backward;
+        rev_convert = wasm_rev_convert;
+        rev_convert_nlt_type3 = wasm_rev_convert_nlt_type3;
+        irv_convert_to_integer = wasm_irv_convert_to_integer;
+        irv_convert_to_float = wasm_irv_convert_to_float;
+        irv_convert_to_integer_nlt_type3 = wasm_irv_convert_to_integer_nlt_type3;
+        irv_convert_to_float_nlt_type3 = wasm_irv_convert_to_float_nlt_type3;
+        rct_forward = wasm_rct_forward;
+        rct_backward = wasm_rct_backward;
+        ict_forward = wasm_ict_forward;
+        ict_backward = wasm_ict_backward;
 
 #endif // !OJPH_ENABLE_WASM_SIMD
-
-      colour_transform_functions_initialized = true;
+      });
     }
 
     //////////////////////////////////////////////////////////////////////////
     const float CT_CNST::ALPHA_RF = 0.299f;
     const float CT_CNST::ALPHA_GF = 0.587f;
     const float CT_CNST::ALPHA_BF = 0.114f;
-    const float CT_CNST::BETA_CbF = float(0.5 / (1 - double(CT_CNST::ALPHA_BF)));
-    const float CT_CNST::BETA_CrF = float(0.5 / (1 - double(CT_CNST::ALPHA_RF)));
+    const float CT_CNST::BETA_CbF = float(0.5/(1-double(CT_CNST::ALPHA_BF)));
+    const float CT_CNST::BETA_CrF = float(0.5/(1-double(CT_CNST::ALPHA_RF)));
     const float CT_CNST::GAMMA_CB2G =
-        float(2.0 * double(ALPHA_BF) * (1.0 - double(ALPHA_BF)) / double(ALPHA_GF));
+      float(2.0*double(ALPHA_BF)*(1.0-double(ALPHA_BF))/double(ALPHA_GF));
     const float CT_CNST::GAMMA_CR2G =
-        float(2.0 * double(ALPHA_RF) * (1.0 - double(ALPHA_RF)) / double(ALPHA_GF));
+      float(2.0*double(ALPHA_RF)*(1.0-double(ALPHA_RF))/double(ALPHA_GF));
     const float CT_CNST::GAMMA_CB2B = float(2.0 * (1.0 - double(ALPHA_BF)));
     const float CT_CNST::GAMMA_CR2R = float(2.0 * (1.0 - double(ALPHA_RF)));
 
@@ -216,9 +217,9 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rev_convert(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width)
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
+      si64 shift, ui32 width)
     {
       if (src_line->flags & line_buf::LFT_32BIT)
       {
@@ -251,9 +252,9 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rev_convert_nlt_type3(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width)
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
+      si64 shift, ui32 width)
     {
       if (src_line->flags & line_buf::LFT_32BIT)
       {
@@ -262,20 +263,18 @@ namespace ojph
           const si32 *sp = src_line->i32 + src_line_offset;
           si32 *dp = dst_line->i32 + dst_line_offset;
           si32 s = (si32)shift;
-          for (ui32 i = width; i > 0; --i)
-          {
+          for (ui32 i = width; i > 0; --i) {
             const si32 v = *sp++;
-            *dp++ = v >= 0 ? v : (-v - s);
+            *dp++ = v >= 0 ? v : (- v - s);
           }
         }
         else
         {
           const si32 *sp = src_line->i32 + src_line_offset;
           si64 *dp = dst_line->i64 + dst_line_offset;
-          for (ui32 i = width; i > 0; --i)
-          {
+          for (ui32 i = width; i > 0; --i) {
             const si64 v = *sp++;
-            *dp++ = v >= 0 ? v : (-v - shift);
+            *dp++ = v >= 0 ? v : (- v - shift);
           }
         }
       }
@@ -285,19 +284,20 @@ namespace ojph
         assert(dst_line->flags & line_buf::LFT_32BIT);
         const si64 *sp = src_line->i64 + src_line_offset;
         si32 *dp = dst_line->i32 + dst_line_offset;
-        for (ui32 i = width; i > 0; --i)
-        {
+        for (ui32 i = width; i > 0; --i) {
           const si64 v = *sp++;
-          *dp++ = (si32)(v >= 0 ? v : (-v - shift));
+          *dp++ = (si32)(v >= 0 ? v : (- v - shift));
         }
       }
     }
 
+
     //////////////////////////////////////////////////////////////////////////
-    template <bool NLT_TYPE3>
-    static inline void local_gen_irv_convert_to_integer(const line_buf *src_line,
-                                                        line_buf *dst_line, ui32 dst_line_offset,
-                                                        ui32 bit_depth, bool is_signed, ui32 width)
+    template<bool NLT_TYPE3>
+    static inline
+    void local_gen_irv_convert_to_integer(const line_buf *src_line,
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       assert((src_line->flags & line_buf::LFT_32BIT) &&
              (src_line->flags & line_buf::LFT_INTEGER) == 0 &&
@@ -305,8 +305,8 @@ namespace ojph
              (dst_line->flags & line_buf::LFT_INTEGER));
 
       assert(bit_depth <= 32);
-      const float *sp = src_line->f32;
-      si32 *dp = dst_line->i32 + dst_line_offset;
+      const float* sp = src_line->f32;
+      si32* dp = dst_line->i32 + dst_line_offset;
       // There is the possibility that converting to integer will
       // exceed the dynamic range of 32bit integer; therefore, care must be
       // exercised.
@@ -323,26 +323,24 @@ namespace ojph
       if (is_signed)
       {
         const si32 bias = (si32)((1ULL << (bit_depth - 1)) + 1);
-        for (int i = (int)width; i > 0; --i)
-        {
+        for (int i = (int)width; i > 0; --i) {
           float t = *sp++ * mul;
           si32 v = ojph_round(t);
           v = t >= fl_low_lim ? v : s32_low_lim;
-          v = t < fl_up_lim ? v : s32_up_lim;
+          v = t <  fl_up_lim  ? v : s32_up_lim;
           if (NLT_TYPE3)
-            v = (v >= 0) ? v : (-v - bias);
+            v = (v >= 0) ? v : (- v - bias);
           *dp++ = v;
         }
       }
       else
       {
         const si32 half = (si32)(1ULL << (bit_depth - 1));
-        for (int i = (int)width; i > 0; --i)
-        {
+        for (int i = (int)width; i > 0; --i) {
           float t = *sp++ * mul;
           si32 v = ojph_round(t);
           v = t >= fl_low_lim ? v : s32_low_lim;
-          v = t < fl_up_lim ? v : s32_up_lim;
+          v = t <  fl_up_lim  ? v : s32_up_lim;
           *dp++ = v + half;
         }
       }
@@ -350,27 +348,28 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_convert_to_integer(const line_buf *src_line,
-                                    line_buf *dst_line, ui32 dst_line_offset,
-                                    ui32 bit_depth, bool is_signed, ui32 width)
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_gen_irv_convert_to_integer<false>(src_line, dst_line,
-                                              dst_line_offset, bit_depth, is_signed, width);
+        dst_line_offset, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_convert_to_integer_nlt_type3(const line_buf *src_line,
-                                              line_buf *dst_line, ui32 dst_line_offset,
-                                              ui32 bit_depth, bool is_signed, ui32 width)
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_gen_irv_convert_to_integer<true>(src_line, dst_line,
-                                             dst_line_offset, bit_depth, is_signed, width);
+        dst_line_offset, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    template <bool NLT_TYPE3>
-    static inline void local_gen_irv_convert_to_float(const line_buf *src_line,
-                                                      ui32 src_line_offset, line_buf *dst_line,
-                                                      ui32 bit_depth, bool is_signed, ui32 width)
+    template<bool NLT_TYPE3>
+    static inline
+    void local_gen_irv_convert_to_float(const line_buf *src_line,
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       assert((src_line->flags & line_buf::LFT_32BIT) &&
              (src_line->flags & line_buf::LFT_INTEGER) &&
@@ -380,24 +379,22 @@ namespace ojph
       assert(bit_depth <= 32);
       float mul = (float)(1.0 / (double)(1ULL << bit_depth));
 
-      const si32 *sp = src_line->i32 + src_line_offset;
-      float *dp = dst_line->f32;
+      const si32* sp = src_line->i32 + src_line_offset;
+      float* dp = dst_line->f32;
       if (is_signed)
       {
         const si32 bias = (si32)((1ULL << (bit_depth - 1)) + 1);
-        for (int i = (int)width; i > 0; --i)
-        {
+        for (int i = (int)width; i > 0; --i) {
           si32 v = *sp++;
           if (NLT_TYPE3)
-            v = (v >= 0) ? v : (-v - bias);
+            v = (v >= 0) ? v : (- v - bias);
           *dp++ = (float)v * mul;
         }
       }
       else
       {
         const si32 half = (si32)(1ULL << (bit_depth - 1));
-        for (int i = (int)width; i > 0; --i)
-        {
+        for (int i = (int)width; i > 0; --i) {
           si32 v = *sp++;
           v -= half;
           *dp++ = (float)v * mul;
@@ -407,44 +404,44 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_convert_to_float(const line_buf *src_line,
-                                  ui32 src_line_offset, line_buf *dst_line,
-                                  ui32 bit_depth, bool is_signed, ui32 width)
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_gen_irv_convert_to_float<false>(src_line, src_line_offset,
-                                            dst_line, bit_depth, is_signed, width);
+        dst_line, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_convert_to_float_nlt_type3(const line_buf *src_line,
-                                            ui32 src_line_offset, line_buf *dst_line,
-                                            ui32 bit_depth, bool is_signed, ui32 width)
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_gen_irv_convert_to_float<true>(src_line, src_line_offset,
-                                           dst_line, bit_depth, is_signed, width);
+        dst_line, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rct_forward(
-        const line_buf *r, const line_buf *g, const line_buf *b,
-        line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat)
+      const line_buf *r, const line_buf *g, const line_buf *b,
+      line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat)
     {
-      assert((y->flags & line_buf::LFT_INTEGER) &&
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
              (cb->flags & line_buf::LFT_INTEGER) &&
              (cr->flags & line_buf::LFT_INTEGER) &&
-             (r->flags & line_buf::LFT_INTEGER) &&
-             (g->flags & line_buf::LFT_INTEGER) &&
-             (b->flags & line_buf::LFT_INTEGER));
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
 
-      if (y->flags & line_buf::LFT_32BIT)
+      if  (y->flags & line_buf::LFT_32BIT)
       {
-        assert((y->flags & line_buf::LFT_32BIT) &&
+        assert((y->flags  & line_buf::LFT_32BIT) &&
                (cb->flags & line_buf::LFT_32BIT) &&
                (cr->flags & line_buf::LFT_32BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
-        const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
-        si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
+        const si32 *rp = r->i32, * gp = g->i32, * bp = b->i32;
+        si32 *yp = y->i32, * cbp = cb->i32, * crp = cr->i32;
         for (ui32 i = repeat; i > 0; --i)
         {
           si32 rr = *rp++, gg = *gp++, bb = *bp++;
@@ -455,12 +452,12 @@ namespace ojph
       }
       else
       {
-        assert((y->flags & line_buf::LFT_64BIT) &&
+        assert((y->flags  & line_buf::LFT_64BIT) &&
                (cb->flags & line_buf::LFT_64BIT) &&
                (cr->flags & line_buf::LFT_64BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
         for (ui32 i = repeat; i > 0; --i)
@@ -475,24 +472,24 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rct_backward(
-        const line_buf *y, const line_buf *cb, const line_buf *cr,
-        line_buf *r, line_buf *g, line_buf *b, ui32 repeat)
+      const line_buf *y, const line_buf *cb, const line_buf *cr,
+      line_buf *r, line_buf *g, line_buf *b, ui32 repeat)
     {
-      assert((y->flags & line_buf::LFT_INTEGER) &&
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
              (cb->flags & line_buf::LFT_INTEGER) &&
              (cr->flags & line_buf::LFT_INTEGER) &&
-             (r->flags & line_buf::LFT_INTEGER) &&
-             (g->flags & line_buf::LFT_INTEGER) &&
-             (b->flags & line_buf::LFT_INTEGER));
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
 
       if (y->flags & line_buf::LFT_32BIT)
       {
-        assert((y->flags & line_buf::LFT_32BIT) &&
+        assert((y->flags  & line_buf::LFT_32BIT) &&
                (cb->flags & line_buf::LFT_32BIT) &&
                (cr->flags & line_buf::LFT_32BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         const si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
         si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         for (ui32 i = repeat; i > 0; --i)
@@ -506,12 +503,12 @@ namespace ojph
       }
       else
       {
-        assert((y->flags & line_buf::LFT_64BIT) &&
+        assert((y->flags  & line_buf::LFT_64BIT) &&
                (cb->flags & line_buf::LFT_64BIT) &&
                (cr->flags & line_buf::LFT_64BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         const si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
         si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         for (ui32 i = repeat; i > 0; --i)
@@ -531,7 +528,9 @@ namespace ojph
     {
       for (ui32 i = repeat; i > 0; --i)
       {
-        *y = CT_CNST::ALPHA_RF * *r + CT_CNST::ALPHA_GF * *g++ + CT_CNST::ALPHA_BF * *b;
+        *y = CT_CNST::ALPHA_RF * *r
+           + CT_CNST::ALPHA_GF * *g++
+           + CT_CNST::ALPHA_BF * *b;
         *cb++ = CT_CNST::BETA_CbF * (*b++ - *y);
         *cr++ = CT_CNST::BETA_CrF * (*r++ - *y++);
       }

--- a/Native/Common/OpenJPH/transform/ojph_colour.h
+++ b/Native/Common/OpenJPH/transform/ojph_colour.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,67 +35,75 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_COLOR_H
 #define OJPH_COLOR_H
 
-namespace ojph
-{
+namespace ojph {
 
   // defined elsewhere
   class line_buf;
 
-  namespace local
-  {
+  namespace local {
 
-    ////////////////////////////////////////////////////////////////////////////
-    void init_colour_transform_functions();
+  ////////////////////////////////////////////////////////////////////////////
+  void init_colour_transform_functions();
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*rev_convert)(const line_buf *src_line, const ui32 src_line_offset,
-                               line_buf *dst_line, const ui32 dst_line_offset,
-                               si64 shift, ui32 width);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*rev_convert)
+    (const line_buf *src_line, const ui32 src_line_offset, 
+     line_buf *dst_line, const ui32 dst_line_offset, 
+     si64 shift, ui32 width);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*rev_convert_nlt_type3)(const line_buf *src_line, const ui32 src_line_offset,
-                                         line_buf *dst_line, const ui32 dst_line_offset,
-                                         si64 shift, ui32 width);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*rev_convert_nlt_type3)
+    (const line_buf *src_line, const ui32 src_line_offset, 
+     line_buf *dst_line, const ui32 dst_line_offset, 
+     si64 shift, ui32 width);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*irv_convert_to_integer)(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*irv_convert_to_float)(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*irv_convert_to_integer) (
+    const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+    ui32 bit_depth, bool is_signed, ui32 width);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*irv_convert_to_integer_nlt_type3)(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*irv_convert_to_float) (
+    const line_buf *src_line, ui32 src_line_offset,
+    line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*irv_convert_to_float_nlt_type3)(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*irv_convert_to_integer_nlt_type3) (
+    const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+    ui32 bit_depth, bool is_signed, ui32 width);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*rct_forward)(const line_buf *r, const line_buf *g, const line_buf *b,
-                               line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*irv_convert_to_float_nlt_type3) (
+    const line_buf *src_line, ui32 src_line_offset,
+    line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*rct_backward)(const line_buf *y, const line_buf *cb, const line_buf *cr,
-                                line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*rct_forward)
+    (const line_buf *r, const line_buf *g, const line_buf *b,
+     line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*ict_forward)(const float *r, const float *g, const float *b,
-                               float *y, float *cb, float *cr, ui32 repeat);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*rct_backward)
+    (const line_buf *y, const line_buf *cb, const line_buf *cr,
+     line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
 
-    ////////////////////////////////////////////////////////////////////////////
-    extern void (*ict_backward)(const float *y, const float *cb, const float *cr,
-                                float *r, float *g, float *b, ui32 repeat);
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*ict_forward)
+    (const float *r, const float *g, const float *b,
+     float *y, float *cb, float *cr, ui32 repeat);
+
+  ////////////////////////////////////////////////////////////////////////////
+  extern void (*ict_backward)
+    (const float *y, const float *cb, const float *cr,
+     float *r, float *g, float *b, ui32 repeat);
   }
 }
+
+
 
 #endif // !OJPH_COLOR_H

--- a/Native/Common/OpenJPH/transform/ojph_colour_avx.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_colour_avx.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -46,10 +46,8 @@
 
 #include <immintrin.h>
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
     void avx_ict_forward(const float *r, const float *g, const float *b,
@@ -71,12 +69,8 @@ namespace ojph
         _mm256_store_ps(cb, _mm256_mul_ps(beta_cbf, _mm256_sub_ps(mb, my)));
         _mm256_store_ps(cr, _mm256_mul_ps(beta_crf, _mm256_sub_ps(mr, my)));
 
-        r += 8;
-        g += 8;
-        b += 8;
-        y += 8;
-        cb += 8;
-        cr += 8;
+        r += 8; g += 8; b += 8;
+        y += 8; cb += 8; cr += 8;
       }
     }
 
@@ -98,12 +92,8 @@ namespace ojph
         _mm256_store_ps(r, _mm256_add_ps(my, _mm256_mul_ps(gamma_cr2r, mcr)));
         _mm256_store_ps(b, _mm256_add_ps(my, _mm256_mul_ps(gamma_cb2b, mcb)));
 
-        y += 8;
-        cb += 8;
-        cr += 8;
-        r += 8;
-        g += 8;
-        b += 8;
+        y += 8; cb += 8; cr += 8;
+        r += 8; g += 8; b += 8;
       }
     }
 

--- a/Native/Common/OpenJPH/transform/ojph_colour_avx2.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_colour_avx2.cpp
@@ -47,14 +47,13 @@
 
 #include <immintrin.h>
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     /////////////////////////////////////////////////////////////////////////
     // https://github.com/seung-lab/dijkstra3d/blob/master/libdivide.h
-    static inline __m256i avx2_mm256_srai_epi64(__m256i a, int amt, __m256i m)
+    static inline
+    __m256i avx2_mm256_srai_epi64(__m256i a, int amt, __m256i m)
     {
       // note than m must be obtained using
       // __m256i m = _mm256_set1_epi64x(1ULL << (63 - amt));
@@ -78,11 +77,11 @@ namespace ojph
           const si32 *sp = src_line->i32 + src_line_offset;
           si32 *dp = dst_line->i32 + dst_line_offset;
           __m256i sh = _mm256_set1_epi32((si32)shift);
-          for (int i = (width + 7) >> 3; i > 0; --i, sp += 8, dp += 8)
+          for (int i = (width + 7) >> 3; i > 0; --i, sp+=8, dp+=8)
           {
-            __m256i s = _mm256_loadu_si256((__m256i *)sp);
+            __m256i s = _mm256_loadu_si256((__m256i*)sp);
             s = _mm256_add_epi32(s, sh);
-            _mm256_storeu_si256((__m256i *)dp, s);
+            _mm256_storeu_si256((__m256i*)dp, s);
           }
         }
         else
@@ -90,18 +89,18 @@ namespace ojph
           const si32 *sp = src_line->i32 + src_line_offset;
           si64 *dp = dst_line->i64 + dst_line_offset;
           __m256i sh = _mm256_set1_epi64x(shift);
-          for (int i = (width + 7) >> 3; i > 0; --i, sp += 8, dp += 8)
+          for (int i = (width + 7) >> 3; i > 0; --i, sp+=8, dp+=8)
           {
             __m256i s, t;
-            s = _mm256_loadu_si256((__m256i *)sp);
+            s = _mm256_loadu_si256((__m256i*)sp);
 
             t = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(s, 0));
             t = _mm256_add_epi64(t, sh);
-            _mm256_storeu_si256((__m256i *)dp, t);
+            _mm256_storeu_si256((__m256i*)dp, t);
 
             t = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(s, 1));
             t = _mm256_add_epi64(t, sh);
-            _mm256_storeu_si256((__m256i *)dp + 1, t);
+            _mm256_storeu_si256((__m256i*)dp + 1, t);
           }
         }
       }
@@ -114,16 +113,16 @@ namespace ojph
         __m256i low_bits = _mm256_set_epi64x(0, (si64)ULLONG_MAX,
                                              0, (si64)ULLONG_MAX);
         __m256i sh = _mm256_set1_epi64x(shift);
-        for (int i = (width + 7) >> 3; i > 0; --i, sp += 8, dp += 8)
+        for (int i = (width + 7) >> 3; i > 0; --i, sp+=8, dp+=8)
         {
           __m256i s, t;
-          s = _mm256_loadu_si256((__m256i *)sp);
+          s = _mm256_loadu_si256((__m256i*)sp);
           s = _mm256_add_epi64(s, sh);
 
           t = _mm256_shuffle_epi32(s, _MM_SHUFFLE(0, 0, 2, 0));
           t = _mm256_and_si256(low_bits, t);
 
-          s = _mm256_loadu_si256((__m256i *)sp + 1);
+          s = _mm256_loadu_si256((__m256i*)sp + 1);
           s = _mm256_add_epi64(s, sh);
 
           s = _mm256_shuffle_epi32(s, _MM_SHUFFLE(2, 0, 0, 0));
@@ -131,7 +130,7 @@ namespace ojph
 
           t = _mm256_or_si256(s, t);
           t = _mm256_permute4x64_epi64(t, _MM_SHUFFLE(3, 1, 2, 0));
-          _mm256_storeu_si256((__m256i *)dp, t);
+          _mm256_storeu_si256((__m256i*)dp, t);
         }
       }
     }
@@ -153,13 +152,13 @@ namespace ojph
           __m256i zero = _mm256_setzero_si256();
           for (int i = (width + 7) >> 3; i > 0; --i, sp += 8, dp += 8)
           {
-            __m256i s = _mm256_loadu_si256((__m256i *)sp);
+            __m256i s = _mm256_loadu_si256((__m256i*)sp);
             __m256i c = _mm256_cmpgt_epi32(zero, s);  // 0xFFFFFFFF for -ve val
             __m256i v_m_sh = _mm256_sub_epi32(sh, s); // - shift - value
             v_m_sh = _mm256_and_si256(c, v_m_sh);     // keep only -shift-val
             s = _mm256_andnot_si256(c, s);            // keep only +ve or 0
             s = _mm256_or_si256(s, v_m_sh);           // combine
-            _mm256_storeu_si256((__m256i *)dp, s);
+            _mm256_storeu_si256((__m256i*)dp, s);
           }
         }
         else
@@ -171,19 +170,19 @@ namespace ojph
           for (int i = (width + 7) >> 3; i > 0; --i, sp += 8, dp += 8)
           {
             __m256i s, t, u0, u1, c, v_m_sh;
-            s = _mm256_loadu_si256((__m256i *)sp);
+            s = _mm256_loadu_si256((__m256i*)sp);
 
-            t = _mm256_cmpgt_epi32(zero, s);  // find -ve 32bit -1
-            u0 = _mm256_unpacklo_epi32(s, t); // correct 64bit data
-            c = _mm256_unpacklo_epi32(t, t);  // 64bit -1 for -ve value
+            t = _mm256_cmpgt_epi32(zero, s);      // find -ve 32bit -1
+            u0 = _mm256_unpacklo_epi32(s, t);     // correct 64bit data
+            c = _mm256_unpacklo_epi32(t, t);      // 64bit -1 for -ve value
 
             v_m_sh = _mm256_sub_epi64(sh, u0);    // - shift - value
             v_m_sh = _mm256_and_si256(c, v_m_sh); // keep only - shift - value
             u0 = _mm256_andnot_si256(c, u0);      // keep only +ve or 0
             u0 = _mm256_or_si256(u0, v_m_sh);     // combine
 
-            u1 = _mm256_unpackhi_epi32(s, t); // correct 64bit data
-            c = _mm256_unpackhi_epi32(t, t);  // 64bit -1 for -ve value
+            u1 = _mm256_unpackhi_epi32(s, t);     // correct 64bit data
+            c = _mm256_unpackhi_epi32(t, t);      // 64bit -1 for -ve value
 
             v_m_sh = _mm256_sub_epi64(sh, u1);    // - shift - value
             v_m_sh = _mm256_and_si256(c, v_m_sh); // keep only - shift - value
@@ -191,10 +190,10 @@ namespace ojph
             u1 = _mm256_or_si256(u1, v_m_sh);     // combine
 
             t = _mm256_permute2x128_si256(u0, u1, (2 << 4) | 0);
-            _mm256_storeu_si256((__m256i *)dp, t);
+            _mm256_storeu_si256((__m256i*)dp, t);
 
             t = _mm256_permute2x128_si256(u0, u1, (3 << 4) | 1);
-            _mm256_storeu_si256((__m256i *)dp + 1, t);
+            _mm256_storeu_si256((__m256i*)dp + 1, t);
           }
         }
       }
@@ -213,61 +212,64 @@ namespace ojph
           // s for source, t for target, p for positive, n for negative,
           // m for mask, and tm for temp
           __m256i s, t, p, n, m, tm;
-          s = _mm256_loadu_si256((__m256i *)sp);
+          s = _mm256_loadu_si256((__m256i*)sp);
 
-          m = _mm256_cmpgt_epi64(zero, s); // 64b -1 for -ve value
-          tm = _mm256_sub_epi64(sh, s);    // - shift - value
-          n = _mm256_and_si256(m, tm);     // -ve
-          p = _mm256_andnot_si256(m, s);   // +ve
+          m = _mm256_cmpgt_epi64(zero, s);    // 64b -1 for -ve value
+          tm = _mm256_sub_epi64(sh, s);       // - shift - value
+          n = _mm256_and_si256(m, tm);        // -ve
+          p = _mm256_andnot_si256(m, s);      // +ve
           tm = _mm256_or_si256(n, p);
           tm = _mm256_shuffle_epi32(tm, _MM_SHUFFLE(0, 0, 2, 0));
           t = _mm256_and_si256(half_mask, tm);
 
-          s = _mm256_loadu_si256((__m256i *)sp + 1);
-          m = _mm256_cmpgt_epi64(zero, s); // 64b -1 for -ve value
-          tm = _mm256_sub_epi64(sh, s);    // - shift - value
-          n = _mm256_and_si256(m, tm);     // -ve
-          p = _mm256_andnot_si256(m, s);   // +ve
+          s = _mm256_loadu_si256((__m256i*)sp + 1);
+          m = _mm256_cmpgt_epi64(zero, s);    // 64b -1 for -ve value
+          tm = _mm256_sub_epi64(sh, s);       // - shift - value
+          n = _mm256_and_si256(m, tm);        // -ve
+          p = _mm256_andnot_si256(m, s);      // +ve
           tm = _mm256_or_si256(n, p);
           tm = _mm256_shuffle_epi32(tm, _MM_SHUFFLE(2, 0, 0, 0));
           tm = _mm256_andnot_si256(half_mask, tm);
 
           t = _mm256_or_si256(t, tm);
           t = _mm256_permute4x64_epi64(t, _MM_SHUFFLE(3, 1, 2, 0));
-          _mm256_storeu_si256((__m256i *)dp, t);
+           _mm256_storeu_si256((__m256i*)dp, t);
         }
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline __m256i ojph_mm256_max_ge_epi32(__m256i a, __m256i b, __m256 x, __m256 y)
+    static inline
+    __m256i ojph_mm256_max_ge_epi32(__m256i a, __m256i b, __m256 x, __m256 y)
     {
       // We must use _CMP_NLT_UQ or _CMP_GE_OQ, _CMP_GE_OS, or _CMP_NLT_US
       // It is not clear to me which to use
       __m256 ct = _mm256_cmp_ps(x, y, _CMP_NLT_UQ); // 0xFFFFFFFF for x >= y
-      __m256i c = _mm256_castps_si256(ct);          // does not generate any code
-      __m256i d = _mm256_and_si256(c, a);           // keep only a, where x >= y
-      __m256i e = _mm256_andnot_si256(c, b);        // keep only b, where x <  y
-      return _mm256_or_si256(d, e);                 // combine
+      __m256i c = _mm256_castps_si256(ct);   // does not generate any code
+      __m256i d = _mm256_and_si256(c, a);    // keep only a, where x >= y
+      __m256i e = _mm256_andnot_si256(c, b); // keep only b, where x <  y
+      return _mm256_or_si256(d, e);          // combine
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline __m256i ojph_mm256_min_lt_epi32(__m256i a, __m256i b, __m256 x, __m256 y)
+    static inline
+    __m256i ojph_mm256_min_lt_epi32(__m256i a, __m256i b, __m256 x, __m256 y)
     {
       // We must use _CMP_LT_OQ or _CMP_NGE_UQ, _CMP_LT_OS, or _CMP_NGE_US
       // It is not clear to me which to use
       __m256 ct = _mm256_cmp_ps(x, y, _CMP_NGE_UQ); // 0xFFFFFFFF for x < y
-      __m256i c = _mm256_castps_si256(ct);          // does not generate any code
-      __m256i d = _mm256_and_si256(c, a);           // keep only a, where x <  y
-      __m256i e = _mm256_andnot_si256(c, b);        // keep only b, where x >= y
-      return _mm256_or_si256(d, e);                 // combine
+      __m256i c = _mm256_castps_si256(ct);   // does not generate any code
+      __m256i d = _mm256_and_si256(c, a);    // keep only a, where x <  y
+      __m256i e = _mm256_andnot_si256(c, b); // keep only b, where x >= y
+      return _mm256_or_si256(d, e);          // combine
     }
 
     //////////////////////////////////////////////////////////////////////////
-    template <bool NLT_TYPE3>
-    static inline void local_avx2_irv_convert_to_integer(const line_buf *src_line,
-                                                         line_buf *dst_line, ui32 dst_line_offset,
-                                                         ui32 bit_depth, bool is_signed, ui32 width)
+    template<bool NLT_TYPE3>
+    static inline
+    void local_avx2_irv_convert_to_integer(const line_buf *src_line,
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       assert((src_line->flags & line_buf::LFT_32BIT) &&
              (src_line->flags & line_buf::LFT_INTEGER) == 0 &&
@@ -275,8 +277,8 @@ namespace ojph
              (dst_line->flags & line_buf::LFT_INTEGER));
 
       assert(bit_depth <= 32);
-      const float *sp = src_line->f32;
-      si32 *dp = dst_line->i32 + dst_line_offset;
+      const float* sp = src_line->f32;
+      si32* dp = dst_line->i32 + dst_line_offset;
       // There is the possibility that converting to integer will
       // exceed the dynamic range of 32bit integer; therefore, care must be
       // exercised.
@@ -285,23 +287,22 @@ namespace ojph
       // to the maximum/minimum that number supports.
       si32 neg_limit = (si32)INT_MIN >> (32 - bit_depth);
       __m256 mul = _mm256_set1_ps((float)(1ull << bit_depth));
-      __m256 fl_up_lim = _mm256_set1_ps(-(float)neg_limit); // val < upper
-      __m256 fl_low_lim = _mm256_set1_ps((float)neg_limit); // val >= lower
+      __m256 fl_up_lim = _mm256_set1_ps(-(float)neg_limit);  // val < upper
+      __m256 fl_low_lim = _mm256_set1_ps((float)neg_limit);  // val >= lower
       __m256i s32_up_lim = _mm256_set1_epi32(INT_MAX >> (32 - bit_depth));
       __m256i s32_low_lim = _mm256_set1_epi32(INT_MIN >> (32 - bit_depth));
 
       if (is_signed)
       {
         __m256i zero = _mm256_setzero_si256();
-        __m256i bias =
-            _mm256_set1_epi32(-(si32)((1ULL << (bit_depth - 1)) + 1));
-        for (int i = (int)width; i > 0; i -= 8, sp += 8, dp += 8)
-        {
+        __m256i bias = 
+          _mm256_set1_epi32(-(si32)((1ULL << (bit_depth - 1)) + 1));
+        for (int i = (int)width; i > 0; i -= 8, sp += 8, dp += 8) {
           __m256 t = _mm256_loadu_ps(sp);
           t = _mm256_mul_ps(t, mul);
           __m256i u = _mm256_cvtps_epi32(t);
           u = ojph_mm256_max_ge_epi32(u, s32_low_lim, t, fl_low_lim);
-          u = ojph_mm256_min_lt_epi32(u, s32_up_lim, t, fl_up_lim);
+          u = ojph_mm256_min_lt_epi32(u,  s32_up_lim, t,  fl_up_lim);
           if (NLT_TYPE3)
           {
             __m256i c = _mm256_cmpgt_epi32(zero, u); // 0xFFFFFFFF for -ve val
@@ -310,48 +311,48 @@ namespace ojph
             u = _mm256_andnot_si256(c, u);           // keep only +ve or 0
             u = _mm256_or_si256(neg, u);             // combine
           }
-          _mm256_storeu_si256((__m256i *)dp, u);
+          _mm256_storeu_si256((__m256i*)dp, u);
         }
       }
       else
       {
         __m256i half = _mm256_set1_epi32((si32)(1ULL << (bit_depth - 1)));
-        for (int i = (int)width; i > 0; i -= 8, sp += 8, dp += 8)
-        {
+        for (int i = (int)width; i > 0; i -= 8, sp += 8, dp += 8) {
           __m256 t = _mm256_loadu_ps(sp);
           t = _mm256_mul_ps(t, mul);
           __m256i u = _mm256_cvtps_epi32(t);
           u = ojph_mm256_max_ge_epi32(u, s32_low_lim, t, fl_low_lim);
-          u = ojph_mm256_min_lt_epi32(u, s32_up_lim, t, fl_up_lim);
+          u = ojph_mm256_min_lt_epi32(u,  s32_up_lim, t,  fl_up_lim);
           u = _mm256_add_epi32(u, half);
-          _mm256_storeu_si256((__m256i *)dp, u);
+          _mm256_storeu_si256((__m256i*)dp, u);
         }
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_irv_convert_to_integer(const line_buf *src_line,
-                                     line_buf *dst_line, ui32 dst_line_offset,
-                                     ui32 bit_depth, bool is_signed, ui32 width)
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
-      local_avx2_irv_convert_to_integer<false>(src_line, dst_line,
-                                               dst_line_offset, bit_depth, is_signed, width);
+      local_avx2_irv_convert_to_integer<false>(src_line, dst_line, 
+        dst_line_offset, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_irv_convert_to_integer_nlt_type3(const line_buf *src_line,
-                                               line_buf *dst_line, ui32 dst_line_offset,
-                                               ui32 bit_depth, bool is_signed, ui32 width)
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
-      local_avx2_irv_convert_to_integer<true>(src_line, dst_line,
-                                              dst_line_offset, bit_depth, is_signed, width);
+      local_avx2_irv_convert_to_integer<true>(src_line, dst_line, 
+        dst_line_offset, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    template <bool NLT_TYPE3>
-    static inline void local_avx2_irv_convert_to_float(const line_buf *src_line,
-                                                       ui32 src_line_offset, line_buf *dst_line,
-                                                       ui32 bit_depth, bool is_signed, ui32 width)
+    template<bool NLT_TYPE3>
+    static inline    
+    void local_avx2_irv_convert_to_float(const line_buf *src_line,
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       assert((src_line->flags & line_buf::LFT_32BIT) &&
              (src_line->flags & line_buf::LFT_INTEGER) &&
@@ -361,18 +362,17 @@ namespace ojph
       assert(bit_depth <= 32);
       __m256 mul = _mm256_set1_ps((float)(1.0 / (double)(1ULL << bit_depth)));
 
-      const si32 *sp = src_line->i32 + src_line_offset;
-      float *dp = dst_line->f32;
+      const si32* sp = src_line->i32 + src_line_offset;
+      float* dp = dst_line->f32;
       if (is_signed)
       {
         __m256i zero = _mm256_setzero_si256();
-        __m256i bias =
-            _mm256_set1_epi32(-(si32)((1ULL << (bit_depth - 1)) + 1));
-        for (int i = (int)width; i > 0; i -= 8, sp += 8, dp += 8)
-        {
-          __m256i t = _mm256_loadu_si256((__m256i *)sp);
+        __m256i bias = 
+          _mm256_set1_epi32(-(si32)((1ULL << (bit_depth - 1)) + 1));
+        for (int i = (int)width; i > 0; i -= 8, sp += 8, dp += 8) {
+          __m256i t = _mm256_loadu_si256((__m256i*)sp);
           if (NLT_TYPE3)
-          {
+          {          
             __m256i c = _mm256_cmpgt_epi32(zero, t); // 0xFFFFFFFF for -ve val
             __m256i neg = _mm256_sub_epi32(bias, t); // - bias - value
             neg = _mm256_and_si256(c, neg);          // keep only - bias - val
@@ -387,9 +387,8 @@ namespace ojph
       else
       {
         __m256i half = _mm256_set1_epi32((si32)(1ULL << (bit_depth - 1)));
-        for (int i = (int)width; i > 0; i -= 8, sp += 8, dp += 8)
-        {
-          __m256i t = _mm256_loadu_si256((__m256i *)sp);
+        for (int i = (int)width; i > 0; i -= 8, sp += 8, dp += 8) {
+          __m256i t = _mm256_loadu_si256((__m256i*)sp);
           t = _mm256_sub_epi32(t, half);
           __m256 v = _mm256_cvtepi32_ps(t);
           v = _mm256_mul_ps(v, mul);
@@ -398,23 +397,24 @@ namespace ojph
       }
     }
 
-    //////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////////
     void avx2_irv_convert_to_float(const line_buf *src_line,
-                                   ui32 src_line_offset, line_buf *dst_line,
-                                   ui32 bit_depth, bool is_signed, ui32 width)
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_avx2_irv_convert_to_float<false>(src_line, src_line_offset,
-                                             dst_line, bit_depth, is_signed, width);
+        dst_line, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_irv_convert_to_float_nlt_type3(const line_buf *src_line,
-                                             ui32 src_line_offset, line_buf *dst_line,
-                                             ui32 bit_depth, bool is_signed, ui32 width)
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_avx2_irv_convert_to_float<true>(src_line, src_line_offset,
-                                            dst_line, bit_depth, is_signed, width);
+        dst_line, bit_depth, is_signed, width);
     }
+
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_rct_forward(const line_buf *r,
@@ -423,60 +423,56 @@ namespace ojph
                           line_buf *y, line_buf *cb, line_buf *cr,
                           ui32 repeat)
     {
-      assert((y->flags & line_buf::LFT_INTEGER) &&
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
              (cb->flags & line_buf::LFT_INTEGER) &&
              (cr->flags & line_buf::LFT_INTEGER) &&
-             (r->flags & line_buf::LFT_INTEGER) &&
-             (g->flags & line_buf::LFT_INTEGER) &&
-             (b->flags & line_buf::LFT_INTEGER));
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
 
-      if (y->flags & line_buf::LFT_32BIT)
+      if  (y->flags & line_buf::LFT_32BIT)
       {
-        assert((y->flags & line_buf::LFT_32BIT) &&
+        assert((y->flags  & line_buf::LFT_32BIT) &&
                (cb->flags & line_buf::LFT_32BIT) &&
                (cr->flags & line_buf::LFT_32BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
-        const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
-        si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
+        const si32 *rp = r->i32, * gp = g->i32, * bp = b->i32;
+        si32 *yp = y->i32, * cbp = cb->i32, * crp = cr->i32;
         for (int i = (repeat + 7) >> 3; i > 0; --i)
         {
-          __m256i mr = _mm256_load_si256((__m256i *)rp);
-          __m256i mg = _mm256_load_si256((__m256i *)gp);
-          __m256i mb = _mm256_load_si256((__m256i *)bp);
+          __m256i mr = _mm256_load_si256((__m256i*)rp);
+          __m256i mg = _mm256_load_si256((__m256i*)gp);
+          __m256i mb = _mm256_load_si256((__m256i*)bp);
           __m256i t = _mm256_add_epi32(mr, mb);
           t = _mm256_add_epi32(t, _mm256_slli_epi32(mg, 1));
-          _mm256_store_si256((__m256i *)yp, _mm256_srai_epi32(t, 2));
+          _mm256_store_si256((__m256i*)yp, _mm256_srai_epi32(t, 2));
           t = _mm256_sub_epi32(mb, mg);
-          _mm256_store_si256((__m256i *)cbp, t);
+          _mm256_store_si256((__m256i*)cbp, t);
           t = _mm256_sub_epi32(mr, mg);
-          _mm256_store_si256((__m256i *)crp, t);
+          _mm256_store_si256((__m256i*)crp, t);
 
-          rp += 8;
-          gp += 8;
-          bp += 8;
-          yp += 8;
-          cbp += 8;
-          crp += 8;
+          rp += 8; gp += 8; bp += 8;
+          yp += 8; cbp += 8; crp += 8;
         }
       }
       else
       {
-        assert((y->flags & line_buf::LFT_64BIT) &&
+        assert((y->flags  & line_buf::LFT_64BIT) &&
                (cb->flags & line_buf::LFT_64BIT) &&
                (cr->flags & line_buf::LFT_64BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         __m256i v2 = _mm256_set1_epi64x(1ULL << (63 - 2));
         const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
         for (int i = (repeat + 7) >> 3; i > 0; --i)
         {
-          __m256i mr32 = _mm256_load_si256((__m256i *)rp);
-          __m256i mg32 = _mm256_load_si256((__m256i *)gp);
-          __m256i mb32 = _mm256_load_si256((__m256i *)bp);
+          __m256i mr32 = _mm256_load_si256((__m256i*)rp);
+          __m256i mg32 = _mm256_load_si256((__m256i*)gp);
+          __m256i mb32 = _mm256_load_si256((__m256i*)bp);
           __m256i mr, mg, mb, t;
           mr = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(mr32, 0));
           mg = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(mg32, 0));
@@ -484,15 +480,13 @@ namespace ojph
 
           t = _mm256_add_epi64(mr, mb);
           t = _mm256_add_epi64(t, _mm256_slli_epi64(mg, 1));
-          _mm256_store_si256((__m256i *)yp, avx2_mm256_srai_epi64(t, 2, v2));
+          _mm256_store_si256((__m256i*)yp, avx2_mm256_srai_epi64(t, 2, v2));
           t = _mm256_sub_epi64(mb, mg);
-          _mm256_store_si256((__m256i *)cbp, t);
+          _mm256_store_si256((__m256i*)cbp, t);
           t = _mm256_sub_epi64(mr, mg);
-          _mm256_store_si256((__m256i *)crp, t);
+          _mm256_store_si256((__m256i*)crp, t);
 
-          yp += 4;
-          cbp += 4;
-          crp += 4;
+          yp += 4; cbp += 4; crp += 4;
 
           mr = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(mr32, 1));
           mg = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(mg32, 1));
@@ -500,18 +494,14 @@ namespace ojph
 
           t = _mm256_add_epi64(mr, mb);
           t = _mm256_add_epi64(t, _mm256_slli_epi64(mg, 1));
-          _mm256_store_si256((__m256i *)yp, avx2_mm256_srai_epi64(t, 2, v2));
+          _mm256_store_si256((__m256i*)yp, avx2_mm256_srai_epi64(t, 2, v2));
           t = _mm256_sub_epi64(mb, mg);
-          _mm256_store_si256((__m256i *)cbp, t);
+          _mm256_store_si256((__m256i*)cbp, t);
           t = _mm256_sub_epi64(mr, mg);
-          _mm256_store_si256((__m256i *)crp, t);
+          _mm256_store_si256((__m256i*)crp, t);
 
-          rp += 8;
-          gp += 8;
-          bp += 8;
-          yp += 4;
-          cbp += 4;
-          crp += 4;
+          rp += 8; gp += 8; bp += 8;
+          yp += 4; cbp += 4; crp += 4;
         }
       }
     }
@@ -523,53 +513,49 @@ namespace ojph
                            line_buf *r, line_buf *g, line_buf *b,
                            ui32 repeat)
     {
-      assert((y->flags & line_buf::LFT_INTEGER) &&
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
              (cb->flags & line_buf::LFT_INTEGER) &&
              (cr->flags & line_buf::LFT_INTEGER) &&
-             (r->flags & line_buf::LFT_INTEGER) &&
-             (g->flags & line_buf::LFT_INTEGER) &&
-             (b->flags & line_buf::LFT_INTEGER));
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
 
       if (y->flags & line_buf::LFT_32BIT)
       {
-        assert((y->flags & line_buf::LFT_32BIT) &&
+        assert((y->flags  & line_buf::LFT_32BIT) &&
                (cb->flags & line_buf::LFT_32BIT) &&
                (cr->flags & line_buf::LFT_32BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         const si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
         si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         for (int i = (repeat + 7) >> 3; i > 0; --i)
         {
-          __m256i my = _mm256_load_si256((__m256i *)yp);
-          __m256i mcb = _mm256_load_si256((__m256i *)cbp);
-          __m256i mcr = _mm256_load_si256((__m256i *)crp);
+          __m256i my  = _mm256_load_si256((__m256i*)yp);
+          __m256i mcb = _mm256_load_si256((__m256i*)cbp);
+          __m256i mcr = _mm256_load_si256((__m256i*)crp);
 
           __m256i t = _mm256_add_epi32(mcb, mcr);
           t = _mm256_sub_epi32(my, _mm256_srai_epi32(t, 2));
-          _mm256_store_si256((__m256i *)gp, t);
+          _mm256_store_si256((__m256i*)gp, t);
           __m256i u = _mm256_add_epi32(mcb, t);
-          _mm256_store_si256((__m256i *)bp, u);
+          _mm256_store_si256((__m256i*)bp, u);
           u = _mm256_add_epi32(mcr, t);
-          _mm256_store_si256((__m256i *)rp, u);
+          _mm256_store_si256((__m256i*)rp, u);
 
-          yp += 8;
-          cbp += 8;
-          crp += 8;
-          rp += 8;
-          gp += 8;
-          bp += 8;
+          yp += 8; cbp += 8; crp += 8;
+          rp += 8; gp += 8; bp += 8;
         }
       }
       else
       {
-        assert((y->flags & line_buf::LFT_64BIT) &&
+        assert((y->flags  & line_buf::LFT_64BIT) &&
                (cb->flags & line_buf::LFT_64BIT) &&
                (cr->flags & line_buf::LFT_64BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         __m256i v2 = _mm256_set1_epi64x(1ULL << (63 - 2));
         __m256i low_bits = _mm256_set_epi64x(0, (si64)ULLONG_MAX,
                                              0, (si64)ULLONG_MAX);
@@ -578,9 +564,9 @@ namespace ojph
         for (int i = (repeat + 7) >> 3; i > 0; --i)
         {
           __m256i my, mcb, mcr, tr, tg, tb;
-          my = _mm256_load_si256((__m256i *)yp);
-          mcb = _mm256_load_si256((__m256i *)cbp);
-          mcr = _mm256_load_si256((__m256i *)crp);
+          my  = _mm256_load_si256((__m256i*)yp);
+          mcb = _mm256_load_si256((__m256i*)cbp);
+          mcr = _mm256_load_si256((__m256i*)crp);
 
           tg = _mm256_add_epi64(mcb, mcr);
           tg = _mm256_sub_epi64(my, avx2_mm256_srai_epi64(tg, 2, v2));
@@ -595,13 +581,11 @@ namespace ojph
           mb = _mm256_shuffle_epi32(tb, _MM_SHUFFLE(0, 0, 2, 0));
           mb = _mm256_and_si256(low_bits, mb);
 
-          yp += 4;
-          cbp += 4;
-          crp += 4;
+          yp += 4; cbp += 4; crp += 4;
 
-          my = _mm256_load_si256((__m256i *)yp);
-          mcb = _mm256_load_si256((__m256i *)cbp);
-          mcr = _mm256_load_si256((__m256i *)crp);
+          my  = _mm256_load_si256((__m256i*)yp);
+          mcb = _mm256_load_si256((__m256i*)cbp);
+          mcr = _mm256_load_si256((__m256i*)crp);
 
           tg = _mm256_add_epi64(mcb, mcr);
           tg = _mm256_sub_epi64(my, avx2_mm256_srai_epi64(tg, 2, v2));
@@ -623,16 +607,12 @@ namespace ojph
           mb = _mm256_or_si256(mb, tb);
           mb = _mm256_permute4x64_epi64(mb, _MM_SHUFFLE(3, 1, 2, 0));
 
-          _mm256_store_si256((__m256i *)rp, mr);
-          _mm256_store_si256((__m256i *)gp, mg);
-          _mm256_store_si256((__m256i *)bp, mb);
+          _mm256_store_si256((__m256i*)rp, mr);
+          _mm256_store_si256((__m256i*)gp, mg);
+          _mm256_store_si256((__m256i*)bp, mb);
 
-          yp += 4;
-          cbp += 4;
-          crp += 4;
-          rp += 8;
-          gp += 8;
-          bp += 8;
+          yp += 4; cbp += 4; crp += 4;
+          rp += 8; gp += 8; bp += 8;
         }
       }
     }

--- a/Native/Common/OpenJPH/transform/ojph_colour_local.h
+++ b/Native/Common/OpenJPH/transform/ojph_colour_local.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,13 +35,12 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_COLOR_LOCAL_H
 #define OJPH_COLOR_LOCAL_H
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     struct CT_CNST
     {
@@ -67,45 +66,45 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rev_convert(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width);
+      const line_buf *src_line, const ui32 src_line_offset, 
+      line_buf *dst_line, const ui32 dst_line_offset, 
+      si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rev_convert_nlt_type3(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width);
+      const line_buf *src_line, const ui32 src_line_offset, 
+      line_buf *dst_line, const ui32 dst_line_offset, 
+      si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_convert_to_float(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_convert_to_integer(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_convert_to_float_nlt_type3(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_convert_to_integer_nlt_type3(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rct_forward(
-        const line_buf *r, const line_buf *g, const line_buf *b,
-        line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
+      const line_buf *r, const line_buf *g, const line_buf *b,
+      line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rct_backward(
-        const line_buf *y, const line_buf *cb, const line_buf *cr,
-        line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
+      const line_buf *y, const line_buf *cb, const line_buf *cr,
+      line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_ict_forward(const float *r, const float *g, const float *b,
@@ -141,13 +140,13 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_convert_to_integer(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_convert_to_integer_nlt_type3(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     //
@@ -159,35 +158,35 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_rev_convert(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width);
+      const line_buf *src_line, const ui32 src_line_offset, 
+      line_buf *dst_line, const ui32 dst_line_offset, 
+      si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_rev_convert_nlt_type3(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width);
+      const line_buf *src_line, const ui32 src_line_offset, 
+      line_buf *dst_line, const ui32 dst_line_offset, 
+      si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_convert_to_float(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_convert_to_float_nlt_type3(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_rct_forward(
-        const line_buf *r, const line_buf *g, const line_buf *b,
-        line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
+      const line_buf *r, const line_buf *g, const line_buf *b,
+      line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_rct_backward(
-        const line_buf *y, const line_buf *cb, const line_buf *cr,
-        line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
+      const line_buf *y, const line_buf *cb, const line_buf *cr,
+      line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
 
     //////////////////////////////////////////////////////////////////////////
     //
@@ -215,95 +214,95 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_rev_convert(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width);
+      const line_buf *src_line, const ui32 src_line_offset, 
+      line_buf *dst_line, const ui32 dst_line_offset, 
+      si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_rev_convert_nlt_type3(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width);
+      const line_buf *src_line, const ui32 src_line_offset, 
+      line_buf *dst_line, const ui32 dst_line_offset, 
+      si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_irv_convert_to_integer(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_irv_convert_to_float(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_irv_convert_to_integer_nlt_type3(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_irv_convert_to_float_nlt_type3(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_rct_forward(
-        const line_buf *r, const line_buf *g, const line_buf *b,
-        line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
+      const line_buf *r, const line_buf *g, const line_buf *b,
+      line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_rct_backward(
-        const line_buf *y, const line_buf *cb, const line_buf *cr,
-        line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
+      const line_buf *y, const line_buf *cb, const line_buf *cr,
+      line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
 
     //////////////////////////////////////////////////////////////////////////
     //
     //
-    //                              WASM Functions
+    //                              WASM Functions 
     //
     //
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_convert_to_integer(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_convert_to_float(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_rev_convert(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width);
+      const line_buf *src_line, const ui32 src_line_offset, 
+      line_buf *dst_line, const ui32 dst_line_offset, 
+      si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_rev_convert_nlt_type3(
-        const line_buf *src_line, const ui32 src_line_offset,
-        line_buf *dst_line, const ui32 dst_line_offset,
-        si64 shift, ui32 width);
+      const line_buf *src_line, const ui32 src_line_offset, 
+      line_buf *dst_line, const ui32 dst_line_offset, 
+      si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_convert_to_integer_nlt_type3(
-        const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
-        ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_convert_to_float_nlt_type3(
-        const line_buf *src_line, ui32 src_line_offset,
-        line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_rct_forward(
-        const line_buf *r, const line_buf *g, const line_buf *b,
-        line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
+      const line_buf *r, const line_buf *g, const line_buf *b,
+      line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_rct_backward(
-        const line_buf *y, const line_buf *cb, const line_buf *cr,
-        line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
+      const line_buf *y, const line_buf *cb, const line_buf *cr,
+      line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_ict_forward(const float *r, const float *g, const float *b,
@@ -315,5 +314,7 @@ namespace ojph
 
   }
 }
+
+
 
 #endif // !OJPH_COLOR_LOCAL_H

--- a/Native/Common/OpenJPH/transform/ojph_colour_sse.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_colour_sse.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -46,10 +46,8 @@
 
 #include <xmmintrin.h>
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
     void sse_ict_forward(const float *r, const float *g, const float *b,
@@ -70,13 +68,9 @@ namespace ojph
         _mm_store_ps(y, my);
         _mm_store_ps(cb, _mm_mul_ps(beta_cbf, _mm_sub_ps(mb, my)));
         _mm_store_ps(cr, _mm_mul_ps(beta_crf, _mm_sub_ps(mr, my)));
-
-        r += 4;
-        g += 4;
-        b += 4;
-        y += 4;
-        cb += 4;
-        cr += 4;
+        
+        r += 4; g += 4; b += 4;
+        y += 4; cb += 4; cr += 4;
       }
     }
 
@@ -98,12 +92,8 @@ namespace ojph
         _mm_store_ps(r, _mm_add_ps(my, _mm_mul_ps(gamma_cr2r, mcr)));
         _mm_store_ps(b, _mm_add_ps(my, _mm_mul_ps(gamma_cb2b, mcb)));
 
-        y += 4;
-        cb += 4;
-        cr += 4;
-        r += 4;
-        g += 4;
-        b += 4;
+        y += 4; cb += 4; cr += 4;
+        r += 4; g += 4; b += 4;
       }
     }
   }

--- a/Native/Common/OpenJPH/transform/ojph_colour_sse2.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_colour_sse2.cpp
@@ -47,25 +47,23 @@
 
 #include <emmintrin.h>
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_cnvrt_float_to_si32_shftd(const float *sp, si32 *dp, float mul,
-                                        ui32 width)
+                                       ui32 width)
     {
       uint32_t rounding_mode = _MM_GET_ROUNDING_MODE();
       _MM_SET_ROUNDING_MODE(_MM_ROUND_NEAREST);
       __m128 shift = _mm_set1_ps(0.5f);
       __m128 m = _mm_set1_ps(mul);
-      for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+      for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
       {
         __m128 t = _mm_loadu_ps(sp);
         __m128 s = _mm_add_ps(t, shift);
         s = _mm_mul_ps(s, m);
-        _mm_storeu_si128((__m128i *)dp, _mm_cvtps_epi32(s));
+        _mm_storeu_si128((__m128i*)dp, _mm_cvtps_epi32(s));
       }
       _MM_SET_ROUNDING_MODE(rounding_mode);
     }
@@ -77,17 +75,18 @@ namespace ojph
       uint32_t rounding_mode = _MM_GET_ROUNDING_MODE();
       _MM_SET_ROUNDING_MODE(_MM_ROUND_NEAREST);
       __m128 m = _mm_set1_ps(mul);
-      for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+      for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
       {
         __m128 t = _mm_loadu_ps(sp);
         __m128 s = _mm_mul_ps(t, m);
-        _mm_storeu_si128((__m128i *)dp, _mm_cvtps_epi32(s));
+        _mm_storeu_si128((__m128i*)dp, _mm_cvtps_epi32(s));
       }
       _MM_SET_ROUNDING_MODE(rounding_mode);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline __m128i ojph_mm_max_ge_epi32(__m128i a, __m128i b, __m128 x, __m128 y)
+    static inline
+    __m128i ojph_mm_max_ge_epi32(__m128i a, __m128i b, __m128 x, __m128 y)
     {
       __m128 ct = _mm_cmpge_ps(x, y);     // 0xFFFFFFFF for x >= y
       __m128i c = _mm_castps_si128(ct);   // does not generate any code
@@ -97,7 +96,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline __m128i ojph_mm_min_lt_epi32(__m128i a, __m128i b, __m128 x, __m128 y)
+    static inline
+    __m128i ojph_mm_min_lt_epi32(__m128i a, __m128i b, __m128 x, __m128 y)
     {
       __m128 ct = _mm_cmplt_ps(x, y);     // 0xFFFFFFFF for x < y
       __m128i c = _mm_castps_si128(ct);   // does not generate any code
@@ -108,9 +108,10 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     template <bool NLT_TYPE3>
-    static inline void local_sse2_irv_convert_to_integer(const line_buf *src_line,
-                                                         line_buf *dst_line, ui32 dst_line_offset,
-                                                         ui32 bit_depth, bool is_signed, ui32 width)
+    static inline
+    void local_sse2_irv_convert_to_integer(const line_buf *src_line,
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       assert((src_line->flags & line_buf::LFT_32BIT) &&
              (src_line->flags & line_buf::LFT_INTEGER) == 0 &&
@@ -121,8 +122,8 @@ namespace ojph
       uint32_t rounding_mode = _MM_GET_ROUNDING_MODE();
       _MM_SET_ROUNDING_MODE(_MM_ROUND_NEAREST);
 
-      const float *sp = src_line->f32;
-      si32 *dp = dst_line->i32 + dst_line_offset;
+      const float* sp = src_line->f32;
+      si32* dp = dst_line->i32 + dst_line_offset;
       // There is the possibility that converting to integer will
       // exceed the dynamic range of 32bit integer; therefore, care must be
       // exercised.
@@ -140,8 +141,7 @@ namespace ojph
       {
         __m128i zero = _mm_setzero_si128();
         __m128i bias = _mm_set1_epi32(-(si32)((1ULL << (bit_depth - 1)) + 1));
-        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4)
-        {
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
           __m128 t = _mm_loadu_ps(sp);
           t = _mm_mul_ps(t, mul);
           __m128i u = _mm_cvtps_epi32(t);
@@ -149,27 +149,26 @@ namespace ojph
           u = ojph_mm_min_lt_epi32(u, s32_up_lim, t, fl_up_lim);
           if (NLT_TYPE3)
           {
-            __m128i c = _mm_cmpgt_epi32(zero, u); // 0xFFFFFFFF for -ve value
+            __m128i c = _mm_cmpgt_epi32(zero, u); //0xFFFFFFFF for -ve value
             __m128i neg = _mm_sub_epi32(bias, u); //-bias -value
-            neg = _mm_and_si128(c, neg);          // keep only - bias - value
-            u = _mm_andnot_si128(c, u);           // keep only +ve or 0
-            u = _mm_or_si128(neg, u);             // combine
+            neg = _mm_and_si128(c, neg);          //keep only - bias - value
+            u = _mm_andnot_si128(c, u);           //keep only +ve or 0
+            u = _mm_or_si128(neg, u);             //combine
           }
-          _mm_storeu_si128((__m128i *)dp, u);
+          _mm_storeu_si128((__m128i*)dp, u);
         }
       }
       else
       {
         __m128i half = _mm_set1_epi32((si32)(1ULL << (bit_depth - 1)));
-        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4)
-        {
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
           __m128 t = _mm_loadu_ps(sp);
           t = _mm_mul_ps(t, mul);
           __m128i u = _mm_cvtps_epi32(t);
           u = ojph_mm_max_ge_epi32(u, s32_low_lim, t, fl_low_lim);
           u = ojph_mm_min_lt_epi32(u, s32_up_lim, t, fl_up_lim);
           u = _mm_add_epi32(u, half);
-          _mm_storeu_si128((__m128i *)dp, u);
+          _mm_storeu_si128((__m128i*)dp, u);
         }
       }
 
@@ -178,20 +177,20 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_convert_to_integer(const line_buf *src_line,
-                                     line_buf *dst_line, ui32 dst_line_offset,
-                                     ui32 bit_depth, bool is_signed, ui32 width)
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
-      local_sse2_irv_convert_to_integer<false>(src_line, dst_line,
-                                               dst_line_offset, bit_depth, is_signed, width);
+      local_sse2_irv_convert_to_integer<false>(src_line, dst_line, 
+        dst_line_offset, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_convert_to_integer_nlt_type3(const line_buf *src_line,
-                                               line_buf *dst_line, ui32 dst_line_offset,
-                                               ui32 bit_depth, bool is_signed, ui32 width)
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
-      local_sse2_irv_convert_to_integer<true>(src_line, dst_line,
-                                              dst_line_offset, bit_depth, is_signed, width);
+      local_sse2_irv_convert_to_integer<true>(src_line, dst_line, 
+        dst_line_offset, bit_depth, is_signed, width);
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -210,7 +209,7 @@ namespace ojph
     static inline __m128i sse2_cvtlo_epi32_epi64(__m128i a, __m128i zero)
     {
       __m128i t;
-      t = _mm_cmplt_epi32(a, zero); // get -ve
+      t = _mm_cmplt_epi32(a, zero);      // get -ve
       t = _mm_unpacklo_epi32(a, t);
       return t;
     }
@@ -219,7 +218,7 @@ namespace ojph
     static inline __m128i sse2_cvthi_epi32_epi64(__m128i a, __m128i zero)
     {
       __m128i t;
-      t = _mm_cmplt_epi32(a, zero); // get -ve
+      t = _mm_cmplt_epi32(a, zero);      // get -ve
       t = _mm_unpackhi_epi32(a, t);
       return t;
     }
@@ -238,11 +237,11 @@ namespace ojph
           const si32 *sp = src_line->i32 + src_line_offset;
           si32 *dp = dst_line->i32 + dst_line_offset;
           __m128i sh = _mm_set1_epi32((si32)shift);
-          for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+          for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
           {
-            __m128i s = _mm_loadu_si128((__m128i *)sp);
+            __m128i s = _mm_loadu_si128((__m128i*)sp);
             s = _mm_add_epi32(s, sh);
-            _mm_storeu_si128((__m128i *)dp, s);
+            _mm_storeu_si128((__m128i*)dp, s);
           }
         }
         else
@@ -251,18 +250,18 @@ namespace ojph
           si64 *dp = dst_line->i64 + dst_line_offset;
           __m128i zero = _mm_setzero_si128();
           __m128i sh = _mm_set1_epi64x(shift);
-          for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+          for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
           {
             __m128i s, t;
-            s = _mm_loadu_si128((__m128i *)sp);
+            s = _mm_loadu_si128((__m128i*)sp);
 
             t = sse2_cvtlo_epi32_epi64(s, zero);
             t = _mm_add_epi64(t, sh);
-            _mm_storeu_si128((__m128i *)dp, t);
+            _mm_storeu_si128((__m128i*)dp, t);
 
             t = sse2_cvthi_epi32_epi64(s, zero);
             t = _mm_add_epi64(t, sh);
-            _mm_storeu_si128((__m128i *)dp + 1, t);
+            _mm_storeu_si128((__m128i*)dp + 1, t);
           }
         }
       }
@@ -274,23 +273,23 @@ namespace ojph
         si32 *dp = dst_line->i32 + dst_line_offset;
         __m128i low_bits = _mm_set_epi64x(0, (si64)ULLONG_MAX);
         __m128i sh = _mm_set1_epi64x(shift);
-        for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+        for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
         {
           __m128i s, t;
-          s = _mm_loadu_si128((__m128i *)sp);
+          s = _mm_loadu_si128((__m128i*)sp);
           s = _mm_add_epi64(s, sh);
 
           t = _mm_shuffle_epi32(s, _MM_SHUFFLE(0, 0, 2, 0));
           t = _mm_and_si128(low_bits, t);
 
-          s = _mm_loadu_si128((__m128i *)sp + 1);
+          s = _mm_loadu_si128((__m128i*)sp + 1);
           s = _mm_add_epi64(s, sh);
 
           s = _mm_shuffle_epi32(s, _MM_SHUFFLE(2, 0, 0, 0));
           s = _mm_andnot_si128(low_bits, s);
 
           t = _mm_or_si128(s, t);
-          _mm_storeu_si128((__m128i *)dp, t);
+          _mm_storeu_si128((__m128i*)dp, t);
         }
       }
     }
@@ -312,13 +311,13 @@ namespace ojph
           __m128i zero = _mm_setzero_si128();
           for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
           {
-            __m128i s = _mm_loadu_si128((__m128i *)sp);
+            __m128i s = _mm_loadu_si128((__m128i*)sp);
             __m128i c = _mm_cmplt_epi32(s, zero);  // 0xFFFFFFFF for -ve value
             __m128i v_m_sh = _mm_sub_epi32(sh, s); // - shift - value
             v_m_sh = _mm_and_si128(c, v_m_sh);     // keep only - shift - value
             s = _mm_andnot_si128(c, s);            // keep only +ve or 0
             s = _mm_or_si128(s, v_m_sh);           // combine
-            _mm_storeu_si128((__m128i *)dp, s);
+            _mm_storeu_si128((__m128i*)dp, s);
           }
         }
         else
@@ -330,27 +329,27 @@ namespace ojph
           for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
           {
             __m128i s, t, u, c, v_m_sh;
-            s = _mm_loadu_si128((__m128i *)sp);
+            s = _mm_loadu_si128((__m128i*)sp);
 
-            t = _mm_cmplt_epi32(s, zero); // find -ve 32bit -1
-            u = _mm_unpacklo_epi32(s, t); // correct 64bit data
-            c = _mm_unpacklo_epi32(t, t); // 64bit -1 for -ve value
-
-            v_m_sh = _mm_sub_epi64(sh, u);     // - shift - value
-            v_m_sh = _mm_and_si128(c, v_m_sh); // keep only - shift - value
-            u = _mm_andnot_si128(c, u);        // keep only +ve or 0
-            u = _mm_or_si128(u, v_m_sh);       // combine
-
-            _mm_storeu_si128((__m128i *)dp, u);
-            u = _mm_unpackhi_epi32(s, t); // correct 64bit data
-            c = _mm_unpackhi_epi32(t, t); // 64bit -1 for -ve value
+            t = _mm_cmplt_epi32(s, zero);      // find -ve 32bit -1
+            u = _mm_unpacklo_epi32(s, t);      // correct 64bit data
+            c = _mm_unpacklo_epi32(t, t);      // 64bit -1 for -ve value
 
             v_m_sh = _mm_sub_epi64(sh, u);     // - shift - value
             v_m_sh = _mm_and_si128(c, v_m_sh); // keep only - shift - value
             u = _mm_andnot_si128(c, u);        // keep only +ve or 0
             u = _mm_or_si128(u, v_m_sh);       // combine
 
-            _mm_storeu_si128((__m128i *)dp + 1, u);
+            _mm_storeu_si128((__m128i*)dp, u);
+            u = _mm_unpackhi_epi32(s, t);      // correct 64bit data
+            c = _mm_unpackhi_epi32(t, t);      // 64bit -1 for -ve value
+
+            v_m_sh = _mm_sub_epi64(sh, u);     // - shift - value
+            v_m_sh = _mm_and_si128(c, v_m_sh); // keep only - shift - value
+            u = _mm_andnot_si128(c, u);        // keep only +ve or 0
+            u = _mm_or_si128(u, v_m_sh);       // combine
+
+            _mm_storeu_si128((__m128i*)dp + 1, u);
           }
         }
       }
@@ -368,38 +367,39 @@ namespace ojph
           // s for source, t for target, p for positive, n for negative,
           // m for mask, and tm for temp
           __m128i s, t, p, n, m, tm;
-          s = _mm_loadu_si128((__m128i *)sp);
+          s = _mm_loadu_si128((__m128i*)sp);
 
-          tm = _mm_cmplt_epi32(s, zero);                      // 32b -1 for -ve value
+          tm = _mm_cmplt_epi32(s, zero);   // 32b -1 for -ve value
           m = _mm_shuffle_epi32(tm, _MM_SHUFFLE(3, 3, 1, 1)); // expand to 64b
-          tm = _mm_sub_epi64(sh, s);                          // - shift - value
-          n = _mm_and_si128(m, tm);                           // -ve
-          p = _mm_andnot_si128(m, s);                         // +ve
+          tm = _mm_sub_epi64(sh, s);       // - shift - value
+          n = _mm_and_si128(m, tm);        // -ve
+          p = _mm_andnot_si128(m, s);      // +ve
           tm = _mm_or_si128(n, p);
           tm = _mm_shuffle_epi32(tm, _MM_SHUFFLE(0, 0, 2, 0));
           t = _mm_and_si128(half_mask, tm);
 
-          s = _mm_loadu_si128((__m128i *)sp + 1);
-          tm = _mm_cmplt_epi32(s, zero);                      // 32b -1 for -ve value
+          s = _mm_loadu_si128((__m128i*)sp + 1);
+          tm = _mm_cmplt_epi32(s, zero);   // 32b -1 for -ve value
           m = _mm_shuffle_epi32(tm, _MM_SHUFFLE(3, 3, 1, 1)); // expand to 64b
-          tm = _mm_sub_epi64(sh, s);                          // - shift - value
-          n = _mm_and_si128(m, tm);                           // -ve
-          p = _mm_andnot_si128(m, s);                         // +ve
+          tm = _mm_sub_epi64(sh, s);       // - shift - value
+          n = _mm_and_si128(m, tm);        // -ve
+          p = _mm_andnot_si128(m, s);      // +ve
           tm = _mm_or_si128(n, p);
           tm = _mm_shuffle_epi32(tm, _MM_SHUFFLE(2, 0, 0, 0));
           tm = _mm_andnot_si128(half_mask, tm);
 
           t = _mm_or_si128(t, tm);
-          _mm_storeu_si128((__m128i *)dp, t);
+           _mm_storeu_si128((__m128i*)dp, t);
         }
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    template <bool NLT_TYPE3>
-    static inline void local_sse2_irv_convert_to_float(const line_buf *src_line,
-                                                       ui32 src_line_offset, line_buf *dst_line,
-                                                       ui32 bit_depth, bool is_signed, ui32 width)
+    template<bool NLT_TYPE3>
+    static inline
+    void local_sse2_irv_convert_to_float(const line_buf *src_line,
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       assert((src_line->flags & line_buf::LFT_32BIT) &&
              (src_line->flags & line_buf::LFT_INTEGER) &&
@@ -409,15 +409,14 @@ namespace ojph
       assert(bit_depth <= 32);
       __m128 mul = _mm_set1_ps((float)(1.0 / (double)(1ULL << bit_depth)));
 
-      const si32 *sp = src_line->i32 + src_line_offset;
-      float *dp = dst_line->f32;
+      const si32* sp = src_line->i32 + src_line_offset;
+      float* dp = dst_line->f32;
       if (is_signed)
       {
         __m128i zero = _mm_setzero_si128();
         __m128i bias = _mm_set1_epi32(-(si32)((1ULL << (bit_depth - 1)) + 1));
-        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4)
-        {
-          __m128i t = _mm_loadu_si128((__m128i *)sp);
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
+          __m128i t = _mm_loadu_si128((__m128i*)sp);
           if (NLT_TYPE3)
           {
             __m128i c = _mm_cmplt_epi32(t, zero); // 0xFFFFFFFF for -ve value
@@ -434,9 +433,8 @@ namespace ojph
       else
       {
         __m128i half = _mm_set1_epi32((si32)(1ULL << (bit_depth - 1)));
-        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4)
-        {
-          __m128i t = _mm_loadu_si128((__m128i *)sp);
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
+          __m128i t = _mm_loadu_si128((__m128i*)sp);
           t = _mm_sub_epi32(t, half);
           __m128 v = _mm_cvtepi32_ps(t);
           v = _mm_mul_ps(v, mul);
@@ -447,20 +445,20 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_convert_to_float(const line_buf *src_line,
-                                   ui32 src_line_offset, line_buf *dst_line,
-                                   ui32 bit_depth, bool is_signed, ui32 width)
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_sse2_irv_convert_to_float<false>(src_line, src_line_offset,
-                                             dst_line, bit_depth, is_signed, width);
+        dst_line, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_irv_convert_to_float_nlt_type3(const line_buf *src_line,
-                                             ui32 src_line_offset, line_buf *dst_line,
-                                             ui32 bit_depth, bool is_signed, ui32 width)
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_sse2_irv_convert_to_float<true>(src_line, src_line_offset,
-                                            dst_line, bit_depth, is_signed, width);
+        dst_line, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -470,61 +468,57 @@ namespace ojph
                           line_buf *y, line_buf *cb, line_buf *cr,
                           ui32 repeat)
     {
-      assert((y->flags & line_buf::LFT_INTEGER) &&
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
              (cb->flags & line_buf::LFT_INTEGER) &&
              (cr->flags & line_buf::LFT_INTEGER) &&
-             (r->flags & line_buf::LFT_INTEGER) &&
-             (g->flags & line_buf::LFT_INTEGER) &&
-             (b->flags & line_buf::LFT_INTEGER));
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
 
-      if (y->flags & line_buf::LFT_32BIT)
+      if  (y->flags & line_buf::LFT_32BIT)
       {
-        assert((y->flags & line_buf::LFT_32BIT) &&
+        assert((y->flags  & line_buf::LFT_32BIT) &&
                (cb->flags & line_buf::LFT_32BIT) &&
                (cr->flags & line_buf::LFT_32BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
-        const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
-        si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
+        const si32 *rp = r->i32, * gp = g->i32, * bp = b->i32;
+        si32 *yp = y->i32, * cbp = cb->i32, * crp = cr->i32;
         for (int i = (repeat + 3) >> 2; i > 0; --i)
         {
-          __m128i mr = _mm_load_si128((__m128i *)rp);
-          __m128i mg = _mm_load_si128((__m128i *)gp);
-          __m128i mb = _mm_load_si128((__m128i *)bp);
+          __m128i mr = _mm_load_si128((__m128i*)rp);
+          __m128i mg = _mm_load_si128((__m128i*)gp);
+          __m128i mb = _mm_load_si128((__m128i*)bp);
           __m128i t = _mm_add_epi32(mr, mb);
           t = _mm_add_epi32(t, _mm_slli_epi32(mg, 1));
-          _mm_store_si128((__m128i *)yp, _mm_srai_epi32(t, 2));
+          _mm_store_si128((__m128i*)yp, _mm_srai_epi32(t, 2));
           t = _mm_sub_epi32(mb, mg);
-          _mm_store_si128((__m128i *)cbp, t);
+          _mm_store_si128((__m128i*)cbp, t);
           t = _mm_sub_epi32(mr, mg);
-          _mm_store_si128((__m128i *)crp, t);
+          _mm_store_si128((__m128i*)crp, t);
 
-          rp += 4;
-          gp += 4;
-          bp += 4;
-          yp += 4;
-          cbp += 4;
-          crp += 4;
+          rp += 4; gp += 4; bp += 4;
+          yp += 4; cbp += 4; crp += 4;
         }
       }
       else
       {
-        assert((y->flags & line_buf::LFT_64BIT) &&
+        assert((y->flags  & line_buf::LFT_64BIT) &&
                (cb->flags & line_buf::LFT_64BIT) &&
                (cr->flags & line_buf::LFT_64BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         __m128i zero = _mm_setzero_si128();
         __m128i v2 = _mm_set1_epi64x(1ULL << (63 - 2));
         const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
         for (int i = (repeat + 3) >> 2; i > 0; --i)
         {
-          __m128i mr32 = _mm_load_si128((__m128i *)rp);
-          __m128i mg32 = _mm_load_si128((__m128i *)gp);
-          __m128i mb32 = _mm_load_si128((__m128i *)bp);
+          __m128i mr32 = _mm_load_si128((__m128i*)rp);
+          __m128i mg32 = _mm_load_si128((__m128i*)gp);
+          __m128i mb32 = _mm_load_si128((__m128i*)bp);
           __m128i mr, mg, mb, t;
           mr = sse2_cvtlo_epi32_epi64(mr32, zero);
           mg = sse2_cvtlo_epi32_epi64(mg32, zero);
@@ -532,15 +526,13 @@ namespace ojph
 
           t = _mm_add_epi64(mr, mb);
           t = _mm_add_epi64(t, _mm_slli_epi64(mg, 1));
-          _mm_store_si128((__m128i *)yp, sse2_mm_srai_epi64(t, 2, v2));
+          _mm_store_si128((__m128i*)yp, sse2_mm_srai_epi64(t, 2, v2));
           t = _mm_sub_epi64(mb, mg);
-          _mm_store_si128((__m128i *)cbp, t);
+          _mm_store_si128((__m128i*)cbp, t);
           t = _mm_sub_epi64(mr, mg);
-          _mm_store_si128((__m128i *)crp, t);
+          _mm_store_si128((__m128i*)crp, t);
 
-          yp += 2;
-          cbp += 2;
-          crp += 2;
+          yp += 2; cbp += 2; crp += 2;
 
           mr = sse2_cvthi_epi32_epi64(mr32, zero);
           mg = sse2_cvthi_epi32_epi64(mg32, zero);
@@ -548,18 +540,14 @@ namespace ojph
 
           t = _mm_add_epi64(mr, mb);
           t = _mm_add_epi64(t, _mm_slli_epi64(mg, 1));
-          _mm_store_si128((__m128i *)yp, sse2_mm_srai_epi64(t, 2, v2));
+          _mm_store_si128((__m128i*)yp, sse2_mm_srai_epi64(t, 2, v2));
           t = _mm_sub_epi64(mb, mg);
-          _mm_store_si128((__m128i *)cbp, t);
+          _mm_store_si128((__m128i*)cbp, t);
           t = _mm_sub_epi64(mr, mg);
-          _mm_store_si128((__m128i *)crp, t);
+          _mm_store_si128((__m128i*)crp, t);
 
-          rp += 4;
-          gp += 4;
-          bp += 4;
-          yp += 2;
-          cbp += 2;
-          crp += 2;
+          rp += 4; gp += 4; bp += 4;
+          yp += 2; cbp += 2; crp += 2;
         }
       }
     }
@@ -571,53 +559,49 @@ namespace ojph
                            line_buf *r, line_buf *g, line_buf *b,
                            ui32 repeat)
     {
-      assert((y->flags & line_buf::LFT_INTEGER) &&
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
              (cb->flags & line_buf::LFT_INTEGER) &&
              (cr->flags & line_buf::LFT_INTEGER) &&
-             (r->flags & line_buf::LFT_INTEGER) &&
-             (g->flags & line_buf::LFT_INTEGER) &&
-             (b->flags & line_buf::LFT_INTEGER));
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
 
       if (y->flags & line_buf::LFT_32BIT)
       {
-        assert((y->flags & line_buf::LFT_32BIT) &&
+        assert((y->flags  & line_buf::LFT_32BIT) &&
                (cb->flags & line_buf::LFT_32BIT) &&
                (cr->flags & line_buf::LFT_32BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         const si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
         si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         for (int i = (repeat + 3) >> 2; i > 0; --i)
         {
-          __m128i my = _mm_load_si128((__m128i *)yp);
-          __m128i mcb = _mm_load_si128((__m128i *)cbp);
-          __m128i mcr = _mm_load_si128((__m128i *)crp);
+          __m128i my  = _mm_load_si128((__m128i*)yp);
+          __m128i mcb = _mm_load_si128((__m128i*)cbp);
+          __m128i mcr = _mm_load_si128((__m128i*)crp);
 
           __m128i t = _mm_add_epi32(mcb, mcr);
           t = _mm_sub_epi32(my, _mm_srai_epi32(t, 2));
-          _mm_store_si128((__m128i *)gp, t);
+          _mm_store_si128((__m128i*)gp, t);
           __m128i u = _mm_add_epi32(mcb, t);
-          _mm_store_si128((__m128i *)bp, u);
+          _mm_store_si128((__m128i*)bp, u);
           u = _mm_add_epi32(mcr, t);
-          _mm_store_si128((__m128i *)rp, u);
+          _mm_store_si128((__m128i*)rp, u);
 
-          yp += 4;
-          cbp += 4;
-          crp += 4;
-          rp += 4;
-          gp += 4;
-          bp += 4;
+          yp += 4; cbp += 4; crp += 4;
+          rp += 4; gp += 4; bp += 4;
         }
       }
       else
       {
-        assert((y->flags & line_buf::LFT_64BIT) &&
+        assert((y->flags  & line_buf::LFT_64BIT) &&
                (cb->flags & line_buf::LFT_64BIT) &&
                (cr->flags & line_buf::LFT_64BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         __m128i v2 = _mm_set1_epi64x(1ULL << (63 - 2));
         __m128i low_bits = _mm_set_epi64x(0, (si64)ULLONG_MAX);
         const si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
@@ -625,9 +609,9 @@ namespace ojph
         for (int i = (repeat + 3) >> 2; i > 0; --i)
         {
           __m128i my, mcb, mcr, tr, tg, tb;
-          my = _mm_load_si128((__m128i *)yp);
-          mcb = _mm_load_si128((__m128i *)cbp);
-          mcr = _mm_load_si128((__m128i *)crp);
+          my  = _mm_load_si128((__m128i*)yp);
+          mcb = _mm_load_si128((__m128i*)cbp);
+          mcr = _mm_load_si128((__m128i*)crp);
 
           tg = _mm_add_epi64(mcb, mcr);
           tg = _mm_sub_epi64(my, sse2_mm_srai_epi64(tg, 2, v2));
@@ -642,13 +626,11 @@ namespace ojph
           mb = _mm_shuffle_epi32(tb, _MM_SHUFFLE(0, 0, 2, 0));
           mb = _mm_and_si128(low_bits, mb);
 
-          yp += 2;
-          cbp += 2;
-          crp += 2;
+          yp += 2; cbp += 2; crp += 2;
 
-          my = _mm_load_si128((__m128i *)yp);
-          mcb = _mm_load_si128((__m128i *)cbp);
-          mcr = _mm_load_si128((__m128i *)crp);
+          my  = _mm_load_si128((__m128i*)yp);
+          mcb = _mm_load_si128((__m128i*)cbp);
+          mcr = _mm_load_si128((__m128i*)crp);
 
           tg = _mm_add_epi64(mcb, mcr);
           tg = _mm_sub_epi64(my, sse2_mm_srai_epi64(tg, 2, v2));
@@ -665,16 +647,12 @@ namespace ojph
           tb = _mm_andnot_si128(low_bits, tb);
           mb = _mm_or_si128(mb, tb);
 
-          _mm_store_si128((__m128i *)rp, mr);
-          _mm_store_si128((__m128i *)gp, mg);
-          _mm_store_si128((__m128i *)bp, mb);
+          _mm_store_si128((__m128i*)rp, mr);
+          _mm_store_si128((__m128i*)gp, mg);
+          _mm_store_si128((__m128i*)bp, mb);
 
-          yp += 2;
-          cbp += 2;
-          crp += 2;
-          rp += 4;
-          gp += 4;
-          bp += 4;
+          yp += 2; cbp += 2; crp += 2;
+          rp += 4; gp += 4; bp += 4;
         }
       }
     }

--- a/Native/Common/OpenJPH/transform/ojph_colour_wasm.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_colour_wasm.cpp
@@ -44,22 +44,21 @@
 #include "ojph_colour.h"
 #include "ojph_colour_local.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    static inline v128_t ojph_convert_float_to_i32(v128_t a, v128_t zero, v128_t half)
+    static inline
+    v128_t ojph_convert_float_to_i32(v128_t a, v128_t zero, v128_t half)
     { // We implement ojph_round, which is
       // val + (val >= 0.0f ? 0.5f : -0.5f), where val is float
-      v128_t c = wasm_f32x4_ge(a, zero);    // greater or equal to zero
-      v128_t p = wasm_f32x4_add(a, half);   // for positive, add half
-      v128_t n = wasm_f32x4_sub(a, half);   // for negative, subtract half
-      v128_t d = wasm_v128_and(c, p);       // keep positive only
-      v128_t e = wasm_v128_andnot(n, c);    // keep negative only
-      v128_t v = wasm_v128_or(d, e);        // combine
-      return wasm_i32x4_trunc_sat_f32x4(v); // truncate (towards 0)
+      v128_t c = wasm_f32x4_ge(a, zero);   // greater or equal to zero
+      v128_t p = wasm_f32x4_add(a, half);  // for positive, add half
+      v128_t n = wasm_f32x4_sub(a, half);  // for negative, subtract half
+      v128_t d = wasm_v128_and(c, p);      // keep positive only
+      v128_t e = wasm_v128_andnot(n, c);   // keep negative only
+      v128_t v = wasm_v128_or(d, e);       // combine
+      return wasm_i32x4_trunc_sat_f32x4(v);// truncate (towards 0)
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -76,7 +75,7 @@ namespace ojph
           const si32 *sp = src_line->i32 + src_line_offset;
           si32 *dp = dst_line->i32 + dst_line_offset;
           v128_t sh = wasm_i32x4_splat((si32)shift);
-          for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+          for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
           {
             v128_t s = wasm_v128_load(sp);
             s = wasm_i32x4_add(s, sh);
@@ -88,7 +87,7 @@ namespace ojph
           const si32 *sp = src_line->i32 + src_line_offset;
           si64 *dp = dst_line->i64 + dst_line_offset;
           v128_t sh = wasm_i64x2_splat(shift);
-          for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+          for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
           {
             v128_t s, t;
             s = wasm_v128_load(sp);
@@ -110,7 +109,7 @@ namespace ojph
         const si64 *sp = src_line->i64 + src_line_offset;
         si32 *dp = dst_line->i32 + dst_line_offset;
         v128_t sh = wasm_i64x2_splat(shift);
-        for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+        for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
         {
           v128_t s0, s1;
           s0 = wasm_v128_load(sp);
@@ -194,17 +193,17 @@ namespace ojph
           // m for mask, and tm for temp
           v128_t s, t0, t1, p, n, m, tm;
           s = wasm_v128_load(sp);
-          m = wasm_i64x2_lt(s, zero); // 64b -1 for -ve value
-          tm = wasm_i64x2_sub(sh, s); // - shift - value
-          n = wasm_v128_and(m, tm);   // -ve
-          p = wasm_v128_andnot(s, m); // +ve
+          m = wasm_i64x2_lt(s, zero);   // 64b -1 for -ve value
+          tm = wasm_i64x2_sub(sh, s);   // - shift - value
+          n = wasm_v128_and(m, tm);     // -ve
+          p = wasm_v128_andnot(s, m);   // +ve
           t0 = wasm_v128_or(n, p);
 
           s = wasm_v128_load(sp + 2);
-          m = wasm_i64x2_lt(s, zero); // 64b -1 for -ve value
-          tm = wasm_i64x2_sub(sh, s); // - shift - value
-          n = wasm_v128_and(m, tm);   // -ve
-          p = wasm_v128_andnot(s, m); // +ve
+          m = wasm_i64x2_lt(s, zero);   // 64b -1 for -ve value
+          tm = wasm_i64x2_sub(sh, s);   // - shift - value
+          n = wasm_v128_and(m, tm);     // -ve
+          p = wasm_v128_andnot(s, m);   // +ve
           t1 = wasm_v128_or(n, p);
 
           t0 = wasm_i32x4_shuffle(t0, t1, 0, 2, 4 + 0, 4 + 2);
@@ -219,7 +218,7 @@ namespace ojph
     {
       v128_t shift = wasm_f32x4_splat(0.5f);
       v128_t m = wasm_f32x4_splat(mul);
-      for (ui32 i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+      for (ui32 i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
       {
         v128_t t = wasm_v128_load(sp);
         v128_t s = wasm_f32x4_convert_i32x4(t);
@@ -234,7 +233,7 @@ namespace ojph
                                   ui32 width)
     {
       v128_t m = wasm_f32x4_splat(mul);
-      for (ui32 i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+      for (ui32 i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
       {
         v128_t t = wasm_v128_load(sp);
         v128_t s = wasm_f32x4_convert_i32x4(t);
@@ -250,7 +249,7 @@ namespace ojph
       const v128_t zero = wasm_f32x4_splat(0.0f);
       const v128_t half = wasm_f32x4_splat(0.5f);
       v128_t m = wasm_f32x4_splat(mul);
-      for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+      for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
       {
         v128_t t = wasm_v128_load(sp);
         v128_t s = wasm_f32x4_add(t, half);
@@ -267,7 +266,7 @@ namespace ojph
       const v128_t zero = wasm_f32x4_splat(0.0f);
       const v128_t half = wasm_f32x4_splat(0.5f);
       v128_t m = wasm_f32x4_splat(mul);
-      for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+      for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
       {
         v128_t t = wasm_v128_load(sp);
         v128_t s = wasm_f32x4_mul(t, m);
@@ -277,7 +276,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline v128_t ojph_wasm_i32x4_max_ge(v128_t a, v128_t b, v128_t x, v128_t y)
+    static inline
+    v128_t ojph_wasm_i32x4_max_ge(v128_t a, v128_t b, v128_t x, v128_t y)
     {
       v128_t c = wasm_f32x4_ge(x, y);    // 0xFFFFFFFF for x >= y
       v128_t d = wasm_v128_and(c, a);    // keep only a, where x >= y
@@ -286,7 +286,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline v128_t ojph_wasm_i32x4_min_lt(v128_t a, v128_t b, v128_t x, v128_t y)
+    static inline
+    v128_t ojph_wasm_i32x4_min_lt(v128_t a, v128_t b, v128_t x, v128_t y)
     {
       v128_t c = wasm_f32x4_lt(x, y);    // 0xFFFFFFFF for x < y
       v128_t d = wasm_v128_and(c, a);    // keep only a, where x <  y
@@ -296,9 +297,10 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     template <bool NLT_TYPE3>
-    static inline void local_wasm_irv_convert_to_integer(const line_buf *src_line,
-                                                         line_buf *dst_line, ui32 dst_line_offset,
-                                                         ui32 bit_depth, bool is_signed, ui32 width)
+    static inline
+    void local_wasm_irv_convert_to_integer(const line_buf *src_line,
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       assert((src_line->flags & line_buf::LFT_32BIT) &&
              (src_line->flags & line_buf::LFT_INTEGER) == 0 &&
@@ -306,8 +308,8 @@ namespace ojph
              (dst_line->flags & line_buf::LFT_INTEGER));
 
       assert(bit_depth <= 32);
-      const float *sp = src_line->f32;
-      si32 *dp = dst_line->i32 + dst_line_offset;
+      const float* sp = src_line->f32;
+      si32* dp = dst_line->i32 + dst_line_offset;
       // There is the possibility that converting to integer will
       // exceed the dynamic range of 32bit integer; therefore, care must be
       // exercised.
@@ -326,8 +328,7 @@ namespace ojph
         const v128_t zero = wasm_f32x4_splat(0.0f);
         const v128_t half = wasm_f32x4_splat(0.5f);
         v128_t bias = wasm_i32x4_splat(-(si32)((1ULL << (bit_depth - 1)) + 1));
-        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4)
-        {
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
           v128_t t = wasm_v128_load(sp);
           t = wasm_f32x4_mul(t, mul);
           v128_t u = ojph_convert_float_to_i32(t, zero, half);
@@ -349,8 +350,7 @@ namespace ojph
         const v128_t zero = wasm_f32x4_splat(0.0f);
         const v128_t half = wasm_f32x4_splat(0.5f);
         v128_t ihalf = wasm_i32x4_splat((si32)(1ULL << (bit_depth - 1)));
-        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4)
-        {
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
           v128_t t = wasm_v128_load(sp);
           t = wasm_f32x4_mul(t, mul);
           v128_t u = ojph_convert_float_to_i32(t, zero, half);
@@ -364,27 +364,28 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_convert_to_integer(const line_buf *src_line,
-                                     line_buf *dst_line, ui32 dst_line_offset,
-                                     ui32 bit_depth, bool is_signed, ui32 width)
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
-      local_wasm_irv_convert_to_integer<false>(src_line, dst_line,
-                                               dst_line_offset, bit_depth, is_signed, width);
+      local_wasm_irv_convert_to_integer<false>(src_line, dst_line, 
+        dst_line_offset, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_convert_to_integer_nlt_type3(const line_buf *src_line,
-                                               line_buf *dst_line, ui32 dst_line_offset,
-                                               ui32 bit_depth, bool is_signed, ui32 width)
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
-      local_wasm_irv_convert_to_integer<true>(src_line, dst_line,
-                                              dst_line_offset, bit_depth, is_signed, width);
+      local_wasm_irv_convert_to_integer<true>(src_line, dst_line, 
+        dst_line_offset, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     template <bool NLT_TYPE3>
-    static inline void local_wasm_irv_convert_to_float(const line_buf *src_line,
-                                                       ui32 src_line_offset, line_buf *dst_line,
-                                                       ui32 bit_depth, bool is_signed, ui32 width)
+    static inline
+    void local_wasm_irv_convert_to_float(const line_buf *src_line,
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       assert((src_line->flags & line_buf::LFT_32BIT) &&
              (src_line->flags & line_buf::LFT_INTEGER) &&
@@ -394,14 +395,13 @@ namespace ojph
       assert(bit_depth <= 32);
       v128_t mul = wasm_f32x4_splat((float)(1.0 / (double)(1ULL << bit_depth)));
 
-      const si32 *sp = src_line->i32 + src_line_offset;
-      float *dp = dst_line->f32;
+      const si32* sp = src_line->i32 + src_line_offset;
+      float* dp = dst_line->f32;
       if (is_signed)
       {
         v128_t zero = wasm_i32x4_splat(0);
         v128_t bias = wasm_i32x4_splat(-(si32)((1ULL << (bit_depth - 1)) + 1));
-        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4)
-        {
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
           v128_t t = wasm_v128_load(sp);
           if (NLT_TYPE3)
           {
@@ -419,8 +419,7 @@ namespace ojph
       else
       {
         v128_t half = wasm_i32x4_splat((si32)(1ULL << (bit_depth - 1)));
-        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4)
-        {
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
           v128_t t = wasm_v128_load(sp);
           t = wasm_i32x4_sub(t, half);
           v128_t v = wasm_f32x4_convert_i32x4(t);
@@ -432,20 +431,20 @@ namespace ojph
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_convert_to_float(const line_buf *src_line,
-                                   ui32 src_line_offset, line_buf *dst_line,
-                                   ui32 bit_depth, bool is_signed, ui32 width)
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_wasm_irv_convert_to_float<false>(src_line, src_line_offset,
-                                             dst_line, bit_depth, is_signed, width);
+        dst_line, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_convert_to_float_nlt_type3(const line_buf *src_line,
-                                             ui32 src_line_offset, line_buf *dst_line,
-                                             ui32 bit_depth, bool is_signed, ui32 width)
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
     {
       local_wasm_irv_convert_to_float<true>(src_line, src_line_offset,
-                                            dst_line, bit_depth, is_signed, width);
+        dst_line, bit_depth, is_signed, width);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -455,23 +454,23 @@ namespace ojph
                           line_buf *y, line_buf *cb, line_buf *cr,
                           ui32 repeat)
     {
-      assert((y->flags & line_buf::LFT_INTEGER) &&
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
              (cb->flags & line_buf::LFT_INTEGER) &&
              (cr->flags & line_buf::LFT_INTEGER) &&
-             (r->flags & line_buf::LFT_INTEGER) &&
-             (g->flags & line_buf::LFT_INTEGER) &&
-             (b->flags & line_buf::LFT_INTEGER));
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
 
-      if (y->flags & line_buf::LFT_32BIT)
+      if  (y->flags & line_buf::LFT_32BIT)
       {
-        assert((y->flags & line_buf::LFT_32BIT) &&
+        assert((y->flags  & line_buf::LFT_32BIT) &&
                (cb->flags & line_buf::LFT_32BIT) &&
                (cr->flags & line_buf::LFT_32BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
-        const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
-        si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
+        const si32 *rp = r->i32, * gp = g->i32, * bp = b->i32;
+        si32 *yp = y->i32, * cbp = cb->i32, * crp = cr->i32;
 
         for (int i = (repeat + 3) >> 2; i > 0; --i)
         {
@@ -486,22 +485,18 @@ namespace ojph
           t = wasm_i32x4_sub(mr, mg);
           wasm_v128_store(crp, t);
 
-          rp += 4;
-          gp += 4;
-          bp += 4;
-          yp += 4;
-          cbp += 4;
-          crp += 4;
+            rp += 4; gp += 4; bp += 4;
+            yp += 4; cbp += 4; crp += 4;
         }
       }
       else
       {
-        assert((y->flags & line_buf::LFT_64BIT) &&
+        assert((y->flags  & line_buf::LFT_64BIT) &&
                (cb->flags & line_buf::LFT_64BIT) &&
                (cr->flags & line_buf::LFT_64BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
         for (int i = (repeat + 3) >> 2; i > 0; --i)
@@ -522,9 +517,7 @@ namespace ojph
           t = wasm_i64x2_sub(mr, mg);
           wasm_v128_store(crp, t);
 
-          yp += 2;
-          cbp += 2;
-          crp += 2;
+          yp += 2; cbp += 2; crp += 2;
 
           mr = wasm_i64x2_extend_high_i32x4(mr32);
           mg = wasm_i64x2_extend_high_i32x4(mg32);
@@ -538,12 +531,8 @@ namespace ojph
           t = wasm_i64x2_sub(mr, mg);
           wasm_v128_store(crp, t);
 
-          rp += 4;
-          gp += 4;
-          bp += 4;
-          yp += 2;
-          cbp += 2;
-          crp += 2;
+          rp += 4; gp += 4; bp += 4;
+          yp += 2; cbp += 2; crp += 2;
         }
       }
     }
@@ -555,26 +544,26 @@ namespace ojph
                            line_buf *r, line_buf *g, line_buf *b,
                            ui32 repeat)
     {
-      assert((y->flags & line_buf::LFT_INTEGER) &&
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
              (cb->flags & line_buf::LFT_INTEGER) &&
              (cr->flags & line_buf::LFT_INTEGER) &&
-             (r->flags & line_buf::LFT_INTEGER) &&
-             (g->flags & line_buf::LFT_INTEGER) &&
-             (b->flags & line_buf::LFT_INTEGER));
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
 
       if (y->flags & line_buf::LFT_32BIT)
       {
-        assert((y->flags & line_buf::LFT_32BIT) &&
+        assert((y->flags  & line_buf::LFT_32BIT) &&
                (cb->flags & line_buf::LFT_32BIT) &&
                (cr->flags & line_buf::LFT_32BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         const si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
         si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         for (int i = (repeat + 3) >> 2; i > 0; --i)
         {
-          v128_t my = wasm_v128_load(yp);
+          v128_t my  = wasm_v128_load(yp);
           v128_t mcb = wasm_v128_load(cbp);
           v128_t mcr = wasm_v128_load(crp);
 
@@ -586,28 +575,24 @@ namespace ojph
           u = wasm_i32x4_add(mcr, t);
           wasm_v128_store(rp, u);
 
-          yp += 4;
-          cbp += 4;
-          crp += 4;
-          rp += 4;
-          gp += 4;
-          bp += 4;
+          yp += 4; cbp += 4; crp += 4;
+          rp += 4; gp += 4; bp += 4;
         }
       }
       else
       {
-        assert((y->flags & line_buf::LFT_64BIT) &&
+        assert((y->flags  & line_buf::LFT_64BIT) &&
                (cb->flags & line_buf::LFT_64BIT) &&
                (cr->flags & line_buf::LFT_64BIT) &&
-               (r->flags & line_buf::LFT_32BIT) &&
-               (g->flags & line_buf::LFT_32BIT) &&
-               (b->flags & line_buf::LFT_32BIT));
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
         const si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
         si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
         for (int i = (repeat + 3) >> 2; i > 0; --i)
         {
           v128_t my, mcb, mcr, tr0, tg0, tb0, tr1, tg1, tb1;
-          my = wasm_v128_load(yp);
+          my  = wasm_v128_load(yp);
           mcb = wasm_v128_load(cbp);
           mcr = wasm_v128_load(crp);
 
@@ -616,11 +601,9 @@ namespace ojph
           tb0 = wasm_i64x2_add(mcb, tg0);
           tr0 = wasm_i64x2_add(mcr, tg0);
 
-          yp += 2;
-          cbp += 2;
-          crp += 2;
+          yp += 2; cbp += 2; crp += 2;
 
-          my = wasm_v128_load(yp);
+          my  = wasm_v128_load(yp);
           mcb = wasm_v128_load(cbp);
           mcr = wasm_v128_load(crp);
 
@@ -637,12 +620,8 @@ namespace ojph
           wasm_v128_store(gp, tg0);
           wasm_v128_store(bp, tb0);
 
-          yp += 2;
-          cbp += 2;
-          crp += 2;
-          rp += 4;
-          gp += 4;
-          bp += 4;
+          yp += 2; cbp += 2; crp += 2;
+          rp += 4; gp += 4; bp += 4;
         }
       }
     }
@@ -667,12 +646,8 @@ namespace ojph
         wasm_v128_store(cb, wasm_f32x4_mul(beta_cbf, wasm_f32x4_sub(mb, my)));
         wasm_v128_store(cr, wasm_f32x4_mul(beta_crf, wasm_f32x4_sub(mr, my)));
 
-        r += 4;
-        g += 4;
-        b += 4;
-        y += 4;
-        cb += 4;
-        cr += 4;
+        r += 4; g += 4; b += 4;
+        y += 4; cb += 4; cr += 4;
       }
     }
 
@@ -694,12 +669,8 @@ namespace ojph
         wasm_v128_store(r, wasm_f32x4_add(my, wasm_f32x4_mul(gamma_cr2r, mcr)));
         wasm_v128_store(b, wasm_f32x4_add(my, wasm_f32x4_mul(gamma_cb2b, mcb)));
 
-        y += 4;
-        cb += 4;
-        cr += 4;
-        r += 4;
-        g += 4;
-        b += 4;
+        y += 4; cb += 4; cr += 4;
+        r += 4; g += 4; b += 4;
       }
     }
 

--- a/Native/Common/OpenJPH/transform/ojph_transform.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_transform.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -36,6 +36,7 @@
 //***************************************************************************/
 
 #include <cstdio>
+#include <mutex>
 
 #include "ojph_arch.h"
 #include "ojph_mem.h"
@@ -44,162 +45,163 @@
 #include "ojph_params.h"
 #include "../codestream/ojph_params_local.h"
 
-namespace ojph
-{
+namespace ojph {
 
   // defined elsewhere
   class line_buf;
 
-  namespace local
-  {
+  namespace local {
 
     /////////////////////////////////////////////////////////////////////////
     // Reversible functions
     /////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void (*rev_vert_step)(const lifting_step *s, const line_buf *sig, const line_buf *other,
-                          const line_buf *aug, ui32 repeat, bool synthesis) = NULL;
+    void (*rev_vert_step)
+      (const lifting_step* s, const line_buf* sig, const line_buf* other,
+        const line_buf* aug, ui32 repeat, bool synthesis) = NULL;
 
     /////////////////////////////////////////////////////////////////////////
-    void (*rev_horz_ana)(const param_atk *atk, const line_buf *ldst, const line_buf *hdst,
-                         const line_buf *src, ui32 width, bool even) = NULL;
+    void (*rev_horz_ana)
+      (const param_atk* atk, const line_buf* ldst, const line_buf* hdst,
+        const line_buf* src, ui32 width, bool even) = NULL;
 
     /////////////////////////////////////////////////////////////////////////
-    void (*rev_horz_syn)(const param_atk *atk, const line_buf *dst, const line_buf *lsrc,
-                         const line_buf *hsrc, ui32 width, bool even) = NULL;
-
+    void (*rev_horz_syn)
+      (const param_atk* atk, const line_buf* dst, const line_buf* lsrc,
+        const line_buf* hsrc, ui32 width, bool even) = NULL;
+    
     /////////////////////////////////////////////////////////////////////////
     // Irreversible functions
     /////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void (*irv_vert_step)(const lifting_step *s, const line_buf *sig, const line_buf *other,
-                          const line_buf *aug, ui32 repeat, bool synthesis) = NULL;
+    void (*irv_vert_step)
+      (const lifting_step* s, const line_buf* sig, const line_buf* other,
+        const line_buf* aug, ui32 repeat, bool synthesis) = NULL;
 
     /////////////////////////////////////////////////////////////////////////
-    void (*irv_vert_times_K)(float K, const line_buf *aug, ui32 repeat) = NULL;
+    void (*irv_vert_times_K)
+      (float K, const line_buf* aug, ui32 repeat) = NULL;
 
     /////////////////////////////////////////////////////////////////////////
-    void (*irv_horz_ana)(const param_atk *atk, const line_buf *ldst, const line_buf *hdst,
-                         const line_buf *src, ui32 width, bool even) = NULL;
+    void (*irv_horz_ana)
+      (const param_atk* atk, const line_buf* ldst, const line_buf* hdst,
+        const line_buf* src, ui32 width, bool even) = NULL;
 
     /////////////////////////////////////////////////////////////////////////
-    void (*irv_horz_syn)(const param_atk *atk, const line_buf *dst, const line_buf *lsrc,
-                         const line_buf *hsrc, ui32 width, bool even) = NULL;
-
-    ////////////////////////////////////////////////////////////////////////////
-    static bool wavelet_transform_functions_initialized = false;
+    void (*irv_horz_syn)
+      (const param_atk* atk, const line_buf* dst, const line_buf* lsrc,
+        const line_buf* hsrc, ui32 width, bool even) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
     void init_wavelet_transform_functions()
     {
-      if (wavelet_transform_functions_initialized)
-        return;
-
+      static std::once_flag wavelet_transform_functions_init_flag;
+      std::call_once(wavelet_transform_functions_init_flag, [](){
 #if !defined(OJPH_ENABLE_WASM_SIMD) || !defined(OJPH_EMSCRIPTEN)
 
-      rev_vert_step = gen_rev_vert_step;
-      rev_horz_ana = gen_rev_horz_ana;
-      rev_horz_syn = gen_rev_horz_syn;
+        rev_vert_step             = gen_rev_vert_step;
+        rev_horz_ana              = gen_rev_horz_ana;
+        rev_horz_syn              = gen_rev_horz_syn;
 
-      irv_vert_step = gen_irv_vert_step;
-      irv_vert_times_K = gen_irv_vert_times_K;
-      irv_horz_ana = gen_irv_horz_ana;
-      irv_horz_syn = gen_irv_horz_syn;
+        irv_vert_step             = gen_irv_vert_step;
+        irv_vert_times_K          = gen_irv_vert_times_K;
+        irv_horz_ana              = gen_irv_horz_ana;
+        irv_horz_syn              = gen_irv_horz_syn;
 
-#ifndef OJPH_DISABLE_SIMD
+  #ifndef OJPH_DISABLE_SIMD
 
-#if (defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
+    #if (defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
-#ifndef OJPH_DISABLE_SSE
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE)
-      {
-        irv_vert_step = sse_irv_vert_step;
-        irv_vert_times_K = sse_irv_vert_times_K;
-        irv_horz_ana = sse_irv_horz_ana;
-        irv_horz_syn = sse_irv_horz_syn;
-      }
-#endif // !OJPH_DISABLE_SSE
+      #ifndef OJPH_DISABLE_SSE
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE)
+        {
+          irv_vert_step             = sse_irv_vert_step;
+          irv_vert_times_K          = sse_irv_vert_times_K;
+          irv_horz_ana              = sse_irv_horz_ana;
+          irv_horz_syn              = sse_irv_horz_syn;
+        }
+      #endif // !OJPH_DISABLE_SSE
 
-#ifndef OJPH_DISABLE_SSE2
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE2)
-      {
-        rev_vert_step = sse2_rev_vert_step;
-        rev_horz_ana = sse2_rev_horz_ana;
-        rev_horz_syn = sse2_rev_horz_syn;
-      }
-#endif // !OJPH_DISABLE_SSE2
+      #ifndef OJPH_DISABLE_SSE2
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_SSE2)
+        {
+          rev_vert_step             = sse2_rev_vert_step;
+          rev_horz_ana              = sse2_rev_horz_ana;
+          rev_horz_syn              = sse2_rev_horz_syn;
+        }
+      #endif // !OJPH_DISABLE_SSE2
 
-#ifndef OJPH_DISABLE_AVX
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX)
-      {
-        irv_vert_step = avx_irv_vert_step;
-        irv_vert_times_K = avx_irv_vert_times_K;
-        irv_horz_ana = avx_irv_horz_ana;
-        irv_horz_syn = avx_irv_horz_syn;
-      }
-#endif // !OJPH_DISABLE_AVX
+      #ifndef OJPH_DISABLE_AVX
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX)
+        {
+          irv_vert_step             = avx_irv_vert_step;
+          irv_vert_times_K          = avx_irv_vert_times_K;
+          irv_horz_ana              = avx_irv_horz_ana;      
+          irv_horz_syn              = avx_irv_horz_syn;
+        }
+      #endif // !OJPH_DISABLE_AVX
 
-#ifndef OJPH_DISABLE_AVX2
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX2)
-      {
-        rev_vert_step = avx2_rev_vert_step;
-        rev_horz_ana = avx2_rev_horz_ana;
-        rev_horz_syn = avx2_rev_horz_syn;
-      }
-#endif // !OJPH_DISABLE_AVX2
+      #ifndef OJPH_DISABLE_AVX2
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX2)
+        {
+          rev_vert_step             = avx2_rev_vert_step;
+          rev_horz_ana              = avx2_rev_horz_ana;
+          rev_horz_syn              = avx2_rev_horz_syn;
+        }
+      #endif // !OJPH_DISABLE_AVX2
 
-#if (defined(OJPH_ARCH_X86_64) && !defined(OJPH_DISABLE_AVX512))
-      if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX512)
-      {
-        // rev_vert_step             = avx512_rev_vert_step;
-        // rev_horz_ana              = avx512_rev_horz_ana;
-        // rev_horz_syn              = avx512_rev_horz_syn;
+      #if (defined(OJPH_ARCH_X86_64) && !defined(OJPH_DISABLE_AVX512))
+        if (get_cpu_ext_level() >= X86_CPU_EXT_LEVEL_AVX512)
+        {
+          // rev_vert_step             = avx512_rev_vert_step;
+          // rev_horz_ana              = avx512_rev_horz_ana;
+          // rev_horz_syn              = avx512_rev_horz_syn;
 
-        irv_vert_step = avx512_irv_vert_step;
-        irv_vert_times_K = avx512_irv_vert_times_K;
-        irv_horz_ana = avx512_irv_horz_ana;
-        irv_horz_syn = avx512_irv_horz_syn;
-      }
-#endif // !OJPH_DISABLE_AVX512
+          irv_vert_step             = avx512_irv_vert_step;
+          irv_vert_times_K          = avx512_irv_vert_times_K;
+          irv_horz_ana              = avx512_irv_horz_ana;
+          irv_horz_syn              = avx512_irv_horz_syn;
+        }
+      #endif // !OJPH_DISABLE_AVX512
+    
+    #elif defined(OJPH_ARCH_ARM)
 
-#elif defined(OJPH_ARCH_ARM)
+    #endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
-#endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
+  #endif // !OJPH_DISABLE_SIMD
 
-#endif // !OJPH_DISABLE_SIMD
-
-#else  // OJPH_ENABLE_WASM_SIMD
-      rev_vert_step = wasm_rev_vert_step;
-      rev_horz_ana = wasm_rev_horz_ana;
-      rev_horz_syn = wasm_rev_horz_syn;
-
-      irv_vert_step = wasm_irv_vert_step;
-      irv_vert_times_K = wasm_irv_vert_times_K;
-      irv_horz_ana = wasm_irv_horz_ana;
-      irv_horz_syn = wasm_irv_horz_syn;
+#else // OJPH_ENABLE_WASM_SIMD
+        rev_vert_step             = wasm_rev_vert_step;
+        rev_horz_ana              = wasm_rev_horz_ana;
+        rev_horz_syn              = wasm_rev_horz_syn;
+        
+        irv_vert_step             = wasm_irv_vert_step;
+        irv_vert_times_K          = wasm_irv_vert_times_K;
+        irv_horz_ana              = wasm_irv_horz_ana;
+        irv_horz_syn              = wasm_irv_horz_syn;
 #endif // !OJPH_ENABLE_WASM_SIMD
-
-      wavelet_transform_functions_initialized = true;
+      });
     }
-
+    
     //////////////////////////////////////////////////////////////////////////
 
 #if !defined(OJPH_ENABLE_WASM_SIMD) || !defined(OJPH_EMSCRIPTEN)
 
     /////////////////////////////////////////////////////////////////////////
-    static void gen_rev_vert_step32(const lifting_step *s, const line_buf *sig,
-                                    const line_buf *other, const line_buf *aug,
-                                    ui32 repeat, bool synthesis)
+    static
+    void gen_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
+                             const line_buf* other, const line_buf* aug, 
+                             ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
       const si32 b = s->rev.Batk;
       const ui8 e = s->rev.Eatk;
 
-      si32 *dst = aug->i32;
-      const si32 *src1 = sig->i32, *src2 = other->i32;
-      // The general definition of the wavelet in Part 2 is slightly
+      si32* dst = aug->i32;
+      const si32* src1 = sig->i32, * src2 = other->i32;
+      // The general definition of the wavelet in Part 2 is slightly 
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -229,8 +231,7 @@ namespace ojph
           for (ui32 i = repeat; i > 0; --i)
             *dst++ += (b - (*src1++ + *src2++)) >> e;
       }
-      else
-      { // general case
+      else { // general case
         if (synthesis)
           for (ui32 i = repeat; i > 0; --i)
             *dst++ -= (b + a * (*src1++ + *src2++)) >> e;
@@ -241,17 +242,18 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void gen_rev_vert_step64(const lifting_step *s, const line_buf *sig,
-                                    const line_buf *other, const line_buf *aug,
-                                    ui32 repeat, bool synthesis)
+    static
+    void gen_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
+                             const line_buf* other, const line_buf* aug, 
+                             ui32 repeat, bool synthesis)
     {
       const si64 a = s->rev.Aatk;
       const si64 b = s->rev.Batk;
       const ui8 e = s->rev.Eatk;
 
-      si64 *dst = aug->i64;
-      const si64 *src1 = sig->i64, *src2 = other->i64;
-      // The general definition of the wavelet in Part 2 is slightly
+      si64* dst = aug->i64;
+      const si64* src1 = sig->i64, * src2 = other->i64;
+      // The general definition of the wavelet in Part 2 is slightly 
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -281,8 +283,7 @@ namespace ojph
           for (ui32 i = repeat; i > 0; --i)
             *dst++ += (b - (*src1++ + *src2++)) >> e;
       }
-      else
-      { // general case
+      else { // general case
         if (synthesis)
           for (ui32 i = repeat; i > 0; --i)
             *dst++ -= (b + a * (*src1++ + *src2++)) >> e;
@@ -293,64 +294,62 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                           const line_buf *other, const line_buf *aug,
+    void gen_rev_vert_step(const lifting_step* s, const line_buf* sig, 
+                           const line_buf* other, const line_buf* aug, 
                            ui32 repeat, bool synthesis)
     {
-      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
           ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
                (aug == NULL || aug->flags & line_buf::LFT_32BIT));
         gen_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
       }
-      else
+      else 
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
                (aug == NULL || aug->flags & line_buf::LFT_64BIT));
         gen_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void gen_rev_horz_ana32(const param_atk *atk, const line_buf *ldst,
-                                   const line_buf *hdst, const line_buf *src,
-                                   ui32 width, bool even)
+    static
+    void gen_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
+                            const line_buf* hdst, const line_buf* src, 
+                            ui32 width, bool even)
     {
       if (width > 1)
       {
         // combine both lsrc and hsrc into dst
-        si32 *dph = hdst->i32;
-        si32 *dpl = ldst->i32;
-        si32 *sp = src->i32;
+        si32* dph = hdst->i32;
+        si32* dpl = ldst->i32;
+        si32* sp = src->i32;
         ui32 w = width;
         if (!even)
         {
-          *dph++ = *sp++;
-          --w;
+          *dph++ = *sp++; --w;
         }
         for (; w > 1; w -= 2)
         {
-          *dpl++ = *sp++;
-          *dph++ = *sp++;
+          *dpl++ = *sp++; *dph++ = *sp++;
         }
         if (w)
         {
-          *dpl++ = *sp++;
-          --w;
+          *dpl++ = *sp++; --w;
         }
 
-        si32 *hp = hdst->i32, *lp = ldst->i32;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si32* hp = hdst->i32, * lp = ldst->i32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
           // first lifting step
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -359,15 +358,15 @@ namespace ojph
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const si32 *sp = lp + (even ? 1 : 0);
-          si32 *dp = hp;
-          if (a == 1)
+          const si32* sp = lp + (even ? 1 : 0);
+          si32* dp = hp;
+          if (a == 1) 
           { // 5/3 update and any case with a == 1
             for (ui32 i = h_width; i > 0; --i, sp++, dp++)
               *dp += (b + (sp[-1] + sp[0])) >> e;
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             for (ui32 i = h_width; i > 0; --i, sp++, dp++)
               *dp -= (sp[-1] + sp[0]) >> e;
           }
@@ -376,25 +375,19 @@ namespace ojph
             for (ui32 i = h_width; i > 0; --i, sp++, dp++)
               *dp += (b - (sp[-1] + sp[0])) >> e;
           }
-          else
-          {
+          else {
             // general case
             for (ui32 i = h_width; i > 0; --i, sp++, dp++)
               *dp += (b + a * (sp[-1] + sp[0])) >> e;
           }
 
           // swap buffers
-          si32 *t = lp;
-          lp = hp;
-          hp = t;
+          si32* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->i32[0] = src->i32[0];
         else
@@ -403,41 +396,39 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void gen_rev_horz_ana64(const param_atk *atk, const line_buf *ldst,
-                                   const line_buf *hdst, const line_buf *src,
-                                   ui32 width, bool even)
+    static
+    void gen_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
+                            const line_buf* hdst, const line_buf* src, 
+                            ui32 width, bool even)
     {
       if (width > 1)
       {
         // combine both lsrc and hsrc into dst
-        si64 *dph = hdst->i64;
-        si64 *dpl = ldst->i64;
-        si64 *sp = src->i64;
+        si64* dph = hdst->i64;
+        si64* dpl = ldst->i64;
+        si64* sp = src->i64;
         ui32 w = width;
         if (!even)
         {
-          *dph++ = *sp++;
-          --w;
+          *dph++ = *sp++; --w;
         }
         for (; w > 1; w -= 2)
         {
-          *dpl++ = *sp++;
-          *dph++ = *sp++;
+          *dpl++ = *sp++; *dph++ = *sp++;
         }
         if (w)
         {
-          *dpl++ = *sp++;
-          --w;
+          *dpl++ = *sp++; --w;
         }
 
-        si64 *hp = hdst->i64, *lp = ldst->i64;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si64* hp = hdst->i64, * lp = ldst->i64;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
           // first lifting step
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const si64 a = s->rev.Aatk;
           const si64 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -446,15 +437,15 @@ namespace ojph
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const si64 *sp = lp + (even ? 1 : 0);
-          si64 *dp = hp;
-          if (a == 1)
+          const si64* sp = lp + (even ? 1 : 0);
+          si64* dp = hp;
+          if (a == 1) 
           { // 5/3 update and any case with a == 1
             for (ui32 i = h_width; i > 0; --i, sp++, dp++)
               *dp += (b + (sp[-1] + sp[0])) >> e;
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             for (ui32 i = h_width; i > 0; --i, sp++, dp++)
               *dp -= (sp[-1] + sp[0]) >> e;
           }
@@ -463,25 +454,19 @@ namespace ojph
             for (ui32 i = h_width; i > 0; --i, sp++, dp++)
               *dp += (b - (sp[-1] + sp[0])) >> e;
           }
-          else
-          {
+          else {
             // general case
             for (ui32 i = h_width; i > 0; --i, sp++, dp++)
               *dp += (b + a * (sp[-1] + sp[0])) >> e;
           }
 
           // swap buffers
-          si64 *t = lp;
-          lp = hp;
-          hp = t;
+          si64* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->i64[0] = src->i64[0];
         else
@@ -490,40 +475,41 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                          const line_buf *hdst, const line_buf *src,
+    void gen_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                          const line_buf* hdst, const line_buf* src, 
                           ui32 width, bool even)
     {
-      if (src->flags & line_buf::LFT_32BIT)
+      if (src->flags & line_buf::LFT_32BIT) 
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
                (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
         gen_rev_horz_ana32(atk, ldst, hdst, src, width, even);
       }
-      else
+      else 
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
                (src == NULL || src->flags & line_buf::LFT_64BIT));
         gen_rev_horz_ana64(atk, ldst, hdst, src, width, even);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static void gen_rev_horz_syn32(const param_atk *atk, const line_buf *dst,
-                                   const line_buf *lsrc, const line_buf *hsrc,
-                                   ui32 width, bool even)
+    static
+    void gen_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
+                            const line_buf* lsrc, const line_buf* hsrc, 
+                            ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        si32 *oth = hsrc->i32, *aug = lsrc->i32;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si32* oth = hsrc->i32, * aug = lsrc->i32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -532,15 +518,15 @@ namespace ojph
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const si32 *sp = oth + (ev ? 0 : 1);
-          si32 *dp = aug;
+          const si32* sp = oth + (ev ? 0 : 1);
+          si32* dp = aug;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
               *dp -= (b + (sp[-1] + sp[0])) >> e;
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
               *dp += (sp[-1] + sp[0]) >> e;
           }
@@ -549,46 +535,37 @@ namespace ojph
             for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
               *dp -= (b - (sp[-1] + sp[0])) >> e;
           }
-          else
-          {
+          else {
             // general case
             for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
               *dp -= (b + a * (sp[-1] + sp[0])) >> e;
           }
 
           // swap buffers
-          si32 *t = aug;
-          aug = oth;
-          oth = t;
+          si32* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
-        si32 *sph = hsrc->i32;
-        si32 *spl = lsrc->i32;
-        si32 *dp = dst->i32;
+        si32* sph = hsrc->i32;
+        si32* spl = lsrc->i32;
+        si32* dp = dst->i32;
         ui32 w = width;
         if (!even)
         {
-          *dp++ = *sph++;
-          --w;
+          *dp++ = *sph++; --w;
         }
         for (; w > 1; w -= 2)
         {
-          *dp++ = *spl++;
-          *dp++ = *sph++;
+          *dp++ = *spl++; *dp++ = *sph++;
         }
         if (w)
         {
-          *dp++ = *spl++;
-          --w;
+          *dp++ = *spl++; --w;
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->i32[0] = lsrc->i32[0];
         else
@@ -597,20 +574,21 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static void gen_rev_horz_syn64(const param_atk *atk, const line_buf *dst,
-                                   const line_buf *lsrc, const line_buf *hsrc,
-                                   ui32 width, bool even)
+    static
+    void gen_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
+                            const line_buf* lsrc, const line_buf* hsrc, 
+                            ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        si64 *oth = hsrc->i64, *aug = lsrc->i64;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si64* oth = hsrc->i64, * aug = lsrc->i64;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const si64 a = s->rev.Aatk;
           const si64 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -619,15 +597,15 @@ namespace ojph
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const si64 *sp = oth + (ev ? 0 : 1);
-          si64 *dp = aug;
+          const si64* sp = oth + (ev ? 0 : 1);
+          si64* dp = aug;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
               *dp -= (b + (sp[-1] + sp[0])) >> e;
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
               *dp += (sp[-1] + sp[0]) >> e;
           }
@@ -636,46 +614,37 @@ namespace ojph
             for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
               *dp -= (b - (sp[-1] + sp[0])) >> e;
           }
-          else
-          {
+          else {
             // general case
             for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
               *dp -= (b + a * (sp[-1] + sp[0])) >> e;
           }
 
           // swap buffers
-          si64 *t = aug;
-          aug = oth;
-          oth = t;
+          si64* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
-        si64 *sph = hsrc->i64;
-        si64 *spl = lsrc->i64;
-        si64 *dp = dst->i64;
+        si64* sph = hsrc->i64;
+        si64* spl = lsrc->i64;
+        si64* dp = dst->i64;
         ui32 w = width;
         if (!even)
         {
-          *dp++ = *sph++;
-          --w;
+          *dp++ = *sph++; --w;
         }
         for (; w > 1; w -= 2)
         {
-          *dp++ = *spl++;
-          *dp++ = *sph++;
+          *dp++ = *spl++; *dp++ = *sph++;
         }
         if (w)
         {
-          *dp++ = *spl++;
-          --w;
+          *dp++ = *spl++; --w;
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->i64[0] = lsrc->i64[0];
         else
@@ -684,28 +653,28 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                          const line_buf *lsrc, const line_buf *hsrc,
+    void gen_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
+                          const line_buf* lsrc, const line_buf* hsrc, 
                           ui32 width, bool even)
     {
-      if (dst->flags & line_buf::LFT_32BIT)
+      if (dst->flags & line_buf::LFT_32BIT) 
       {
-        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
                (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
         gen_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
       }
-      else
+      else 
       {
         assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
                (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
         gen_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
       }
-    }
+    }    
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                           const line_buf *other, const line_buf *aug,
+    void gen_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                           const line_buf* other, const line_buf* aug, 
                            ui32 repeat, bool synthesis)
     {
       float a = s->irv.Aatk;
@@ -713,80 +682,73 @@ namespace ojph
       if (synthesis)
         a = -a;
 
-      float *dst = aug->f32;
-      const float *src1 = sig->f32, *src2 = other->f32;
+      float* dst = aug->f32;
+      const float* src1 = sig->f32, * src2 = other->f32;
       for (ui32 i = repeat; i > 0; --i)
         *dst++ += a * (*src1++ + *src2++);
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat)
+    void gen_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat)
     {
-      float *dst = aug->f32;
+      float* dst = aug->f32;
       for (ui32 i = repeat; i > 0; --i)
         *dst++ *= K;
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                          const line_buf *hdst, const line_buf *src,
+    void gen_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                          const line_buf* hdst, const line_buf* src, 
                           ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
-        float *dph = hdst->f32;
-        float *dpl = ldst->f32;
-        float *sp = src->f32;
+        float* dph = hdst->f32;
+        float* dpl = ldst->f32;
+        float* sp = src->f32;
         ui32 w = width;
         if (!even)
         {
-          *dph++ = *sp++;
-          --w;
+          *dph++ = *sp++; --w;
         }
         for (; w > 1; w -= 2)
         {
-          *dpl++ = *sp++;
-          *dph++ = *sp++;
+          *dpl++ = *sp++; *dph++ = *sp++;
         }
         if (w)
         {
-          *dpl++ = *sp++;
-          --w;
+          *dpl++ = *sp++; --w;
         }
 
-        float *hp = hdst->f32, *lp = ldst->f32;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        float* hp = hdst->f32, * lp = ldst->f32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const float a = s->irv.Aatk;
 
           // extension
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const float *sp = lp + (even ? 1 : 0);
-          float *dp = hp;
+          const float* sp = lp + (even ? 1 : 0);
+          float* dp = hp;
           for (ui32 i = h_width; i > 0; --i, sp++, dp++)
             *dp += a * (sp[-1] + sp[0]);
 
           // swap buffers
-          float *t = lp;
-          lp = hp;
-          hp = t;
+          float* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
 
         {
           float K = atk->get_K();
           float K_inv = 1.0f / K;
-          float *dp;
+          float* dp;
 
           dp = lp;
           for (ui32 i = l_width; i > 0; --i)
@@ -797,31 +759,30 @@ namespace ojph
             *dp++ *= K;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->f32[0] = src->f32[0];
         else
           hdst->f32[0] = src->f32[0] * 2.0f;
       }
     }
-
+    
     //////////////////////////////////////////////////////////////////////////
-    void gen_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                          const line_buf *lsrc, const line_buf *hsrc,
+    void gen_irv_horz_syn(const param_atk* atk, const line_buf* dst, 
+                          const line_buf* lsrc, const line_buf* hsrc, 
                           ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        float *oth = hsrc->f32, *aug = lsrc->f32;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        float* oth = hsrc->f32, * aug = lsrc->f32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
 
         {
           float K = atk->get_K();
           float K_inv = 1.0f / K;
-          float *dp;
+          float* dp;
 
           dp = aug;
           for (ui32 i = aug_width; i > 0; --i)
@@ -835,51 +796,37 @@ namespace ojph
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const float a = s->irv.Aatk;
 
           // extension
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const float *sp = oth + (ev ? 0 : 1);
-          float *dp = aug;
+          const float* sp = oth + (ev ? 0 : 1);
+          float* dp = aug;
           for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
             *dp -= a * (sp[-1] + sp[0]);
 
           // swap buffers
-          float *t = aug;
-          aug = oth;
-          oth = t;
+          float* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
-        float *sph = hsrc->f32;
-        float *spl = lsrc->f32;
-        float *dp = dst->f32;
+        float* sph = hsrc->f32;
+        float* spl = lsrc->f32;
+        float* dp = dst->f32;
         ui32 w = width;
         if (!even)
-        {
-          *dp++ = *sph++;
-          --w;
-        }
+        { *dp++ = *sph++; --w; }
         for (; w > 1; w -= 2)
-        {
-          *dp++ = *spl++;
-          *dp++ = *sph++;
-        }
+        { *dp++ = *spl++; *dp++ = *sph++; }
         if (w)
-        {
-          *dp++ = *spl++;
-          --w;
-        }
+        { *dp++ = *spl++; --w; }
       }
-      else
-      {
+      else {
         if (even)
           dst->f32[0] = lsrc->f32[0];
         else

--- a/Native/Common/OpenJPH/transform/ojph_transform.h
+++ b/Native/Common/OpenJPH/transform/ojph_transform.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,19 +35,18 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_TRANSFORM_H
 #define OJPH_TRANSFORM_H
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   // defined elsewhere
   class line_buf;
 
-  namespace local
-  {
+  namespace local {
     union lifting_step;
     struct param_atk;
 
@@ -59,35 +58,42 @@ namespace ojph
     /////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    extern void (*rev_vert_step)(const lifting_step *s, const line_buf *sig, const line_buf *other,
-                                 const line_buf *aug, ui32 repeat, bool synthesis);
+    extern void (*rev_vert_step)
+      (const lifting_step* s, const line_buf* sig, const line_buf* other,
+        const line_buf* aug, ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    extern void (*rev_horz_ana)(const param_atk *atk, const line_buf *ldst, const line_buf *hdst,
-                                const line_buf *src, ui32 width, bool even);
+    extern void (*rev_horz_ana)
+      (const param_atk* atk, const line_buf* ldst, const line_buf* hdst,
+        const line_buf* src, ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    extern void (*rev_horz_syn)(const param_atk *atk, const line_buf *dst, const line_buf *lsrc,
-                                const line_buf *hsrc, ui32 width, bool even);
+    extern void (*rev_horz_syn)
+      (const param_atk* atk, const line_buf* dst, const line_buf* lsrc,
+        const line_buf* hsrc, ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     // Irreversible functions
     /////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    extern void (*irv_vert_step)(const lifting_step *s, const line_buf *sig, const line_buf *other,
-                                 const line_buf *aug, ui32 repeat, bool synthesis);
+    extern void (*irv_vert_step)
+      (const lifting_step* s, const line_buf* sig, const line_buf* other, 
+        const line_buf* aug, ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    extern void (*irv_vert_times_K)(float K, const line_buf *aug, ui32 repeat);
+    extern void (*irv_vert_times_K)
+      (float K, const line_buf* aug, ui32 repeat);
 
     /////////////////////////////////////////////////////////////////////////
-    extern void (*irv_horz_ana)(const param_atk *atk, const line_buf *ldst, const line_buf *hdst,
-                                const line_buf *src, ui32 width, bool even);
+    extern void (*irv_horz_ana)
+      (const param_atk* atk, const line_buf* ldst, const line_buf* hdst, 
+        const line_buf* src, ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    extern void (*irv_horz_syn)(const param_atk *atk, const line_buf *dst, const line_buf *lsrc,
-                                const line_buf *hsrc, ui32 width, bool even);
+    extern void (*irv_horz_syn)
+      (const param_atk* atk, const line_buf* dst, const line_buf* lsrc, 
+        const line_buf* hsrc, ui32 width, bool even);
 
   }
 }

--- a/Native/Common/OpenJPH/transform/ojph_transform_avx.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_transform_avx.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -49,13 +49,11 @@
 #include "ojph_transform.h"
 #include "ojph_transform_local.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void avx_multiply_const(float *p, float f, int width)
+    static inline void avx_multiply_const(float* p, float f, int width)
     {
       __m256 factor = _mm256_set1_ps(f);
       for (; width > 0; width -= 8, p += 8)
@@ -66,7 +64,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void avx_deinterleave32(float *dpl, float *dph, float *sp, int width)
+    static inline
+    void avx_deinterleave32(float* dpl, float* dph, float* sp, int width)
     {
       for (; width > 0; width -= 16, sp += 16, dpl += 8, dph += 8)
       {
@@ -82,7 +81,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void avx_interleave32(float *dp, float *spl, float *sph, int width)
+    static inline 
+    void avx_interleave32(float* dp, float* spl, float* sph, int width)
     {
       for (; width > 0; width -= 16, dp += 16, spl += 8, sph += 8)
       {
@@ -98,8 +98,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                           const line_buf *other, const line_buf *aug,
+    void avx_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                           const line_buf* other, const line_buf* aug, 
                            ui32 repeat, bool synthesis)
     {
       float a = s->irv.Aatk;
@@ -108,10 +108,10 @@ namespace ojph
 
       __m256 factor = _mm256_set1_ps(a);
 
-      float *dst = aug->f32;
-      const float *src1 = sig->f32, *src2 = other->f32;
+      float* dst = aug->f32;
+      const float* src1 = sig->f32, * src2 = other->f32;
       int i = (int)repeat;
-      for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+      for ( ; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
       {
         __m256 s1 = _mm256_load_ps(src1);
         __m256 s2 = _mm256_load_ps(src2);
@@ -122,43 +122,43 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat)
+    void avx_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat)
     {
       avx_multiply_const(aug->f32, K, (int)repeat);
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                          const line_buf *hdst, const line_buf *src,
+    void avx_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                          const line_buf* hdst, const line_buf* src, 
                           ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          float *dpl = even ? ldst->f32 : hdst->f32;
-          float *dph = even ? hdst->f32 : ldst->f32;
-          float *sp = src->f32;
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp = src->f32;
           int w = (int)width;
           avx_deinterleave32(dpl, dph, sp, w);
         }
 
         // the actual horizontal transform
-        float *hp = hdst->f32, *lp = ldst->f32;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        float* hp = hdst->f32, * lp = ldst->f32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const float a = s->irv.Aatk;
 
           // extension
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const float *sp = lp;
-          float *dp = hp;
+          const float* sp = lp;
+          float* dp = hp;
           int i = (int)h_width;
           __m256 f = _mm256_set1_ps(a);
           if (even)
@@ -185,13 +185,9 @@ namespace ojph
           }
 
           // swap buffers
-          float *t = lp;
-          lp = hp;
-          hp = t;
+          float* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
 
         { // multiply by K or 1/K
@@ -201,26 +197,25 @@ namespace ojph
           avx_multiply_const(hp, K, (int)h_width);
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->f32[0] = src->f32[0];
         else
           hdst->f32[0] = src->f32[0] * 2.0f;
       }
     }
-
+    
     //////////////////////////////////////////////////////////////////////////
-    void avx_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                          const line_buf *lsrc, const line_buf *hsrc,
+    void avx_irv_horz_syn(const param_atk* atk, const line_buf* dst, 
+                          const line_buf* lsrc, const line_buf* hsrc, 
                           ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        float *oth = hsrc->f32, *aug = lsrc->f32;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        float* oth = hsrc->f32, * aug = lsrc->f32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
 
         { // multiply by K or 1/K
           float K = atk->get_K();
@@ -233,15 +228,15 @@ namespace ojph
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const float a = s->irv.Aatk;
 
           // extension
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const float *sp = oth;
-          float *dp = aug;
+          const float* sp = oth;
+          float* dp = aug;
           int i = (int)aug_width;
           __m256 f = _mm256_set1_ps(a);
           if (ev)
@@ -268,26 +263,21 @@ namespace ojph
           }
 
           // swap buffers
-          float *t = aug;
-          aug = oth;
-          oth = t;
+          float* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          float *dp = dst->f32;
-          float *spl = even ? lsrc->f32 : hsrc->f32;
-          float *sph = even ? hsrc->f32 : lsrc->f32;
+          float* dp = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           avx_interleave32(dp, spl, sph, w);
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->f32[0] = lsrc->f32[0];
         else

--- a/Native/Common/OpenJPH/transform/ojph_transform_avx2.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_transform_avx2.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -51,14 +51,13 @@
 
 #include <immintrin.h>
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     /////////////////////////////////////////////////////////////////////////
     // https://github.com/seung-lab/dijkstra3d/blob/master/libdivide.h
-    static inline __m256i avx2_mm256_srai_epi64(__m256i a, int amt, __m256i m)
+    static inline 
+    __m256i avx2_mm256_srai_epi64(__m256i a, int amt, __m256i m) 
     {
       // note than m must be obtained using
       // __m256i m = _mm256_set1_epi64x(1ULL << (63 - amt));
@@ -69,7 +68,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void avx2_deinterleave32(float *dpl, float *dph, float *sp, int width)
+    static inline
+    void avx2_deinterleave32(float* dpl, float* dph, float* sp, int width)
     {
       for (; width > 0; width -= 16, sp += 16, dpl += 8, dph += 8)
       {
@@ -85,7 +85,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void avx2_interleave32(float *dp, float *spl, float *sph, int width)
+    static inline 
+    void avx2_interleave32(float* dp, float* spl, float* sph, int width)
     {
       for (; width > 0; width -= 16, dp += 16, spl += 8, sph += 8)
       {
@@ -101,7 +102,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void avx2_deinterleave64(double *dpl, double *dph, double *sp, int width)
+    static inline 
+    void avx2_deinterleave64(double* dpl, double* dph, double* sp, int width)
     {
       for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
       {
@@ -117,7 +119,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void avx2_interleave64(double *dp, double *spl, double *sph, int width)
+    static inline 
+    void avx2_interleave64(double* dp, double* spl, double* sph, int width)
     {
       for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
       {
@@ -133,9 +136,10 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void avx2_rev_vert_step32(const lifting_step *s, const line_buf *sig,
-                                     const line_buf *other, const line_buf *aug,
-                                     ui32 repeat, bool synthesis)
+    static
+    void avx2_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
+                              ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
       const si32 b = s->rev.Batk;
@@ -143,9 +147,9 @@ namespace ojph
       __m256i va = _mm256_set1_epi32(a);
       __m256i vb = _mm256_set1_epi32(b);
 
-      si32 *dst = aug->i32;
-      const si32 *src1 = sig->i32, *src2 = other->i32;
-      // The general definition of the wavelet in Part 2 is slightly
+      si32* dst = aug->i32;
+      const si32* src1 = sig->i32, * src2 = other->i32;
+      // The general definition of the wavelet in Part 2 is slightly 
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -154,26 +158,26 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi32(s1, s2);
             __m256i v = _mm256_add_epi32(vb, t);
             __m256i w = _mm256_srai_epi32(v, e);
             d = _mm256_sub_epi32(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
         else
           for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi32(s1, s2);
             __m256i v = _mm256_add_epi32(vb, t);
             __m256i w = _mm256_srai_epi32(v, e);
             d = _mm256_add_epi32(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
       }
       else if (a == -1 && b == 1 && e == 1)
@@ -182,24 +186,24 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi32(s1, s2);
             __m256i w = _mm256_srai_epi32(t, e);
             d = _mm256_add_epi32(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
         else
           for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi32(s1, s2);
             __m256i w = _mm256_srai_epi32(t, e);
             d = _mm256_sub_epi32(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
       }
       else if (a == -1)
@@ -208,74 +212,74 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi32(s1, s2);
             __m256i v = _mm256_sub_epi32(vb, t);
             __m256i w = _mm256_srai_epi32(v, e);
             d = _mm256_sub_epi32(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
         else
           for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi32(s1, s2);
             __m256i v = _mm256_sub_epi32(vb, t);
             __m256i w = _mm256_srai_epi32(v, e);
             d = _mm256_add_epi32(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
       }
-      else
-      { // general case
+      else { // general case
         int i = (int)repeat;
         if (synthesis)
           for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi32(s1, s2);
             __m256i u = _mm256_mullo_epi32(va, t);
             __m256i v = _mm256_add_epi32(vb, u);
             __m256i w = _mm256_srai_epi32(v, e);
             d = _mm256_sub_epi32(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
         else
           for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi32(s1, s2);
             __m256i u = _mm256_mullo_epi32(va, t);
             __m256i v = _mm256_add_epi32(vb, u);
             __m256i w = _mm256_srai_epi32(v, e);
             d = _mm256_add_epi32(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void avx2_rev_vert_step64(const lifting_step *s, const line_buf *sig,
-                                     const line_buf *other, const line_buf *aug,
-                                     ui32 repeat, bool synthesis)
+    static
+    void avx2_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
+                              ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
       const si32 b = s->rev.Batk;
       const ui8 e = s->rev.Eatk;
       __m256i vb = _mm256_set1_epi64x(b);
-      __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));
+      __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));      
 
-      si64 *dst = aug->i64;
-      const si64 *src1 = sig->i64, *src2 = other->i64;
-      // The general definition of the wavelet in Part 2 is slightly
+      si64* dst = aug->i64;
+      const si64* src1 = sig->i64, * src2 = other->i64;
+      // The general definition of the wavelet in Part 2 is slightly 
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -284,26 +288,26 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi64(s1, s2);
             __m256i v = _mm256_add_epi64(vb, t);
             __m256i w = avx2_mm256_srai_epi64(v, e, ve);
             d = _mm256_sub_epi64(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi64(s1, s2);
             __m256i v = _mm256_add_epi64(vb, t);
             __m256i w = avx2_mm256_srai_epi64(v, e, ve);
             d = _mm256_add_epi64(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
       }
       else if (a == -1 && b == 1 && e == 1)
@@ -312,24 +316,24 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi64(s1, s2);
             __m256i w = avx2_mm256_srai_epi64(t, e, ve);
             d = _mm256_add_epi64(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi64(s1, s2);
             __m256i w = avx2_mm256_srai_epi64(t, e, ve);
             d = _mm256_sub_epi64(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
       }
       else if (a == -1)
@@ -338,30 +342,29 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi64(s1, s2);
             __m256i v = _mm256_sub_epi64(vb, t);
             __m256i w = avx2_mm256_srai_epi64(v, e, ve);
             d = _mm256_sub_epi64(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m256i s1 = _mm256_load_si256((__m256i *)src1);
-            __m256i s2 = _mm256_load_si256((__m256i *)src2);
-            __m256i d = _mm256_load_si256((__m256i *)dst);
+            __m256i s1 = _mm256_load_si256((__m256i*)src1);
+            __m256i s2 = _mm256_load_si256((__m256i*)src2);
+            __m256i d = _mm256_load_si256((__m256i*)dst);
             __m256i t = _mm256_add_epi64(s1, s2);
             __m256i v = _mm256_sub_epi64(vb, t);
             __m256i w = avx2_mm256_srai_epi64(v, e, ve);
             d = _mm256_add_epi64(d, w);
-            _mm256_store_si256((__m256i *)dst, d);
+            _mm256_store_si256((__m256i*)dst, d);
           }
       }
-      else
-      { // general case
+      else { // general case
         // 64bit multiplication is not supported in avx2;
         // in particular, _mm256_mullo_epi64.
         if (synthesis)
@@ -374,55 +377,56 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                            const line_buf *other, const line_buf *aug,
+    void avx2_rev_vert_step(const lifting_step* s, const line_buf* sig, 
+                            const line_buf* other, const line_buf* aug, 
                             ui32 repeat, bool synthesis)
     {
-      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
           ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
                (aug == NULL || aug->flags & line_buf::LFT_32BIT));
         avx2_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
       }
-      else
+      else 
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
                (aug == NULL || aug->flags & line_buf::LFT_64BIT));
         avx2_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void avx2_rev_horz_ana32(const param_atk *atk, const line_buf *ldst,
-                                    const line_buf *hdst, const line_buf *src,
-                                    ui32 width, bool even)
+    static
+    void avx2_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
+                             const line_buf* hdst, const line_buf* src, 
+                             ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          float *dpl = even ? ldst->f32 : hdst->f32;
-          float *dph = even ? hdst->f32 : ldst->f32;
-          float *sp = src->f32;
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp  = src->f32;
           int w = (int)width;
           avx2_deinterleave32(dpl, dph, sp, w);
         }
 
-        si32 *hp = hdst->i32, *lp = ldst->i32;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si32* hp = hdst->i32, * lp = ldst->i32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
           // first lifting step
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
-          const ui8 e = s->rev.Eatk;
+          const ui8 e  = s->rev.Eatk;
           __m256i va = _mm256_set1_epi32(a);
           __m256i vb = _mm256_set1_epi32(b);
 
@@ -430,8 +434,8 @@ namespace ojph
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const si32 *sp = lp;
-          si32 *dp = hp;
+          const si32* sp = lp;
+          si32* dp = hp;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)h_width;
@@ -439,55 +443,55 @@ namespace ojph
             {
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i v = _mm256_add_epi32(vb, t);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_add_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i v = _mm256_add_epi32(vb, t);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_add_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i w = _mm256_srai_epi32(t, e);
                 d = _mm256_sub_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i w = _mm256_srai_epi32(t, e);
                 d = _mm256_sub_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
           else if (a == -1)
@@ -496,72 +500,66 @@ namespace ojph
             if (even)
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i v = _mm256_sub_epi32(vb, t);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_add_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i v = _mm256_sub_epi32(vb, t);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_add_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
-          else
-          {
+          else {
             // general case
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i u = _mm256_mullo_epi32(va, t);
                 __m256i v = _mm256_add_epi32(vb, u);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_add_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i u = _mm256_mullo_epi32(va, t);
                 __m256i v = _mm256_add_epi32(vb, u);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_add_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
 
           // swap buffers
-          si32 *t = lp;
-          lp = hp;
-          hp = t;
+          si32* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->i32[0] = src->i32[0];
         else
@@ -570,32 +568,33 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void avx2_rev_horz_ana64(const param_atk *atk, const line_buf *ldst,
-                                    const line_buf *hdst, const line_buf *src,
-                                    ui32 width, bool even)
+    static
+    void avx2_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
+                             const line_buf* hdst, const line_buf* src, 
+                             ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          double *dpl = (double *)(even ? ldst->p : hdst->p);
-          double *dph = (double *)(even ? hdst->p : ldst->p);
-          double *sp = (double *)src->p;
+          double* dpl = (double*)(even ? ldst->p : hdst->p);
+          double* dph = (double*)(even ? hdst->p : ldst->p);
+          double* sp  = (double*)src->p;
           int w = (int)width;
           avx2_deinterleave64(dpl, dph, sp, w);
         }
 
-        si64 *hp = hdst->i64, *lp = ldst->i64;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si64* hp = hdst->i64, * lp = ldst->i64;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
           // first lifting step
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
-          const ui8 e = s->rev.Eatk;
+          const ui8 e  = s->rev.Eatk;
           __m256i vb = _mm256_set1_epi64x(b);
           __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));
 
@@ -603,8 +602,8 @@ namespace ojph
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const si64 *sp = lp;
-          si64 *dp = hp;
+          const si64* sp = lp;
+          si64* dp = hp;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)h_width;
@@ -612,55 +611,55 @@ namespace ojph
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i v = _mm256_add_epi64(vb, t);
                 __m256i w = avx2_mm256_srai_epi64(v, e, ve);
                 d = _mm256_add_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i v = _mm256_add_epi64(vb, t);
                 __m256i w = avx2_mm256_srai_epi64(v, e, ve);
                 d = _mm256_add_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i w = avx2_mm256_srai_epi64(t, e, ve);
                 d = _mm256_sub_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i w = avx2_mm256_srai_epi64(t, e, ve);
                 d = _mm256_sub_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
           else if (a == -1)
@@ -669,30 +668,29 @@ namespace ojph
             if (even)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i v = _mm256_sub_epi64(vb, t);
                 __m256i w = avx2_mm256_srai_epi64(v, e, ve);
                 d = _mm256_add_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i v = _mm256_sub_epi64(vb, t);
                 __m256i w = avx2_mm256_srai_epi64(v, e, ve);
                 d = _mm256_add_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
-          else
-          {
+          else {
             // general case
             // 64bit multiplication is not supported in avx2;
             // in particular, _mm256_mullo_epi64.
@@ -705,17 +703,12 @@ namespace ojph
           }
 
           // swap buffers
-          si64 *t = lp;
-          lp = hp;
-          hp = t;
+          si64* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->i64[0] = src->i64[0];
         else
@@ -724,43 +717,44 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                           const line_buf *hdst, const line_buf *src,
+    void avx2_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                           const line_buf* hdst, const line_buf* src, 
                            ui32 width, bool even)
     {
-      if (src->flags & line_buf::LFT_32BIT)
+      if (src->flags & line_buf::LFT_32BIT) 
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
                (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
         avx2_rev_horz_ana32(atk, ldst, hdst, src, width, even);
       }
-      else
+      else 
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
                (src == NULL || src->flags & line_buf::LFT_64BIT));
         avx2_rev_horz_ana64(atk, ldst, hdst, src, width, even);
       }
-    }
-
+    } 
+    
     //////////////////////////////////////////////////////////////////////////
-    static void avx2_rev_horz_syn32(const param_atk *atk, const line_buf *dst,
-                                    const line_buf *lsrc, const line_buf *hsrc,
-                                    ui32 width, bool even)
+    static
+    void avx2_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
+                             const line_buf* lsrc, const line_buf* hsrc, 
+                             ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        si32 *oth = hsrc->i32, *aug = lsrc->i32;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si32* oth = hsrc->i32, * aug = lsrc->i32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
-          const ui8 e = s->rev.Eatk;
+          const ui8 e  = s->rev.Eatk;
           __m256i va = _mm256_set1_epi32(a);
           __m256i vb = _mm256_set1_epi32(b);
 
@@ -768,8 +762,8 @@ namespace ojph
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const si32 *sp = oth;
-          si32 *dp = aug;
+          const si32* sp = oth;
+          si32* dp = aug;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)aug_width;
@@ -777,55 +771,55 @@ namespace ojph
             {
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i v = _mm256_add_epi32(vb, t);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_sub_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i v = _mm256_add_epi32(vb, t);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_sub_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i w = _mm256_srai_epi32(t, e);
                 d = _mm256_add_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i w = _mm256_srai_epi32(t, e);
                 d = _mm256_add_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
           else if (a == -1)
@@ -834,81 +828,75 @@ namespace ojph
             if (ev)
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i v = _mm256_sub_epi32(vb, t);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_sub_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i v = _mm256_sub_epi32(vb, t);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_sub_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
-          else
-          {
+          else {
             // general case
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i u = _mm256_mullo_epi32(va, t);
                 __m256i v = _mm256_add_epi32(vb, u);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_sub_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 8, sp += 8, dp += 8)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi32(s1, s2);
                 __m256i u = _mm256_mullo_epi32(va, t);
                 __m256i v = _mm256_add_epi32(vb, u);
                 __m256i w = _mm256_srai_epi32(v, e);
                 d = _mm256_sub_epi32(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
 
           // swap buffers
-          si32 *t = aug;
-          aug = oth;
-          oth = t;
+          si32* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          float *dp = dst->f32;
-          float *spl = even ? lsrc->f32 : hsrc->f32;
-          float *sph = even ? hsrc->f32 : lsrc->f32;
+          float* dp  = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           avx2_interleave32(dp, spl, sph, w);
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->i32[0] = lsrc->i32[0];
         else
@@ -917,32 +905,33 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static void avx2_rev_horz_syn64(const param_atk *atk, const line_buf *dst,
-                                    const line_buf *lsrc, const line_buf *hsrc,
-                                    ui32 width, bool even)
+    static
+    void avx2_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
+                             const line_buf* lsrc, const line_buf* hsrc, 
+                             ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        si64 *oth = hsrc->i64, *aug = lsrc->i64;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si64* oth = hsrc->i64, * aug = lsrc->i64;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
-          const ui8 e = s->rev.Eatk;
+          const ui8 e  = s->rev.Eatk;
           __m256i vb = _mm256_set1_epi64x(b);
-          __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));
+          __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));      
 
           // extension
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const si64 *sp = oth;
-          si64 *dp = aug;
+          const si64* sp = oth;
+          si64* dp = aug;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)aug_width;
@@ -950,55 +939,55 @@ namespace ojph
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i v = _mm256_add_epi64(vb, t);
                 __m256i w = avx2_mm256_srai_epi64(v, e, ve);
                 d = _mm256_sub_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i v = _mm256_add_epi64(vb, t);
                 __m256i w = avx2_mm256_srai_epi64(v, e, ve);
                 d = _mm256_sub_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i w = avx2_mm256_srai_epi64(t, e, ve);
                 d = _mm256_add_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i w = avx2_mm256_srai_epi64(t, e, ve);
                 d = _mm256_add_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
           else if (a == -1)
@@ -1007,30 +996,29 @@ namespace ojph
             if (ev)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp - 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp - 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i v = _mm256_sub_epi64(vb, t);
                 __m256i w = avx2_mm256_srai_epi64(v, e, ve);
                 d = _mm256_sub_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m256i s1 = _mm256_load_si256((__m256i *)sp);
-                __m256i s2 = _mm256_loadu_si256((__m256i *)(sp + 1));
-                __m256i d = _mm256_load_si256((__m256i *)dp);
+                __m256i s1 = _mm256_load_si256((__m256i*)sp);
+                __m256i s2 = _mm256_loadu_si256((__m256i*)(sp + 1));
+                __m256i d = _mm256_load_si256((__m256i*)dp);
                 __m256i t = _mm256_add_epi64(s1, s2);
                 __m256i v = _mm256_sub_epi64(vb, t);
                 __m256i w = avx2_mm256_srai_epi64(v, e, ve);
                 d = _mm256_sub_epi64(d, w);
-                _mm256_store_si256((__m256i *)dp, d);
+                _mm256_store_si256((__m256i*)dp, d);
               }
           }
-          else
-          {
+          else {
             // general case
             // 64bit multiplication is not supported in avx2;
             // in particular, _mm_mullo_epi64.
@@ -1043,48 +1031,43 @@ namespace ojph
           }
 
           // swap buffers
-          si64 *t = aug;
-          aug = oth;
-          oth = t;
+          si64* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          double *dp = (double *)dst->p;
-          double *spl = (double *)(even ? lsrc->p : hsrc->p);
-          double *sph = (double *)(even ? hsrc->p : lsrc->p);
+          double* dp  = (double*)dst->p;
+          double* spl = (double*)(even ? lsrc->p : hsrc->p);
+          double* sph = (double*)(even ? hsrc->p : lsrc->p);
           int w = (int)width;
           avx2_interleave64(dp, spl, sph, w);
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->i64[0] = lsrc->i64[0];
         else
           dst->i64[0] = hsrc->i64[0] >> 1;
       }
-    }
+    }    
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                           const line_buf *lsrc, const line_buf *hsrc,
+    void avx2_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
+                           const line_buf* lsrc, const line_buf* hsrc, 
                            ui32 width, bool even)
     {
-      if (dst->flags & line_buf::LFT_32BIT)
+      if (dst->flags & line_buf::LFT_32BIT) 
       {
-        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
                (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
         avx2_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
       }
-      else
+      else 
       {
         assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
                (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
         avx2_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
       }

--- a/Native/Common/OpenJPH/transform/ojph_transform_avx512.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_transform_avx512.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019-2024, Aous Naman
+// Copyright (c) 2019-2024, Aous Naman 
 // Copyright (c) 2019-2024, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019-2024, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -50,1405 +50,1380 @@
 
 #include <immintrin.h>
 
-namespace ojph
-{
-    namespace local
+namespace ojph {
+  namespace local {
+
+    //////////////////////////////////////////////////////////////////////////
+    // We split multiples of 32 followed by multiples of 16, because
+    // we assume byte_alignment == 64
+    static 
+    void avx512_deinterleave32(float* dpl, float* dph, float* sp, int width)
     {
+      __m512i idx1 = _mm512_set_epi32(
+        0x1E, 0x1C, 0x1A, 0x18, 0x16, 0x14, 0x12, 0x10,
+        0x0E, 0x0C, 0x0A, 0x08, 0x06, 0x04, 0x02, 0x00
+      );
+      __m512i idx2 = _mm512_set_epi32(
+        0x1F, 0x1D, 0x1B, 0x19, 0x17, 0x15, 0x13, 0x11,
+        0x0F, 0x0D, 0x0B, 0x09, 0x07, 0x05, 0x03, 0x01
+      );
+      for (; width > 16; width -= 32, sp += 32, dpl += 16, dph += 16)
+      {
+        __m512 a = _mm512_load_ps(sp);
+        __m512 b = _mm512_load_ps(sp + 16);
+        __m512 c = _mm512_permutex2var_ps(a, idx1, b);
+        __m512 d = _mm512_permutex2var_ps(a, idx2, b);
+        _mm512_store_ps(dpl, c);
+        _mm512_store_ps(dph, d);
+      }
+      for (; width > 0; width -= 16, sp += 16, dpl += 8, dph += 8)
+      {
+        __m256 a = _mm256_load_ps(sp);
+        __m256 b = _mm256_load_ps(sp + 8);
+        __m256 c = _mm256_permute2f128_ps(a, b, (2 << 4) | (0));
+        __m256 d = _mm256_permute2f128_ps(a, b, (3 << 4) | (1));
+        __m256 e = _mm256_shuffle_ps(c, d, _MM_SHUFFLE(2, 0, 2, 0));
+        __m256 f = _mm256_shuffle_ps(c, d, _MM_SHUFFLE(3, 1, 3, 1));
+        _mm256_store_ps(dpl, e);
+        _mm256_store_ps(dph, f);
+      }
+    }
 
-        //////////////////////////////////////////////////////////////////////////
-        // We split multiples of 32 followed by multiples of 16, because
-        // we assume byte_alignment == 64
-        static void avx512_deinterleave32(float *dpl, float *dph, float *sp, int width)
+    //////////////////////////////////////////////////////////////////////////
+    // We split multiples of 32 followed by multiples of 16, because
+    // we assume byte_alignment == 64
+    static 
+    void avx512_interleave32(float* dp, float* spl, float* sph, int width)
+    {
+      __m512i idx1 = _mm512_set_epi32(
+        0x17, 0x7, 0x16, 0x6, 0x15, 0x5, 0x14, 0x4,
+        0x13, 0x3, 0x12, 0x2, 0x11, 0x1, 0x10, 0x0
+      );
+      __m512i idx2 = _mm512_set_epi32(
+        0x1F, 0xF, 0x1E, 0xE, 0x1D, 0xD, 0x1C, 0xC,
+        0x1B, 0xB, 0x1A, 0xA, 0x19, 0x9, 0x18, 0x8
+      );
+      for (; width > 16; width -= 32, dp += 32, spl += 16, sph += 16)
+      {
+        __m512 a = _mm512_load_ps(spl);
+        __m512 b = _mm512_load_ps(sph);
+        __m512 c = _mm512_permutex2var_ps(a, idx1, b);
+        __m512 d = _mm512_permutex2var_ps(a, idx2, b);
+        _mm512_store_ps(dp, c);
+        _mm512_store_ps(dp + 16, d);
+      }
+      for (; width > 0; width -= 16, dp += 16, spl += 8, sph += 8)
+      {
+        __m256 a = _mm256_load_ps(spl);
+        __m256 b = _mm256_load_ps(sph);
+        __m256 c = _mm256_unpacklo_ps(a, b);
+        __m256 d = _mm256_unpackhi_ps(a, b);
+        __m256 e = _mm256_permute2f128_ps(c, d, (2 << 4) | (0));
+        __m256 f = _mm256_permute2f128_ps(c, d, (3 << 4) | (1));
+        _mm256_store_ps(dp, e);
+        _mm256_store_ps(dp + 8, f);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // We split multiples of 32 followed by multiples of 16, because
+    // we assume byte_alignment == 64
+    static void avx512_deinterleave64(double* dpl, double* dph, double* sp, 
+                                      int width)
+    {
+      __m512i idx1 = _mm512_set_epi64(
+        0x0E, 0x0C, 0x0A, 0x08, 0x06, 0x04, 0x02, 0x00
+      );
+      __m512i idx2 = _mm512_set_epi64(
+        0x0F, 0x0D, 0x0B, 0x09, 0x07, 0x05, 0x03, 0x01
+      );
+      for (; width > 8; width -= 16, sp += 16, dpl += 8, dph += 8)
+      {
+        __m512d a = _mm512_load_pd(sp);
+        __m512d b = _mm512_load_pd(sp + 16);
+        __m512d c = _mm512_permutex2var_pd(a, idx1, b);
+        __m512d d = _mm512_permutex2var_pd(a, idx2, b);
+        _mm512_store_pd(dpl, c);
+        _mm512_store_pd(dph, d);
+      }
+      for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
+      {
+        __m256d a = _mm256_load_pd(sp);
+        __m256d b = _mm256_load_pd(sp + 4);
+        __m256d c = _mm256_permute2f128_pd(a, b, (2 << 4) | (0));
+        __m256d d = _mm256_permute2f128_pd(a, b, (3 << 4) | (1));
+        __m256d e = _mm256_shuffle_pd(c, d, 0x0);
+        __m256d f = _mm256_shuffle_pd(c, d, 0xF);
+        _mm256_store_pd(dpl, e);
+        _mm256_store_pd(dph, f);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // We split multiples of 32 followed by multiples of 16, because
+    // we assume byte_alignment == 64
+    static void avx512_interleave64(double* dp, double* spl, double* sph, 
+                                    int width)
+    {
+      __m512i idx1 = _mm512_set_epi64(
+        0xB, 0x3, 0xA, 0x2, 0x9, 0x1, 0x8, 0x0
+      );
+      __m512i idx2 = _mm512_set_epi64(
+        0xF, 0x7, 0xE, 0x6, 0xD, 0x5, 0xC, 0x4
+      );
+      for (; width > 8; width -= 16, dp += 16, spl += 8, sph += 8)
+      {
+        __m512d a = _mm512_load_pd(spl);
+        __m512d b = _mm512_load_pd(sph);
+        __m512d c = _mm512_permutex2var_pd(a, idx1, b);
+        __m512d d = _mm512_permutex2var_pd(a, idx2, b);
+        _mm512_store_pd(dp, c);
+        _mm512_store_pd(dp + 16, d);
+      }
+      for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
+      {
+        __m256d a = _mm256_load_pd(spl);
+        __m256d b = _mm256_load_pd(sph);
+        __m256d c = _mm256_unpacklo_pd(a, b);
+        __m256d d = _mm256_unpackhi_pd(a, b);
+        __m256d e = _mm256_permute2f128_pd(c, d, (2 << 4) | (0));
+        __m256d f = _mm256_permute2f128_pd(c, d, (3 << 4) | (1));
+        _mm256_store_pd(dp, e);
+        _mm256_store_pd(dp + 4, f);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline void avx512_multiply_const(float* p, float f, int width)
+    {
+      __m512 factor = _mm512_set1_ps(f);
+      for (; width > 0; width -= 16, p += 16)
+      {
+        __m512 s = _mm512_load_ps(p);
+        _mm512_store_ps(p, _mm512_mul_ps(factor, s));
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void avx512_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
+                              ui32 repeat, bool synthesis)
+    {
+      float a = s->irv.Aatk;
+      if (synthesis)
+        a = -a;
+
+      __m512 factor = _mm512_set1_ps(a);
+
+      float* dst = aug->f32;
+      const float* src1 = sig->f32, * src2 = other->f32;
+      int i = (int)repeat;
+      for ( ; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+      {
+        __m512 s1 = _mm512_load_ps(src1);
+        __m512 s2 = _mm512_load_ps(src2);
+        __m512 d = _mm512_load_ps(dst);
+        d = _mm512_add_ps(d, _mm512_mul_ps(factor, _mm512_add_ps(s1, s2)));
+        _mm512_store_ps(dst, d);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void avx512_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat)
+    {
+      avx512_multiply_const(aug->f32, K, (int)repeat);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void avx512_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                             const line_buf* hdst, const line_buf* src, 
+                             ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        // split src into ldst and hdst
         {
-            __m512i idx1 = _mm512_set_epi32(
-                0x1E, 0x1C, 0x1A, 0x18, 0x16, 0x14, 0x12, 0x10,
-                0x0E, 0x0C, 0x0A, 0x08, 0x06, 0x04, 0x02, 0x00);
-            __m512i idx2 = _mm512_set_epi32(
-                0x1F, 0x1D, 0x1B, 0x19, 0x17, 0x15, 0x13, 0x11,
-                0x0F, 0x0D, 0x0B, 0x09, 0x07, 0x05, 0x03, 0x01);
-            for (; width > 16; width -= 32, sp += 32, dpl += 16, dph += 16)
-            {
-                __m512 a = _mm512_load_ps(sp);
-                __m512 b = _mm512_load_ps(sp + 16);
-                __m512 c = _mm512_permutex2var_ps(a, idx1, b);
-                __m512 d = _mm512_permutex2var_ps(a, idx2, b);
-                _mm512_store_ps(dpl, c);
-                _mm512_store_ps(dph, d);
-            }
-            for (; width > 0; width -= 16, sp += 16, dpl += 8, dph += 8)
-            {
-                __m256 a = _mm256_load_ps(sp);
-                __m256 b = _mm256_load_ps(sp + 8);
-                __m256 c = _mm256_permute2f128_ps(a, b, (2 << 4) | (0));
-                __m256 d = _mm256_permute2f128_ps(a, b, (3 << 4) | (1));
-                __m256 e = _mm256_shuffle_ps(c, d, _MM_SHUFFLE(2, 0, 2, 0));
-                __m256 f = _mm256_shuffle_ps(c, d, _MM_SHUFFLE(3, 1, 3, 1));
-                _mm256_store_ps(dpl, e);
-                _mm256_store_ps(dph, f);
-            }
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp  = src->f32;
+          int w = (int)width;
+          avx512_deinterleave32(dpl, dph, sp, w);
         }
 
-        //////////////////////////////////////////////////////////////////////////
-        // We split multiples of 32 followed by multiples of 16, because
-        // we assume byte_alignment == 64
-        static void avx512_interleave32(float *dp, float *spl, float *sph, int width)
+        // the actual horizontal transform
+        float* hp = hdst->f32, * lp = ldst->f32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = num_steps; j > 0; --j)
         {
-            __m512i idx1 = _mm512_set_epi32(
-                0x17, 0x7, 0x16, 0x6, 0x15, 0x5, 0x14, 0x4,
-                0x13, 0x3, 0x12, 0x2, 0x11, 0x1, 0x10, 0x0);
-            __m512i idx2 = _mm512_set_epi32(
-                0x1F, 0xF, 0x1E, 0xE, 0x1D, 0xD, 0x1C, 0xC,
-                0x1B, 0xB, 0x1A, 0xA, 0x19, 0x9, 0x18, 0x8);
-            for (; width > 16; width -= 32, dp += 32, spl += 16, sph += 16)
+          const lifting_step* s = atk->get_step(j - 1);
+          const float a = s->irv.Aatk;
+
+          // extension
+          lp[-1] = lp[0];
+          lp[l_width] = lp[l_width - 1];
+          // lifting step
+          const float* sp = lp;
+          float* dp = hp;
+          int i = (int)h_width;
+          __m512 f = _mm512_set1_ps(a);
+          if (even)
+          {
+            for (; i > 0; i -= 16, sp += 16, dp += 16)
             {
-                __m512 a = _mm512_load_ps(spl);
-                __m512 b = _mm512_load_ps(sph);
-                __m512 c = _mm512_permutex2var_ps(a, idx1, b);
-                __m512 d = _mm512_permutex2var_ps(a, idx2, b);
-                _mm512_store_ps(dp, c);
-                _mm512_store_ps(dp + 16, d);
+              __m512 m = _mm512_load_ps(sp);
+              __m512 n = _mm512_loadu_ps(sp + 1);
+              __m512 p = _mm512_load_ps(dp);
+              p = _mm512_add_ps(p, _mm512_mul_ps(f, _mm512_add_ps(m, n)));
+              _mm512_store_ps(dp, p);
             }
-            for (; width > 0; width -= 16, dp += 16, spl += 8, sph += 8)
+          }
+          else
+          {
+            for (; i > 0; i -= 16, sp += 16, dp += 16)
             {
-                __m256 a = _mm256_load_ps(spl);
-                __m256 b = _mm256_load_ps(sph);
-                __m256 c = _mm256_unpacklo_ps(a, b);
-                __m256 d = _mm256_unpackhi_ps(a, b);
-                __m256 e = _mm256_permute2f128_ps(c, d, (2 << 4) | (0));
-                __m256 f = _mm256_permute2f128_ps(c, d, (3 << 4) | (1));
-                _mm256_store_ps(dp, e);
-                _mm256_store_ps(dp + 8, f);
+              __m512 m = _mm512_load_ps(sp);
+              __m512 n = _mm512_loadu_ps(sp - 1);
+              __m512 p = _mm512_load_ps(dp);
+              p = _mm512_add_ps(p, _mm512_mul_ps(f, _mm512_add_ps(m, n)));
+              _mm512_store_ps(dp, p);
             }
+          }
+
+          // swap buffers
+          float* t = lp; lp = hp; hp = t;
+          even = !even;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
 
-        //////////////////////////////////////////////////////////////////////////
-        // We split multiples of 32 followed by multiples of 16, because
-        // we assume byte_alignment == 64
-        static void avx512_deinterleave64(double *dpl, double *dph, double *sp,
-                                          int width)
-        {
-            __m512i idx1 = _mm512_set_epi64(
-                0x0E, 0x0C, 0x0A, 0x08, 0x06, 0x04, 0x02, 0x00);
-            __m512i idx2 = _mm512_set_epi64(
-                0x0F, 0x0D, 0x0B, 0x09, 0x07, 0x05, 0x03, 0x01);
-            for (; width > 8; width -= 16, sp += 16, dpl += 8, dph += 8)
-            {
-                __m512d a = _mm512_load_pd(sp);
-                __m512d b = _mm512_load_pd(sp + 16);
-                __m512d c = _mm512_permutex2var_pd(a, idx1, b);
-                __m512d d = _mm512_permutex2var_pd(a, idx2, b);
-                _mm512_store_pd(dpl, c);
-                _mm512_store_pd(dph, d);
-            }
-            for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
-            {
-                __m256d a = _mm256_load_pd(sp);
-                __m256d b = _mm256_load_pd(sp + 4);
-                __m256d c = _mm256_permute2f128_pd(a, b, (2 << 4) | (0));
-                __m256d d = _mm256_permute2f128_pd(a, b, (3 << 4) | (1));
-                __m256d e = _mm256_shuffle_pd(c, d, 0x0);
-                __m256d f = _mm256_shuffle_pd(c, d, 0xF);
-                _mm256_store_pd(dpl, e);
-                _mm256_store_pd(dph, f);
-            }
+        { // multiply by K or 1/K
+          float K = atk->get_K();
+          float K_inv = 1.0f / K;
+          avx512_multiply_const(lp, K_inv, (int)l_width);
+          avx512_multiply_const(hp, K, (int)h_width);
+        }
+      }
+      else {
+        if (even)
+          ldst->f32[0] = src->f32[0];
+        else
+          hdst->f32[0] = src->f32[0] * 2.0f;
+      }
+    }
+    
+    //////////////////////////////////////////////////////////////////////////
+    void avx512_irv_horz_syn(const param_atk* atk, const line_buf* dst, 
+                             const line_buf* lsrc, const line_buf* hsrc, 
+                             ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        bool ev = even;
+        float* oth = hsrc->f32, * aug = lsrc->f32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+
+        { // multiply by K or 1/K
+          float K = atk->get_K();
+          float K_inv = 1.0f / K;
+          avx512_multiply_const(aug, K, (int)aug_width);
+          avx512_multiply_const(oth, K_inv, (int)oth_width);
         }
 
-        //////////////////////////////////////////////////////////////////////////
-        // We split multiples of 32 followed by multiples of 16, because
-        // we assume byte_alignment == 64
-        static void avx512_interleave64(double *dp, double *spl, double *sph,
-                                        int width)
+        // the actual horizontal transform
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = 0; j < num_steps; ++j)
         {
-            __m512i idx1 = _mm512_set_epi64(
-                0xB, 0x3, 0xA, 0x2, 0x9, 0x1, 0x8, 0x0);
-            __m512i idx2 = _mm512_set_epi64(
-                0xF, 0x7, 0xE, 0x6, 0xD, 0x5, 0xC, 0x4);
-            for (; width > 8; width -= 16, dp += 16, spl += 8, sph += 8)
+          const lifting_step* s = atk->get_step(j);
+          const float a = s->irv.Aatk;
+
+          // extension
+          oth[-1] = oth[0];
+          oth[oth_width] = oth[oth_width - 1];
+          // lifting step
+          const float* sp = oth;
+          float* dp = aug;
+          int i = (int)aug_width;
+          __m512 f = _mm512_set1_ps(a);
+          if (ev)
+          {
+            for (; i > 0; i -= 16, sp += 16, dp += 16)
             {
-                __m512d a = _mm512_load_pd(spl);
-                __m512d b = _mm512_load_pd(sph);
-                __m512d c = _mm512_permutex2var_pd(a, idx1, b);
-                __m512d d = _mm512_permutex2var_pd(a, idx2, b);
-                _mm512_store_pd(dp, c);
-                _mm512_store_pd(dp + 16, d);
+              __m512 m = _mm512_load_ps(sp);
+              __m512 n = _mm512_loadu_ps(sp - 1);
+              __m512 p = _mm512_load_ps(dp);
+              p = _mm512_sub_ps(p, _mm512_mul_ps(f, _mm512_add_ps(m, n)));
+              _mm512_store_ps(dp, p);
             }
-            for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
+          }
+          else
+          {
+            for (; i > 0; i -= 16, sp += 16, dp += 16)
             {
-                __m256d a = _mm256_load_pd(spl);
-                __m256d b = _mm256_load_pd(sph);
-                __m256d c = _mm256_unpacklo_pd(a, b);
-                __m256d d = _mm256_unpackhi_pd(a, b);
-                __m256d e = _mm256_permute2f128_pd(c, d, (2 << 4) | (0));
-                __m256d f = _mm256_permute2f128_pd(c, d, (3 << 4) | (1));
-                _mm256_store_pd(dp, e);
-                _mm256_store_pd(dp + 4, f);
+              __m512 m = _mm512_load_ps(sp);
+              __m512 n = _mm512_loadu_ps(sp + 1);
+              __m512 p = _mm512_load_ps(dp);
+              p = _mm512_sub_ps(p, _mm512_mul_ps(f, _mm512_add_ps(m, n)));
+              _mm512_store_ps(dp, p);
             }
+          }
+
+          // swap buffers
+          float* t = aug; aug = oth; oth = t;
+          ev = !ev;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
-        //////////////////////////////////////////////////////////////////////////
-        static inline void avx512_multiply_const(float *p, float f, int width)
+        // combine both lsrc and hsrc into dst
         {
-            __m512 factor = _mm512_set1_ps(f);
-            for (; width > 0; width -= 16, p += 16)
+          float* dp  = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
+          int w = (int)width;
+          avx512_interleave32(dp, spl, sph, w);
+        }        
+      }
+      else {
+        if (even)
+          dst->f32[0] = lsrc->f32[0];
+        else
+          dst->f32[0] = hsrc->f32[0] * 0.5f;
+      }
+    }
+
+
+    /////////////////////////////////////////////////////////////////////////
+    void avx512_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
+                                const line_buf* other, const line_buf* aug, 
+                                ui32 repeat, bool synthesis)
+    {
+      const si32 a = s->rev.Aatk;
+      const si32 b = s->rev.Batk;
+      const ui8 e = s->rev.Eatk;
+      __m512i va = _mm512_set1_epi32(a);
+      __m512i vb = _mm512_set1_epi32(b);
+
+      si32* dst = aug->i32;
+      const si32* src1 = sig->i32, * src2 = other->i32;
+      // The general definition of the wavelet in Part 2 is slightly 
+      // different to part 2, although they are mathematically equivalent
+      // here, we identify the simpler form from Part 1 and employ them
+      if (a == 1)
+      { // 5/3 update and any case with a == 1
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi32(s1, s2);
+            __m512i v = _mm512_add_epi32(vb, t);
+            __m512i w = _mm512_srai_epi32(v, e);
+            d = _mm512_sub_epi32(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi32(s1, s2);
+            __m512i v = _mm512_add_epi32(vb, t);
+            __m512i w = _mm512_srai_epi32(v, e);
+            d = _mm512_add_epi32(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+      }
+      else if (a == -1 && b == 1 && e == 1)
+      { // 5/3 predict
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi32(s1, s2);
+            __m512i w = _mm512_srai_epi32(t, e);
+            d = _mm512_add_epi32(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi32(s1, s2);
+            __m512i w = _mm512_srai_epi32(t, e);
+            d = _mm512_sub_epi32(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+      }
+      else if (a == -1)
+      { // any case with a == -1, which is not 5/3 predict
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi32(s1, s2);
+            __m512i v = _mm512_sub_epi32(vb, t);
+            __m512i w = _mm512_srai_epi32(v, e);
+            d = _mm512_sub_epi32(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi32(s1, s2);
+            __m512i v = _mm512_sub_epi32(vb, t);
+            __m512i w = _mm512_srai_epi32(v, e);
+            d = _mm512_add_epi32(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+      }
+      else { // general case
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi32(s1, s2);
+            __m512i u = _mm512_mullo_epi32(va, t);
+            __m512i v = _mm512_add_epi32(vb, u);
+            __m512i w = _mm512_srai_epi32(v, e);
+            d = _mm512_sub_epi32(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi32(s1, s2);
+            __m512i u = _mm512_mullo_epi32(va, t);
+            __m512i v = _mm512_add_epi32(vb, u);
+            __m512i w = _mm512_srai_epi32(v, e);
+            d = _mm512_add_epi32(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void avx512_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
+                                const line_buf* other, const line_buf* aug, 
+                                ui32 repeat, bool synthesis)
+    {
+      const si32 a = s->rev.Aatk;
+      const si32 b = s->rev.Batk;
+      const ui8 e = s->rev.Eatk;
+      __m512i vb = _mm512_set1_epi64(b);
+
+      si64* dst = aug->i64;
+      const si64* src1 = sig->i64, * src2 = other->i64;
+      // The general definition of the wavelet in Part 2 is slightly 
+      // different to part 2, although they are mathematically equivalent
+      // here, we identify the simpler form from Part 1 and employ them
+      if (a == 1)
+      { // 5/3 update and any case with a == 1
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi64(s1, s2);
+            __m512i v = _mm512_add_epi64(vb, t);
+            __m512i w = _mm512_srai_epi64(v, e);
+            d = _mm512_sub_epi64(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi64(s1, s2);
+            __m512i v = _mm512_add_epi64(vb, t);
+            __m512i w = _mm512_srai_epi64(v, e);
+            d = _mm512_add_epi64(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+      }
+      else if (a == -1 && b == 1 && e == 1)
+      { // 5/3 predict
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi64(s1, s2);
+            __m512i w = _mm512_srai_epi64(t, e);
+            d = _mm512_add_epi64(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi64(s1, s2);
+            __m512i w = _mm512_srai_epi64(t, e);
+            d = _mm512_sub_epi64(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+      }
+      else if (a == -1)
+      { // any case with a == -1, which is not 5/3 predict
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi64(s1, s2);
+            __m512i v = _mm512_sub_epi64(vb, t);
+            __m512i w = _mm512_srai_epi64(v, e);
+            d = _mm512_sub_epi64(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+          {
+            __m512i s1 = _mm512_load_si512((__m512i*)src1);
+            __m512i s2 = _mm512_load_si512((__m512i*)src2);
+            __m512i d = _mm512_load_si512((__m512i*)dst);
+            __m512i t = _mm512_add_epi64(s1, s2);
+            __m512i v = _mm512_sub_epi64(vb, t);
+            __m512i w = _mm512_srai_epi64(v, e);
+            d = _mm512_add_epi64(d, w);
+            _mm512_store_si512((__m512i*)dst, d);
+          }
+      }
+      else { 
+        // general case
+        // 64bit multiplication is not supported in AVX512F + AVX512CD;
+        // in particular, _mm256_mullo_epi64.
+        if (synthesis)
+          for (ui32 i = repeat; i > 0; --i)
+            *dst++ -= (b + a * (*src1++ + *src2++)) >> e;
+        else
+          for (ui32 i = repeat; i > 0; --i)
+            *dst++ += (b + a * (*src1++ + *src2++)) >> e;
+      }
+
+      // This can only be used if you have AVX512DQ
+      // { // general case
+      //   __m512i va = _mm512_set1_epi64(a);
+      //   int i = (int)repeat;
+      //   if (synthesis)
+      //     for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+      //     {
+      //       __m512i s1 = _mm512_load_si512((__m512i*)src1);
+      //       __m512i s2 = _mm512_load_si512((__m512i*)src2);
+      //       __m512i d = _mm512_load_si512((__m512i*)dst);
+      //       __m512i t = _mm512_add_epi64(s1, s2);
+      //       __m512i u = _mm512_mullo_epi64(va, t);
+      //       __m512i v = _mm512_add_epi64(vb, u);
+      //       __m512i w = _mm512_srai_epi64(v, e);
+      //       d = _mm512_sub_epi64(d, w);
+      //       _mm512_store_si512((__m512i*)dst, d);
+      //     }
+      //   else
+      //     for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
+      //     {
+      //       __m512i s1 = _mm512_load_si512((__m512i*)src1);
+      //       __m512i s2 = _mm512_load_si512((__m512i*)src2);
+      //       __m512i d = _mm512_load_si512((__m512i*)dst);
+      //       __m512i t = _mm512_add_epi64(s1, s2);
+      //       __m512i u = _mm512_mullo_epi64(va, t);
+      //       __m512i v = _mm512_add_epi64(vb, u);
+      //       __m512i w = _mm512_srai_epi64(v, e);
+      //       d = _mm512_add_epi64(d, w);
+      //       _mm512_store_si512((__m512i*)dst, d);
+      //     }
+      // }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void avx512_rev_vert_step(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
+                              ui32 repeat, bool synthesis)
+    {
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
+          ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
+      {
+        assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
+               (aug == NULL || aug->flags & line_buf::LFT_32BIT));
+        avx512_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
+      }
+      else 
+      {
+        assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
+               (aug == NULL || aug->flags & line_buf::LFT_64BIT));
+        avx512_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void avx512_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
+                               const line_buf* hdst, const line_buf* src, 
+                               ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        // split src into ldst and hdst
+        {
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp  = src->f32;
+          int w = (int)width;
+          avx512_deinterleave32(dpl, dph, sp, w);
+        }        
+
+        si32* hp = hdst->i32, * lp = ldst->i32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = num_steps; j > 0; --j)
+        {
+          // first lifting step
+          const lifting_step* s = atk->get_step(j - 1);
+          const si32 a = s->rev.Aatk;
+          const si32 b = s->rev.Batk;
+          const ui8 e = s->rev.Eatk;
+          __m512i va = _mm512_set1_epi32(a);
+          __m512i vb = _mm512_set1_epi32(b);
+
+          // extension
+          lp[-1] = lp[0];
+          lp[l_width] = lp[l_width - 1];
+          // lifting step
+          const si32* sp = lp;
+          si32* dp = hp;
+          if (a == 1)
+          { // 5/3 update and any case with a == 1
+            int i = (int)h_width;
+            if (even)
             {
-                __m512 s = _mm512_load_ps(p);
-                _mm512_store_ps(p, _mm512_mul_ps(factor, s));
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        void avx512_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                                  const line_buf *other, const line_buf *aug,
-                                  ui32 repeat, bool synthesis)
-        {
-            float a = s->irv.Aatk;
-            if (synthesis)
-                a = -a;
-
-            __m512 factor = _mm512_set1_ps(a);
-
-            float *dst = aug->f32;
-            const float *src1 = sig->f32, *src2 = other->f32;
-            int i = (int)repeat;
-            for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-            {
-                __m512 s1 = _mm512_load_ps(src1);
-                __m512 s2 = _mm512_load_ps(src2);
-                __m512 d = _mm512_load_ps(dst);
-                d = _mm512_add_ps(d, _mm512_mul_ps(factor, _mm512_add_ps(s1, s2)));
-                _mm512_store_ps(dst, d);
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        void avx512_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat)
-        {
-            avx512_multiply_const(aug->f32, K, (int)repeat);
-        }
-
-        /////////////////////////////////////////////////////////////////////////
-        void avx512_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                                 const line_buf *hdst, const line_buf *src,
-                                 ui32 width, bool even)
-        {
-            if (width > 1)
-            {
-                // split src into ldst and hdst
-                {
-                    float *dpl = even ? ldst->f32 : hdst->f32;
-                    float *dph = even ? hdst->f32 : ldst->f32;
-                    float *sp = src->f32;
-                    int w = (int)width;
-                    avx512_deinterleave32(dpl, dph, sp, w);
-                }
-
-                // the actual horizontal transform
-                float *hp = hdst->f32, *lp = ldst->f32;
-                ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-                ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
-                ui32 num_steps = atk->get_num_steps();
-                for (ui32 j = num_steps; j > 0; --j)
-                {
-                    const lifting_step *s = atk->get_step(j - 1);
-                    const float a = s->irv.Aatk;
-
-                    // extension
-                    lp[-1] = lp[0];
-                    lp[l_width] = lp[l_width - 1];
-                    // lifting step
-                    const float *sp = lp;
-                    float *dp = hp;
-                    int i = (int)h_width;
-                    __m512 f = _mm512_set1_ps(a);
-                    if (even)
-                    {
-                        for (; i > 0; i -= 16, sp += 16, dp += 16)
-                        {
-                            __m512 m = _mm512_load_ps(sp);
-                            __m512 n = _mm512_loadu_ps(sp + 1);
-                            __m512 p = _mm512_load_ps(dp);
-                            p = _mm512_add_ps(p, _mm512_mul_ps(f, _mm512_add_ps(m, n)));
-                            _mm512_store_ps(dp, p);
-                        }
-                    }
-                    else
-                    {
-                        for (; i > 0; i -= 16, sp += 16, dp += 16)
-                        {
-                            __m512 m = _mm512_load_ps(sp);
-                            __m512 n = _mm512_loadu_ps(sp - 1);
-                            __m512 p = _mm512_load_ps(dp);
-                            p = _mm512_add_ps(p, _mm512_mul_ps(f, _mm512_add_ps(m, n)));
-                            _mm512_store_ps(dp, p);
-                        }
-                    }
-
-                    // swap buffers
-                    float *t = lp;
-                    lp = hp;
-                    hp = t;
-                    even = !even;
-                    ui32 w = l_width;
-                    l_width = h_width;
-                    h_width = w;
-                }
-
-                { // multiply by K or 1/K
-                    float K = atk->get_K();
-                    float K_inv = 1.0f / K;
-                    avx512_multiply_const(lp, K_inv, (int)l_width);
-                    avx512_multiply_const(hp, K, (int)h_width);
-                }
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i v = _mm512_add_epi32(vb, t);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_add_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             }
             else
             {
-                if (even)
-                    ldst->f32[0] = src->f32[0];
-                else
-                    hdst->f32[0] = src->f32[0] * 2.0f;
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i v = _mm512_add_epi32(vb, t);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_add_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             }
+          }
+          else if (a == -1 && b == 1 && e == 1)
+          {  // 5/3 predict
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i w = _mm512_srai_epi32(t, e);
+                d = _mm512_sub_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i w = _mm512_srai_epi32(t, e);
+                d = _mm512_sub_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+          else if (a == -1)
+          { // any case with a == -1, which is not 5/3 predict
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i v = _mm512_sub_epi32(vb, t);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_add_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i v = _mm512_sub_epi32(vb, t);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_add_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+          else {
+            // general case
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i u = _mm512_mullo_epi32(va, t);
+                __m512i v = _mm512_add_epi32(vb, u);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_add_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i u = _mm512_mullo_epi32(va, t);
+                __m512i v = _mm512_add_epi32(vb, u);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_add_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+
+          // swap buffers
+          si32* t = lp; lp = hp; hp = t;
+          even = !even;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
-
-        //////////////////////////////////////////////////////////////////////////
-        void avx512_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                                 const line_buf *lsrc, const line_buf *hsrc,
-                                 ui32 width, bool even)
+      }
+      else {
+        if (even)
+          ldst->i32[0] = src->i32[0];
+        else
+          hdst->i32[0] = src->i32[0] << 1;
+      }
+    }
+    
+    /////////////////////////////////////////////////////////////////////////
+    void avx512_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
+                               const line_buf* hdst, const line_buf* src, 
+                               ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        // split src into ldst and hdst
         {
-            if (width > 1)
+          double* dpl = (double*)(even ? ldst->p : hdst->p);
+          double* dph = (double*)(even ? hdst->p : ldst->p);
+          double* sp  = (double*)(src->p);
+          int w = (int)width;
+          avx512_deinterleave64(dpl, dph, sp, w);
+        }        
+
+        si64* hp = hdst->i64, * lp = ldst->i64;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = num_steps; j > 0; --j)
+        {
+          // first lifting step
+          const lifting_step* s = atk->get_step(j - 1);
+          const si32 a = s->rev.Aatk;
+          const si32 b = s->rev.Batk;
+          const ui8 e = s->rev.Eatk;
+          __m512i vb = _mm512_set1_epi64(b);
+
+          // extension
+          lp[-1] = lp[0];
+          lp[l_width] = lp[l_width - 1];
+          // lifting step
+          const si64* sp = lp;
+          si64* dp = hp;
+          if (a == 1)
+          { // 5/3 update and any case with a == 1
+            int i = (int)h_width;
+            if (even)
             {
-                bool ev = even;
-                float *oth = hsrc->f32, *aug = lsrc->f32;
-                ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-                ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
-
-                { // multiply by K or 1/K
-                    float K = atk->get_K();
-                    float K_inv = 1.0f / K;
-                    avx512_multiply_const(aug, K, (int)aug_width);
-                    avx512_multiply_const(oth, K_inv, (int)oth_width);
-                }
-
-                // the actual horizontal transform
-                ui32 num_steps = atk->get_num_steps();
-                for (ui32 j = 0; j < num_steps; ++j)
-                {
-                    const lifting_step *s = atk->get_step(j);
-                    const float a = s->irv.Aatk;
-
-                    // extension
-                    oth[-1] = oth[0];
-                    oth[oth_width] = oth[oth_width - 1];
-                    // lifting step
-                    const float *sp = oth;
-                    float *dp = aug;
-                    int i = (int)aug_width;
-                    __m512 f = _mm512_set1_ps(a);
-                    if (ev)
-                    {
-                        for (; i > 0; i -= 16, sp += 16, dp += 16)
-                        {
-                            __m512 m = _mm512_load_ps(sp);
-                            __m512 n = _mm512_loadu_ps(sp - 1);
-                            __m512 p = _mm512_load_ps(dp);
-                            p = _mm512_sub_ps(p, _mm512_mul_ps(f, _mm512_add_ps(m, n)));
-                            _mm512_store_ps(dp, p);
-                        }
-                    }
-                    else
-                    {
-                        for (; i > 0; i -= 16, sp += 16, dp += 16)
-                        {
-                            __m512 m = _mm512_load_ps(sp);
-                            __m512 n = _mm512_loadu_ps(sp + 1);
-                            __m512 p = _mm512_load_ps(dp);
-                            p = _mm512_sub_ps(p, _mm512_mul_ps(f, _mm512_add_ps(m, n)));
-                            _mm512_store_ps(dp, p);
-                        }
-                    }
-
-                    // swap buffers
-                    float *t = aug;
-                    aug = oth;
-                    oth = t;
-                    ev = !ev;
-                    ui32 w = aug_width;
-                    aug_width = oth_width;
-                    oth_width = w;
-                }
-
-                // combine both lsrc and hsrc into dst
-                {
-                    float *dp = dst->f32;
-                    float *spl = even ? lsrc->f32 : hsrc->f32;
-                    float *sph = even ? hsrc->f32 : lsrc->f32;
-                    int w = (int)width;
-                    avx512_interleave32(dp, spl, sph, w);
-                }
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i v = _mm512_add_epi64(vb, t);
+                __m512i w = _mm512_srai_epi64(v, e);
+                d = _mm512_add_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             }
             else
             {
-                if (even)
-                    dst->f32[0] = lsrc->f32[0];
-                else
-                    dst->f32[0] = hsrc->f32[0] * 0.5f;
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i v = _mm512_add_epi64(vb, t);
+                __m512i w = _mm512_srai_epi64(v, e);
+                d = _mm512_add_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             }
-        }
-
-        /////////////////////////////////////////////////////////////////////////
-        void avx512_rev_vert_step32(const lifting_step *s, const line_buf *sig,
-                                    const line_buf *other, const line_buf *aug,
-                                    ui32 repeat, bool synthesis)
-        {
-            const si32 a = s->rev.Aatk;
-            const si32 b = s->rev.Batk;
-            const ui8 e = s->rev.Eatk;
-            __m512i va = _mm512_set1_epi32(a);
-            __m512i vb = _mm512_set1_epi32(b);
-
-            si32 *dst = aug->i32;
-            const si32 *src1 = sig->i32, *src2 = other->i32;
-            // The general definition of the wavelet in Part 2 is slightly
-            // different to part 2, although they are mathematically equivalent
-            // here, we identify the simpler form from Part 1 and employ them
-            if (a == 1)
-            { // 5/3 update and any case with a == 1
-                int i = (int)repeat;
-                if (synthesis)
-                    for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi32(s1, s2);
-                        __m512i v = _mm512_add_epi32(vb, t);
-                        __m512i w = _mm512_srai_epi32(v, e);
-                        d = _mm512_sub_epi32(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-                else
-                    for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi32(s1, s2);
-                        __m512i v = _mm512_add_epi32(vb, t);
-                        __m512i w = _mm512_srai_epi32(v, e);
-                        d = _mm512_add_epi32(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-            }
-            else if (a == -1 && b == 1 && e == 1)
-            { // 5/3 predict
-                int i = (int)repeat;
-                if (synthesis)
-                    for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi32(s1, s2);
-                        __m512i w = _mm512_srai_epi32(t, e);
-                        d = _mm512_add_epi32(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-                else
-                    for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi32(s1, s2);
-                        __m512i w = _mm512_srai_epi32(t, e);
-                        d = _mm512_sub_epi32(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-            }
-            else if (a == -1)
-            { // any case with a == -1, which is not 5/3 predict
-                int i = (int)repeat;
-                if (synthesis)
-                    for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi32(s1, s2);
-                        __m512i v = _mm512_sub_epi32(vb, t);
-                        __m512i w = _mm512_srai_epi32(v, e);
-                        d = _mm512_sub_epi32(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-                else
-                    for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi32(s1, s2);
-                        __m512i v = _mm512_sub_epi32(vb, t);
-                        __m512i w = _mm512_srai_epi32(v, e);
-                        d = _mm512_add_epi32(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-            }
+          }
+          else if (a == -1 && b == 1 && e == 1)
+          {  // 5/3 predict
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i w = _mm512_srai_epi64(t, e);
+                d = _mm512_sub_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             else
-            { // general case
-                int i = (int)repeat;
-                if (synthesis)
-                    for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi32(s1, s2);
-                        __m512i u = _mm512_mullo_epi32(va, t);
-                        __m512i v = _mm512_add_epi32(vb, u);
-                        __m512i w = _mm512_srai_epi32(v, e);
-                        d = _mm512_sub_epi32(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-                else
-                    for (; i > 0; i -= 16, dst += 16, src1 += 16, src2 += 16)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi32(s1, s2);
-                        __m512i u = _mm512_mullo_epi32(va, t);
-                        __m512i v = _mm512_add_epi32(vb, u);
-                        __m512i w = _mm512_srai_epi32(v, e);
-                        d = _mm512_add_epi32(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-            }
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i w = _mm512_srai_epi64(t, e);
+                d = _mm512_sub_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+          else if (a == -1)
+          { // any case with a == -1, which is not 5/3 predict
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i v = _mm512_sub_epi64(vb, t);
+                __m512i w = _mm512_srai_epi64(v, e);
+                d = _mm512_add_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i v = _mm512_sub_epi64(vb, t);
+                __m512i w = _mm512_srai_epi64(v, e);
+                d = _mm512_add_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+          else 
+          {
+            // general case
+            // 64bit multiplication is not supported in AVX512F + AVX512CD;
+            // in particular, _mm256_mullo_epi64.
+            if (even)
+              for (ui32 i = h_width; i > 0; --i, sp++, dp++)
+                *dp += (b + a * (sp[0] + sp[1])) >> e;
+            else
+              for (ui32 i = h_width; i > 0; --i, sp++, dp++)
+                *dp += (b + a * (sp[-1] + sp[0])) >> e;
+          }
+
+          // This can only be used if you have AVX512DQ
+          // {
+          //   // general case
+          //   __m512i va = _mm512_set1_epi64(a);
+          //   int i = (int)h_width;
+          //   if (even)
+          //     for (; i > 0; i -= 8, sp += 8, dp += 8)
+          //     {
+          //       __m512i s1 = _mm512_load_si512((__m512i*)sp);
+          //       __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+          //       __m512i d = _mm512_load_si512((__m512i*)dp);
+          //       __m512i t = _mm512_add_epi64(s1, s2);
+          //       __m512i u = _mm512_mullo_epi64(va, t);
+          //       __m512i v = _mm512_add_epi64(vb, u);
+          //       __m512i w = _mm512_srai_epi64(v, e);
+          //       d = _mm512_add_epi64(d, w);
+          //       _mm512_store_si512((__m512i*)dp, d);
+          //     }
+          //   else
+          //     for (; i > 0; i -= 8, sp += 8, dp += 8)
+          //     {
+          //       __m512i s1 = _mm512_load_si512((__m512i*)sp);
+          //       __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+          //       __m512i d = _mm512_load_si512((__m512i*)dp);
+          //       __m512i t = _mm512_add_epi64(s1, s2);
+          //       __m512i u = _mm512_mullo_epi64(va, t);
+          //       __m512i v = _mm512_add_epi64(vb, u);
+          //       __m512i w = _mm512_srai_epi64(v, e);
+          //       d = _mm512_add_epi64(d, w);
+          //       _mm512_store_si512((__m512i*)dp, d);
+          //     }
+          // }
+
+          // swap buffers
+          si64* t = lp; lp = hp; hp = t;
+          even = !even;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
+      }
+      else {
+        if (even)
+          ldst->i64[0] = src->i64[0];
+        else
+          hdst->i64[0] = src->i64[0] << 1;
+      }
+    }
 
-        /////////////////////////////////////////////////////////////////////////
-        void avx512_rev_vert_step64(const lifting_step *s, const line_buf *sig,
-                                    const line_buf *other, const line_buf *aug,
-                                    ui32 repeat, bool synthesis)
+    /////////////////////////////////////////////////////////////////////////
+    void avx512_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                             const line_buf* hdst, const line_buf* src, 
+                             ui32 width, bool even)
+    {
+      if (src->flags & line_buf::LFT_32BIT) 
+      {
+        assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
+               (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
+        avx512_rev_horz_ana32(atk, ldst, hdst, src, width, even);
+      }
+      else 
+      {
+        assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
+               (src == NULL || src->flags & line_buf::LFT_64BIT));
+        avx512_rev_horz_ana64(atk, ldst, hdst, src, width, even);
+      }
+    } 
+
+    //////////////////////////////////////////////////////////////////////////
+    void avx512_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
+                               const line_buf* lsrc, const line_buf* hsrc, 
+                               ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        bool ev = even;
+        si32* oth = hsrc->i32, * aug = lsrc->i32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = 0; j < num_steps; ++j)
         {
-            const si32 a = s->rev.Aatk;
-            const si32 b = s->rev.Batk;
-            const ui8 e = s->rev.Eatk;
-            __m512i vb = _mm512_set1_epi64(b);
+          const lifting_step* s = atk->get_step(j);
+          const si32 a = s->rev.Aatk;
+          const si32 b = s->rev.Batk;
+          const ui8 e = s->rev.Eatk;
+          __m512i va = _mm512_set1_epi32(a);
+          __m512i vb = _mm512_set1_epi32(b);
 
-            si64 *dst = aug->i64;
-            const si64 *src1 = sig->i64, *src2 = other->i64;
-            // The general definition of the wavelet in Part 2 is slightly
-            // different to part 2, although they are mathematically equivalent
-            // here, we identify the simpler form from Part 1 and employ them
-            if (a == 1)
-            { // 5/3 update and any case with a == 1
-                int i = (int)repeat;
-                if (synthesis)
-                    for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi64(s1, s2);
-                        __m512i v = _mm512_add_epi64(vb, t);
-                        __m512i w = _mm512_srai_epi64(v, e);
-                        d = _mm512_sub_epi64(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-                else
-                    for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi64(s1, s2);
-                        __m512i v = _mm512_add_epi64(vb, t);
-                        __m512i w = _mm512_srai_epi64(v, e);
-                        d = _mm512_add_epi64(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-            }
-            else if (a == -1 && b == 1 && e == 1)
-            { // 5/3 predict
-                int i = (int)repeat;
-                if (synthesis)
-                    for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi64(s1, s2);
-                        __m512i w = _mm512_srai_epi64(t, e);
-                        d = _mm512_add_epi64(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-                else
-                    for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi64(s1, s2);
-                        __m512i w = _mm512_srai_epi64(t, e);
-                        d = _mm512_sub_epi64(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-            }
-            else if (a == -1)
-            { // any case with a == -1, which is not 5/3 predict
-                int i = (int)repeat;
-                if (synthesis)
-                    for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi64(s1, s2);
-                        __m512i v = _mm512_sub_epi64(vb, t);
-                        __m512i w = _mm512_srai_epi64(v, e);
-                        d = _mm512_sub_epi64(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
-                else
-                    for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
-                    {
-                        __m512i s1 = _mm512_load_si512((__m512i *)src1);
-                        __m512i s2 = _mm512_load_si512((__m512i *)src2);
-                        __m512i d = _mm512_load_si512((__m512i *)dst);
-                        __m512i t = _mm512_add_epi64(s1, s2);
-                        __m512i v = _mm512_sub_epi64(vb, t);
-                        __m512i w = _mm512_srai_epi64(v, e);
-                        d = _mm512_add_epi64(d, w);
-                        _mm512_store_si512((__m512i *)dst, d);
-                    }
+          // extension
+          oth[-1] = oth[0];
+          oth[oth_width] = oth[oth_width - 1];
+          // lifting step
+          const si32* sp = oth;
+          si32* dp = aug;
+          if (a == 1)
+          { // 5/3 update and any case with a == 1
+            int i = (int)aug_width;
+            if (ev)
+            {
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i v = _mm512_add_epi32(vb, t);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_sub_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             }
             else
             {
-                // general case
-                // 64bit multiplication is not supported in AVX512F + AVX512CD;
-                // in particular, _mm256_mullo_epi64.
-                if (synthesis)
-                    for (ui32 i = repeat; i > 0; --i)
-                        *dst++ -= (b + a * (*src1++ + *src2++)) >> e;
-                else
-                    for (ui32 i = repeat; i > 0; --i)
-                        *dst++ += (b + a * (*src1++ + *src2++)) >> e;
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i v = _mm512_add_epi32(vb, t);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_sub_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             }
+          }
+          else if (a == -1 && b == 1 && e == 1)
+          {  // 5/3 predict
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i w = _mm512_srai_epi32(t, e);
+                d = _mm512_add_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i w = _mm512_srai_epi32(t, e);
+                d = _mm512_add_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+          else if (a == -1)
+          { // any case with a == -1, which is not 5/3 predict
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i v = _mm512_sub_epi32(vb, t);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_sub_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i v = _mm512_sub_epi32(vb, t);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_sub_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+          else {
+            // general case
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i u = _mm512_mullo_epi32(va, t);
+                __m512i v = _mm512_add_epi32(vb, u);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_sub_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 16, sp += 16, dp += 16)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi32(s1, s2);
+                __m512i u = _mm512_mullo_epi32(va, t);
+                __m512i v = _mm512_add_epi32(vb, u);
+                __m512i w = _mm512_srai_epi32(v, e);
+                d = _mm512_sub_epi32(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
 
-            // This can only be used if you have AVX512DQ
-            // { // general case
-            //   __m512i va = _mm512_set1_epi64(a);
-            //   int i = (int)repeat;
-            //   if (synthesis)
-            //     for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
-            //     {
-            //       __m512i s1 = _mm512_load_si512((__m512i*)src1);
-            //       __m512i s2 = _mm512_load_si512((__m512i*)src2);
-            //       __m512i d = _mm512_load_si512((__m512i*)dst);
-            //       __m512i t = _mm512_add_epi64(s1, s2);
-            //       __m512i u = _mm512_mullo_epi64(va, t);
-            //       __m512i v = _mm512_add_epi64(vb, u);
-            //       __m512i w = _mm512_srai_epi64(v, e);
-            //       d = _mm512_sub_epi64(d, w);
-            //       _mm512_store_si512((__m512i*)dst, d);
-            //     }
-            //   else
-            //     for (; i > 0; i -= 8, dst += 8, src1 += 8, src2 += 8)
-            //     {
-            //       __m512i s1 = _mm512_load_si512((__m512i*)src1);
-            //       __m512i s2 = _mm512_load_si512((__m512i*)src2);
-            //       __m512i d = _mm512_load_si512((__m512i*)dst);
-            //       __m512i t = _mm512_add_epi64(s1, s2);
-            //       __m512i u = _mm512_mullo_epi64(va, t);
-            //       __m512i v = _mm512_add_epi64(vb, u);
-            //       __m512i w = _mm512_srai_epi64(v, e);
-            //       d = _mm512_add_epi64(d, w);
-            //       _mm512_store_si512((__m512i*)dst, d);
-            //     }
-            // }
+          // swap buffers
+          si32* t = aug; aug = oth; oth = t;
+          ev = !ev;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
-        /////////////////////////////////////////////////////////////////////////
-        void avx512_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                                  const line_buf *other, const line_buf *aug,
-                                  ui32 repeat, bool synthesis)
+        // combine both lsrc and hsrc into dst
         {
-            if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
-                ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-                ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
+          float* dp  = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
+          int w = (int)width;
+          avx512_interleave32(dp, spl, sph, w);
+        }          
+      }
+      else {
+        if (even)
+          dst->i32[0] = lsrc->i32[0];
+        else
+          dst->i32[0] = hsrc->i32[0] >> 1;
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void avx512_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
+                               const line_buf* lsrc, const line_buf* hsrc, 
+                               ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        bool ev = even;
+        si64* oth = hsrc->i64, * aug = lsrc->i64;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = 0; j < num_steps; ++j)
+        {
+          const lifting_step* s = atk->get_step(j);
+          const si32 a = s->rev.Aatk;
+          const si32 b = s->rev.Batk;
+          const ui8 e = s->rev.Eatk;
+          __m512i vb = _mm512_set1_epi64(b);
+
+          // extension
+          oth[-1] = oth[0];
+          oth[oth_width] = oth[oth_width - 1];
+          // lifting step
+          const si64* sp = oth;
+          si64* dp = aug;
+          if (a == 1)
+          { // 5/3 update and any case with a == 1
+            int i = (int)aug_width;
+            if (ev)
             {
-                assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-                       (other == NULL || other->flags & line_buf::LFT_32BIT) &&
-                       (aug == NULL || aug->flags & line_buf::LFT_32BIT));
-                avx512_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i v = _mm512_add_epi64(vb, t);
+                __m512i w = _mm512_srai_epi64(v, e);
+                d = _mm512_sub_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             }
             else
             {
-                assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-                       (other == NULL || other->flags & line_buf::LFT_64BIT) &&
-                       (aug == NULL || aug->flags & line_buf::LFT_64BIT));
-                avx512_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i v = _mm512_add_epi64(vb, t);
+                __m512i w = _mm512_srai_epi64(v, e);
+                d = _mm512_sub_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             }
-        }
-
-        /////////////////////////////////////////////////////////////////////////
-        void avx512_rev_horz_ana32(const param_atk *atk, const line_buf *ldst,
-                                   const line_buf *hdst, const line_buf *src,
-                                   ui32 width, bool even)
-        {
-            if (width > 1)
-            {
-                // split src into ldst and hdst
-                {
-                    float *dpl = even ? ldst->f32 : hdst->f32;
-                    float *dph = even ? hdst->f32 : ldst->f32;
-                    float *sp = src->f32;
-                    int w = (int)width;
-                    avx512_deinterleave32(dpl, dph, sp, w);
-                }
-
-                si32 *hp = hdst->i32, *lp = ldst->i32;
-                ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-                ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
-                ui32 num_steps = atk->get_num_steps();
-                for (ui32 j = num_steps; j > 0; --j)
-                {
-                    // first lifting step
-                    const lifting_step *s = atk->get_step(j - 1);
-                    const si32 a = s->rev.Aatk;
-                    const si32 b = s->rev.Batk;
-                    const ui8 e = s->rev.Eatk;
-                    __m512i va = _mm512_set1_epi32(a);
-                    __m512i vb = _mm512_set1_epi32(b);
-
-                    // extension
-                    lp[-1] = lp[0];
-                    lp[l_width] = lp[l_width - 1];
-                    // lifting step
-                    const si32 *sp = lp;
-                    si32 *dp = hp;
-                    if (a == 1)
-                    { // 5/3 update and any case with a == 1
-                        int i = (int)h_width;
-                        if (even)
-                        {
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i v = _mm512_add_epi32(vb, t);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_add_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        }
-                        else
-                        {
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i v = _mm512_add_epi32(vb, t);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_add_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        }
-                    }
-                    else if (a == -1 && b == 1 && e == 1)
-                    { // 5/3 predict
-                        int i = (int)h_width;
-                        if (even)
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i w = _mm512_srai_epi32(t, e);
-                                d = _mm512_sub_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i w = _mm512_srai_epi32(t, e);
-                                d = _mm512_sub_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-                    else if (a == -1)
-                    { // any case with a == -1, which is not 5/3 predict
-                        int i = (int)h_width;
-                        if (even)
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i v = _mm512_sub_epi32(vb, t);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_add_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i v = _mm512_sub_epi32(vb, t);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_add_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-                    else
-                    {
-                        // general case
-                        int i = (int)h_width;
-                        if (even)
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i u = _mm512_mullo_epi32(va, t);
-                                __m512i v = _mm512_add_epi32(vb, u);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_add_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i u = _mm512_mullo_epi32(va, t);
-                                __m512i v = _mm512_add_epi32(vb, u);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_add_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-
-                    // swap buffers
-                    si32 *t = lp;
-                    lp = hp;
-                    hp = t;
-                    even = !even;
-                    ui32 w = l_width;
-                    l_width = h_width;
-                    h_width = w;
-                }
-            }
+          }
+          else if (a == -1 && b == 1 && e == 1)
+          {  // 5/3 predict
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i w = _mm512_srai_epi64(t, e);
+                d = _mm512_add_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             else
-            {
-                if (even)
-                    ldst->i32[0] = src->i32[0];
-                else
-                    hdst->i32[0] = src->i32[0] << 1;
-            }
-        }
-
-        /////////////////////////////////////////////////////////////////////////
-        void avx512_rev_horz_ana64(const param_atk *atk, const line_buf *ldst,
-                                   const line_buf *hdst, const line_buf *src,
-                                   ui32 width, bool even)
-        {
-            if (width > 1)
-            {
-                // split src into ldst and hdst
-                {
-                    double *dpl = (double *)(even ? ldst->p : hdst->p);
-                    double *dph = (double *)(even ? hdst->p : ldst->p);
-                    double *sp = (double *)(src->p);
-                    int w = (int)width;
-                    avx512_deinterleave64(dpl, dph, sp, w);
-                }
-
-                si64 *hp = hdst->i64, *lp = ldst->i64;
-                ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-                ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
-                ui32 num_steps = atk->get_num_steps();
-                for (ui32 j = num_steps; j > 0; --j)
-                {
-                    // first lifting step
-                    const lifting_step *s = atk->get_step(j - 1);
-                    const si32 a = s->rev.Aatk;
-                    const si32 b = s->rev.Batk;
-                    const ui8 e = s->rev.Eatk;
-                    __m512i vb = _mm512_set1_epi64(b);
-
-                    // extension
-                    lp[-1] = lp[0];
-                    lp[l_width] = lp[l_width - 1];
-                    // lifting step
-                    const si64 *sp = lp;
-                    si64 *dp = hp;
-                    if (a == 1)
-                    { // 5/3 update and any case with a == 1
-                        int i = (int)h_width;
-                        if (even)
-                        {
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i v = _mm512_add_epi64(vb, t);
-                                __m512i w = _mm512_srai_epi64(v, e);
-                                d = _mm512_add_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        }
-                        else
-                        {
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i v = _mm512_add_epi64(vb, t);
-                                __m512i w = _mm512_srai_epi64(v, e);
-                                d = _mm512_add_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        }
-                    }
-                    else if (a == -1 && b == 1 && e == 1)
-                    { // 5/3 predict
-                        int i = (int)h_width;
-                        if (even)
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i w = _mm512_srai_epi64(t, e);
-                                d = _mm512_sub_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i w = _mm512_srai_epi64(t, e);
-                                d = _mm512_sub_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-                    else if (a == -1)
-                    { // any case with a == -1, which is not 5/3 predict
-                        int i = (int)h_width;
-                        if (even)
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i v = _mm512_sub_epi64(vb, t);
-                                __m512i w = _mm512_srai_epi64(v, e);
-                                d = _mm512_add_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i v = _mm512_sub_epi64(vb, t);
-                                __m512i w = _mm512_srai_epi64(v, e);
-                                d = _mm512_add_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-                    else
-                    {
-                        // general case
-                        // 64bit multiplication is not supported in AVX512F + AVX512CD;
-                        // in particular, _mm256_mullo_epi64.
-                        if (even)
-                            for (ui32 i = h_width; i > 0; --i, sp++, dp++)
-                                *dp += (b + a * (sp[0] + sp[1])) >> e;
-                        else
-                            for (ui32 i = h_width; i > 0; --i, sp++, dp++)
-                                *dp += (b + a * (sp[-1] + sp[0])) >> e;
-                    }
-
-                    // This can only be used if you have AVX512DQ
-                    // {
-                    //   // general case
-                    //   __m512i va = _mm512_set1_epi64(a);
-                    //   int i = (int)h_width;
-                    //   if (even)
-                    //     for (; i > 0; i -= 8, sp += 8, dp += 8)
-                    //     {
-                    //       __m512i s1 = _mm512_load_si512((__m512i*)sp);
-                    //       __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
-                    //       __m512i d = _mm512_load_si512((__m512i*)dp);
-                    //       __m512i t = _mm512_add_epi64(s1, s2);
-                    //       __m512i u = _mm512_mullo_epi64(va, t);
-                    //       __m512i v = _mm512_add_epi64(vb, u);
-                    //       __m512i w = _mm512_srai_epi64(v, e);
-                    //       d = _mm512_add_epi64(d, w);
-                    //       _mm512_store_si512((__m512i*)dp, d);
-                    //     }
-                    //   else
-                    //     for (; i > 0; i -= 8, sp += 8, dp += 8)
-                    //     {
-                    //       __m512i s1 = _mm512_load_si512((__m512i*)sp);
-                    //       __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
-                    //       __m512i d = _mm512_load_si512((__m512i*)dp);
-                    //       __m512i t = _mm512_add_epi64(s1, s2);
-                    //       __m512i u = _mm512_mullo_epi64(va, t);
-                    //       __m512i v = _mm512_add_epi64(vb, u);
-                    //       __m512i w = _mm512_srai_epi64(v, e);
-                    //       d = _mm512_add_epi64(d, w);
-                    //       _mm512_store_si512((__m512i*)dp, d);
-                    //     }
-                    // }
-
-                    // swap buffers
-                    si64 *t = lp;
-                    lp = hp;
-                    hp = t;
-                    even = !even;
-                    ui32 w = l_width;
-                    l_width = h_width;
-                    h_width = w;
-                }
-            }
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i w = _mm512_srai_epi64(t, e);
+                d = _mm512_add_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+          else if (a == -1)
+          { // any case with a == -1, which is not 5/3 predict
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i v = _mm512_sub_epi64(vb, t);
+                __m512i w = _mm512_srai_epi64(v, e);
+                d = _mm512_sub_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
             else
-            {
-                if (even)
-                    ldst->i64[0] = src->i64[0];
-                else
-                    hdst->i64[0] = src->i64[0] << 1;
-            }
-        }
-
-        /////////////////////////////////////////////////////////////////////////
-        void avx512_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                                 const line_buf *hdst, const line_buf *src,
-                                 ui32 width, bool even)
-        {
-            if (src->flags & line_buf::LFT_32BIT)
-            {
-                assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
-                       (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
-                avx512_rev_horz_ana32(atk, ldst, hdst, src, width, even);
-            }
+              for (; i > 0; i -= 8, sp += 8, dp += 8)
+              {
+                __m512i s1 = _mm512_load_si512((__m512i*)sp);
+                __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+                __m512i d = _mm512_load_si512((__m512i*)dp);
+                __m512i t = _mm512_add_epi64(s1, s2);
+                __m512i v = _mm512_sub_epi64(vb, t);
+                __m512i w = _mm512_srai_epi64(v, e);
+                d = _mm512_sub_epi64(d, w);
+                _mm512_store_si512((__m512i*)dp, d);
+              }
+          }
+          else 
+           {
+            // general case
+            // 64bit multiplication is not supported in AVX512F + AVX512CD;
+            // in particular, _mm256_mullo_epi64.            
+            if (ev)
+              for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
+                *dp -= (b + a * (sp[-1] + sp[0])) >> e;
             else
-            {
-                assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-                       (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
-                       (src == NULL || src->flags & line_buf::LFT_64BIT));
-                avx512_rev_horz_ana64(atk, ldst, hdst, src, width, even);
-            }
+              for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
+                *dp -= (b + a * (sp[0] + sp[1])) >> e;
+          }
+
+          // This can only be used if you have AVX512DQ
+          // {
+          //   // general case
+          //   __m512i va = _mm512_set1_epi64(a);
+          //   int i = (int)aug_width;
+          //   if (ev)
+          //     for (; i > 0; i -= 8, sp += 8, dp += 8)
+          //     {
+          //       __m512i s1 = _mm512_load_si512((__m512i*)sp);
+          //       __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
+          //       __m512i d = _mm512_load_si512((__m512i*)dp);
+          //       __m512i t = _mm512_add_epi64(s1, s2);
+          //       __m512i u = _mm512_mullo_epi64(va, t);
+          //       __m512i v = _mm512_add_epi64(vb, u);
+          //       __m512i w = _mm512_srai_epi64(v, e);
+          //       d = _mm512_sub_epi64(d, w);
+          //       _mm512_store_si512((__m512i*)dp, d);
+          //     }
+          //   else
+          //     for (; i > 0; i -= 8, sp += 8, dp += 8)
+          //     {
+          //       __m512i s1 = _mm512_load_si512((__m512i*)sp);
+          //       __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
+          //       __m512i d = _mm512_load_si512((__m512i*)dp);
+          //       __m512i t = _mm512_add_epi64(s1, s2);
+          //       __m512i u = _mm512_mullo_epi64(va, t);
+          //       __m512i v = _mm512_add_epi64(vb, u);
+          //       __m512i w = _mm512_srai_epi64(v, e);
+          //       d = _mm512_sub_epi64(d, w);
+          //       _mm512_store_si512((__m512i*)dp, d);
+          //     }
+          // }
+
+          // swap buffers
+          si64* t = aug; aug = oth; oth = t;
+          ev = !ev;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
-        //////////////////////////////////////////////////////////////////////////
-        void avx512_rev_horz_syn32(const param_atk *atk, const line_buf *dst,
-                                   const line_buf *lsrc, const line_buf *hsrc,
-                                   ui32 width, bool even)
+        // combine both lsrc and hsrc into dst
         {
-            if (width > 1)
-            {
-                bool ev = even;
-                si32 *oth = hsrc->i32, *aug = lsrc->i32;
-                ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-                ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
-                ui32 num_steps = atk->get_num_steps();
-                for (ui32 j = 0; j < num_steps; ++j)
-                {
-                    const lifting_step *s = atk->get_step(j);
-                    const si32 a = s->rev.Aatk;
-                    const si32 b = s->rev.Batk;
-                    const ui8 e = s->rev.Eatk;
-                    __m512i va = _mm512_set1_epi32(a);
-                    __m512i vb = _mm512_set1_epi32(b);
+          double* dp  = (double*)(dst->p);
+          double* spl = (double*)(even ? lsrc->p : hsrc->p);
+          double* sph = (double*)(even ? hsrc->p : lsrc->p);
+          int w = (int)width;
+          avx512_interleave64(dp, spl, sph, w);
+        }          
+      }
+      else {
+        if (even)
+          dst->i64[0] = lsrc->i64[0];
+        else
+          dst->i64[0] = hsrc->i64[0] >> 1;
+      }
+    }
 
-                    // extension
-                    oth[-1] = oth[0];
-                    oth[oth_width] = oth[oth_width - 1];
-                    // lifting step
-                    const si32 *sp = oth;
-                    si32 *dp = aug;
-                    if (a == 1)
-                    { // 5/3 update and any case with a == 1
-                        int i = (int)aug_width;
-                        if (ev)
-                        {
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i v = _mm512_add_epi32(vb, t);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_sub_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        }
-                        else
-                        {
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i v = _mm512_add_epi32(vb, t);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_sub_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        }
-                    }
-                    else if (a == -1 && b == 1 && e == 1)
-                    { // 5/3 predict
-                        int i = (int)aug_width;
-                        if (ev)
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i w = _mm512_srai_epi32(t, e);
-                                d = _mm512_add_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i w = _mm512_srai_epi32(t, e);
-                                d = _mm512_add_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-                    else if (a == -1)
-                    { // any case with a == -1, which is not 5/3 predict
-                        int i = (int)aug_width;
-                        if (ev)
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i v = _mm512_sub_epi32(vb, t);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_sub_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i v = _mm512_sub_epi32(vb, t);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_sub_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-                    else
-                    {
-                        // general case
-                        int i = (int)aug_width;
-                        if (ev)
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i u = _mm512_mullo_epi32(va, t);
-                                __m512i v = _mm512_add_epi32(vb, u);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_sub_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 16, sp += 16, dp += 16)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi32(s1, s2);
-                                __m512i u = _mm512_mullo_epi32(va, t);
-                                __m512i v = _mm512_add_epi32(vb, u);
-                                __m512i w = _mm512_srai_epi32(v, e);
-                                d = _mm512_sub_epi32(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
+    /////////////////////////////////////////////////////////////////////////
+    void avx512_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
+                             const line_buf* lsrc, const line_buf* hsrc, 
+                             ui32 width, bool even)
+    {
+      if (dst->flags & line_buf::LFT_32BIT) 
+      {
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
+               (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
+        avx512_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
+      }
+      else 
+      {
+        assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
+               (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
+        avx512_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
+      }
+    }
 
-                    // swap buffers
-                    si32 *t = aug;
-                    aug = oth;
-                    oth = t;
-                    ev = !ev;
-                    ui32 w = aug_width;
-                    aug_width = oth_width;
-                    oth_width = w;
-                }
-
-                // combine both lsrc and hsrc into dst
-                {
-                    float *dp = dst->f32;
-                    float *spl = even ? lsrc->f32 : hsrc->f32;
-                    float *sph = even ? hsrc->f32 : lsrc->f32;
-                    int w = (int)width;
-                    avx512_interleave32(dp, spl, sph, w);
-                }
-            }
-            else
-            {
-                if (even)
-                    dst->i32[0] = lsrc->i32[0];
-                else
-                    dst->i32[0] = hsrc->i32[0] >> 1;
-            }
-        }
-
-        //////////////////////////////////////////////////////////////////////////
-        void avx512_rev_horz_syn64(const param_atk *atk, const line_buf *dst,
-                                   const line_buf *lsrc, const line_buf *hsrc,
-                                   ui32 width, bool even)
-        {
-            if (width > 1)
-            {
-                bool ev = even;
-                si64 *oth = hsrc->i64, *aug = lsrc->i64;
-                ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-                ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
-                ui32 num_steps = atk->get_num_steps();
-                for (ui32 j = 0; j < num_steps; ++j)
-                {
-                    const lifting_step *s = atk->get_step(j);
-                    const si32 a = s->rev.Aatk;
-                    const si32 b = s->rev.Batk;
-                    const ui8 e = s->rev.Eatk;
-                    __m512i vb = _mm512_set1_epi64(b);
-
-                    // extension
-                    oth[-1] = oth[0];
-                    oth[oth_width] = oth[oth_width - 1];
-                    // lifting step
-                    const si64 *sp = oth;
-                    si64 *dp = aug;
-                    if (a == 1)
-                    { // 5/3 update and any case with a == 1
-                        int i = (int)aug_width;
-                        if (ev)
-                        {
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i v = _mm512_add_epi64(vb, t);
-                                __m512i w = _mm512_srai_epi64(v, e);
-                                d = _mm512_sub_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        }
-                        else
-                        {
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i v = _mm512_add_epi64(vb, t);
-                                __m512i w = _mm512_srai_epi64(v, e);
-                                d = _mm512_sub_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        }
-                    }
-                    else if (a == -1 && b == 1 && e == 1)
-                    { // 5/3 predict
-                        int i = (int)aug_width;
-                        if (ev)
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i w = _mm512_srai_epi64(t, e);
-                                d = _mm512_add_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i w = _mm512_srai_epi64(t, e);
-                                d = _mm512_add_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-                    else if (a == -1)
-                    { // any case with a == -1, which is not 5/3 predict
-                        int i = (int)aug_width;
-                        if (ev)
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp - 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i v = _mm512_sub_epi64(vb, t);
-                                __m512i w = _mm512_srai_epi64(v, e);
-                                d = _mm512_sub_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                        else
-                            for (; i > 0; i -= 8, sp += 8, dp += 8)
-                            {
-                                __m512i s1 = _mm512_load_si512((__m512i *)sp);
-                                __m512i s2 = _mm512_loadu_si512((__m512i *)(sp + 1));
-                                __m512i d = _mm512_load_si512((__m512i *)dp);
-                                __m512i t = _mm512_add_epi64(s1, s2);
-                                __m512i v = _mm512_sub_epi64(vb, t);
-                                __m512i w = _mm512_srai_epi64(v, e);
-                                d = _mm512_sub_epi64(d, w);
-                                _mm512_store_si512((__m512i *)dp, d);
-                            }
-                    }
-                    else
-                    {
-                        // general case
-                        // 64bit multiplication is not supported in AVX512F + AVX512CD;
-                        // in particular, _mm256_mullo_epi64.
-                        if (ev)
-                            for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
-                                *dp -= (b + a * (sp[-1] + sp[0])) >> e;
-                        else
-                            for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
-                                *dp -= (b + a * (sp[0] + sp[1])) >> e;
-                    }
-
-                    // This can only be used if you have AVX512DQ
-                    // {
-                    //   // general case
-                    //   __m512i va = _mm512_set1_epi64(a);
-                    //   int i = (int)aug_width;
-                    //   if (ev)
-                    //     for (; i > 0; i -= 8, sp += 8, dp += 8)
-                    //     {
-                    //       __m512i s1 = _mm512_load_si512((__m512i*)sp);
-                    //       __m512i s2 = _mm512_loadu_si512((__m512i*)(sp - 1));
-                    //       __m512i d = _mm512_load_si512((__m512i*)dp);
-                    //       __m512i t = _mm512_add_epi64(s1, s2);
-                    //       __m512i u = _mm512_mullo_epi64(va, t);
-                    //       __m512i v = _mm512_add_epi64(vb, u);
-                    //       __m512i w = _mm512_srai_epi64(v, e);
-                    //       d = _mm512_sub_epi64(d, w);
-                    //       _mm512_store_si512((__m512i*)dp, d);
-                    //     }
-                    //   else
-                    //     for (; i > 0; i -= 8, sp += 8, dp += 8)
-                    //     {
-                    //       __m512i s1 = _mm512_load_si512((__m512i*)sp);
-                    //       __m512i s2 = _mm512_loadu_si512((__m512i*)(sp + 1));
-                    //       __m512i d = _mm512_load_si512((__m512i*)dp);
-                    //       __m512i t = _mm512_add_epi64(s1, s2);
-                    //       __m512i u = _mm512_mullo_epi64(va, t);
-                    //       __m512i v = _mm512_add_epi64(vb, u);
-                    //       __m512i w = _mm512_srai_epi64(v, e);
-                    //       d = _mm512_sub_epi64(d, w);
-                    //       _mm512_store_si512((__m512i*)dp, d);
-                    //     }
-                    // }
-
-                    // swap buffers
-                    si64 *t = aug;
-                    aug = oth;
-                    oth = t;
-                    ev = !ev;
-                    ui32 w = aug_width;
-                    aug_width = oth_width;
-                    oth_width = w;
-                }
-
-                // combine both lsrc and hsrc into dst
-                {
-                    double *dp = (double *)(dst->p);
-                    double *spl = (double *)(even ? lsrc->p : hsrc->p);
-                    double *sph = (double *)(even ? hsrc->p : lsrc->p);
-                    int w = (int)width;
-                    avx512_interleave64(dp, spl, sph, w);
-                }
-            }
-            else
-            {
-                if (even)
-                    dst->i64[0] = lsrc->i64[0];
-                else
-                    dst->i64[0] = hsrc->i64[0] >> 1;
-            }
-        }
-
-        /////////////////////////////////////////////////////////////////////////
-        void avx512_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                                 const line_buf *lsrc, const line_buf *hsrc,
-                                 ui32 width, bool even)
-        {
-            if (dst->flags & line_buf::LFT_32BIT)
-            {
-                assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
-                       (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
-                avx512_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
-            }
-            else
-            {
-                assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-                       (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
-                       (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
-                avx512_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
-            }
-        }
-
-    } // !local
+  } // !local
 } // !ojph
 
 #endif

--- a/Native/Common/OpenJPH/transform/ojph_transform_local.h
+++ b/Native/Common/OpenJPH/transform/ojph_transform_local.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,19 +35,18 @@
 // Date: 28 August 2019
 //***************************************************************************/
 
+
 #ifndef OJPH_TRANSFORM_LOCAL_H
 #define OJPH_TRANSFORM_LOCAL_H
 
 #include "ojph_defs.h"
 
-namespace ojph
-{
+namespace ojph {
 
   // defined elsewhere
   class line_buf;
 
-  namespace local
-  {
+  namespace local {
     struct param_atk;
     union lifting_step;
 
@@ -64,21 +63,21 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                           const line_buf *other, const line_buf *aug,
+    void gen_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                           const line_buf* other, const line_buf* aug, 
                            ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat);
+    void gen_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                          const line_buf *hdst, const line_buf *src,
+    void gen_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                          const line_buf* hdst, const line_buf* src, 
                           ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                          const line_buf *lsrc, const line_buf *hsrc,
+    void gen_irv_horz_syn(const param_atk *atk, const line_buf* dst, 
+                          const line_buf *lsrc, const line_buf *hsrc, 
                           ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -86,18 +85,18 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                           const line_buf *other, const line_buf *aug,
+    void gen_rev_vert_step(const lifting_step* s, const line_buf* sig, 
+                           const line_buf* other, const line_buf* aug, 
                            ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                          const line_buf *hdst, const line_buf *src,
+    void gen_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                          const line_buf* hdst, const line_buf* src, 
                           ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                          const line_buf *lsrc, const line_buf *hsrc,
+    void gen_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
+                          const line_buf* lsrc, const line_buf* hsrc, 
                           ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -113,21 +112,21 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void sse_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                           const line_buf *other, const line_buf *aug,
+    void sse_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                           const line_buf* other, const line_buf* aug, 
                            ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void sse_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat);
+    void sse_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat);
 
     /////////////////////////////////////////////////////////////////////////
-    void sse_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                          const line_buf *hdst, const line_buf *src,
+    void sse_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                          const line_buf* hdst, const line_buf* src, 
                           ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void sse_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                          const line_buf *lsrc, const line_buf *hsrc,
+    void sse_irv_horz_syn(const param_atk *atk, const line_buf* dst,
+                          const line_buf *lsrc, const line_buf *hsrc, 
                           ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -143,19 +142,20 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                            const line_buf *other, const line_buf *aug,
+    void sse2_rev_vert_step(const lifting_step* s, const line_buf* sig, 
+                            const line_buf* other, const line_buf* aug, 
                             ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                           const line_buf *hdst, const line_buf *src,
+    void sse2_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src, 
                            ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                           const line_buf *lsrc, const line_buf *hsrc,
+    void sse2_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc, 
                            ui32 width, bool even);
+
 
     //////////////////////////////////////////////////////////////////////////
     //
@@ -170,21 +170,21 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void avx_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                           const line_buf *other, const line_buf *aug,
+    void avx_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                           const line_buf* other, const line_buf* aug, 
                            ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat);
+    void avx_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                          const line_buf *hdst, const line_buf *src,
+    void avx_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                          const line_buf* hdst, const line_buf* src, 
                           ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                          const line_buf *lsrc, const line_buf *hsrc,
+    void avx_irv_horz_syn(const param_atk *atk, const line_buf* dst,
+                          const line_buf *lsrc, const line_buf *hsrc, 
                           ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -200,18 +200,18 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                            const line_buf *other, const line_buf *aug,
+    void avx2_rev_vert_step(const lifting_step* s, const line_buf* sig, 
+                            const line_buf* other, const line_buf* aug, 
                             ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                           const line_buf *hdst, const line_buf *src,
+    void avx2_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src, 
                            ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                           const line_buf *lsrc, const line_buf *hsrc,
+    void avx2_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc, 
                            ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -227,40 +227,41 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                              const line_buf *other, const line_buf *aug,
+    void avx512_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
                               ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat);
+    void avx512_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                             const line_buf *hdst, const line_buf *src,
+    void avx512_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src, 
                              ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                             const line_buf *lsrc, const line_buf *hsrc,
+    void avx512_irv_horz_syn(const param_atk *atk, const line_buf* dst,
+                             const line_buf *lsrc, const line_buf *hsrc, 
                              ui32 width, bool even);
+
 
     //////////////////////////////////////////////////////////////////////////
     // Reversible functions
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                              const line_buf *other, const line_buf *aug,
+    void avx512_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug, 
                               ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                             const line_buf *hdst, const line_buf *src,
+    void avx512_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src, 
                              ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                             const line_buf *lsrc, const line_buf *hsrc,
+    void avx512_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc, 
                              ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -276,21 +277,21 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                            const line_buf *other, const line_buf *aug,
+    void wasm_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                            const line_buf* other, const line_buf* aug, 
                             ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat);
+    void wasm_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat);
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                           const line_buf *hdst, const line_buf *src,
+    void wasm_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src, 
                            ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                           const line_buf *lsrc, const line_buf *hsrc,
+    void wasm_irv_horz_syn(const param_atk *atk, const line_buf* dst,
+                           const line_buf *lsrc, const line_buf *hsrc, 
                            ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -298,18 +299,18 @@ namespace ojph
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                            const line_buf *other, const line_buf *aug,
+    void wasm_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug, 
                             ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                           const line_buf *hdst, const line_buf *src,
+    void wasm_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src, 
                            ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                           const line_buf *lsrc, const line_buf *hsrc,
+    void wasm_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc, 
                            ui32 width, bool even);
   }
 }

--- a/Native/Common/OpenJPH/transform/ojph_transform_sse.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_transform_sse.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -49,13 +49,12 @@
 #include "ojph_transform.h"
 #include "ojph_transform_local.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void sse_deinterleave32(float *dpl, float *dph, float *sp, int width)
+    static inline
+    void sse_deinterleave32(float* dpl, float* dph, float* sp, int width)
     {
       for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
       {
@@ -69,7 +68,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void sse_interleave32(float *dp, float *spl, float *sph, int width)
+    static inline
+    void sse_interleave32(float* dp, float* spl, float* sph, int width)                      \
     {
       for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
       {
@@ -83,7 +83,7 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void sse_multiply_const(float *p, float f, int width)
+    static inline void sse_multiply_const(float* p, float f, int width)
     {
       __m128 factor = _mm_set1_ps(f);
       for (; width > 0; width -= 4, p += 4)
@@ -94,8 +94,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void sse_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                           const line_buf *other, const line_buf *aug,
+    void sse_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                           const line_buf* other, const line_buf* aug, 
                            ui32 repeat, bool synthesis)
     {
       float a = s->irv.Aatk;
@@ -104,57 +104,57 @@ namespace ojph
 
       __m128 factor = _mm_set1_ps(a);
 
-      float *dst = aug->f32;
-      const float *src1 = sig->f32, *src2 = other->f32;
+      float* dst = aug->f32;
+      const float* src1 = sig->f32, * src2 = other->f32;
       int i = (int)repeat;
-      for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+      for ( ; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
       {
         __m128 s1 = _mm_load_ps(src1);
         __m128 s2 = _mm_load_ps(src2);
-        __m128 d = _mm_load_ps(dst);
+        __m128 d  = _mm_load_ps(dst);
         d = _mm_add_ps(d, _mm_mul_ps(factor, _mm_add_ps(s1, s2)));
         _mm_store_ps(dst, d);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void sse_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat)
+    void sse_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat)
     {
       sse_multiply_const(aug->f32, K, (int)repeat);
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void sse_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                          const line_buf *hdst, const line_buf *src,
+    void sse_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                          const line_buf* hdst, const line_buf* src, 
                           ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          float *dpl = even ? ldst->f32 : hdst->f32;
-          float *dph = even ? hdst->f32 : ldst->f32;
-          float *sp = src->f32;
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp = src->f32;
           int w = (int)width;
           sse_deinterleave32(dpl, dph, sp, w);
         }
 
         // the actual horizontal transform
-        float *hp = hdst->f32, *lp = ldst->f32;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        float* hp = hdst->f32, * lp = ldst->f32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const float a = s->irv.Aatk;
 
           // extension
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const float *sp = lp;
-          float *dp = hp;
+          const float* sp = lp;
+          float* dp = hp;
           int i = (int)h_width;
           __m128 f = _mm_set1_ps(a);
           if (even)
@@ -181,13 +181,9 @@ namespace ojph
           }
 
           // swap buffers
-          float *t = lp;
-          lp = hp;
-          hp = t;
+          float* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
 
         { // multiply by K or 1/K
@@ -197,26 +193,25 @@ namespace ojph
           sse_multiply_const(hp, K, (int)h_width);
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->f32[0] = src->f32[0];
         else
           hdst->f32[0] = src->f32[0] * 2.0f;
       }
     }
-
+    
     //////////////////////////////////////////////////////////////////////////
-    void sse_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                          const line_buf *lsrc, const line_buf *hsrc,
+    void sse_irv_horz_syn(const param_atk* atk, const line_buf* dst, 
+                          const line_buf* lsrc, const line_buf* hsrc, 
                           ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        float *oth = hsrc->f32, *aug = lsrc->f32;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        float* oth = hsrc->f32, * aug = lsrc->f32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
 
         { // multiply by K or 1/K
           float K = atk->get_K();
@@ -229,20 +224,20 @@ namespace ojph
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const float a = s->irv.Aatk;
 
           // extension
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const float *sp = oth;
-          float *dp = aug;
+          const float* sp = oth;
+          float* dp = aug;
           int i = (int)aug_width;
           __m128 f = _mm_set1_ps(a);
           if (ev)
           {
-            for (; i > 0; i -= 4, sp += 4, dp += 4)
+            for ( ; i > 0; i -= 4, sp += 4, dp += 4)
             {
               __m128 m = _mm_load_ps(sp);
               __m128 n = _mm_loadu_ps(sp - 1);
@@ -253,7 +248,7 @@ namespace ojph
           }
           else
           {
-            for (; i > 0; i -= 4, sp += 4, dp += 4)
+            for ( ; i > 0; i -= 4, sp += 4, dp += 4)
             {
               __m128 m = _mm_load_ps(sp);
               __m128 n = _mm_loadu_ps(sp + 1);
@@ -264,26 +259,21 @@ namespace ojph
           }
 
           // swap buffers
-          float *t = aug;
-          aug = oth;
-          oth = t;
+          float* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          float *dp = dst->f32;
-          float *spl = even ? lsrc->f32 : hsrc->f32;
-          float *sph = even ? hsrc->f32 : lsrc->f32;
+          float* dp = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           sse_interleave32(dp, spl, sph, w);
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->f32[0] = lsrc->f32[0];
         else

--- a/Native/Common/OpenJPH/transform/ojph_transform_sse2.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_transform_sse2.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman
+// Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -51,14 +51,12 @@
 
 #include <emmintrin.h>
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     /////////////////////////////////////////////////////////////////////////
     // https://github.com/seung-lab/dijkstra3d/blob/master/libdivide.h
-    static inline __m128i sse2_mm_srai_epi64(__m128i a, int amt, __m128i m)
+    static inline __m128i sse2_mm_srai_epi64(__m128i a, int amt, __m128i m) 
     {
       // note than m must be obtained using
       // __m128i m = _mm_set1_epi64x(1ULL << (63 - amt));
@@ -69,7 +67,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void sse2_deinterleave32(float *dpl, float *dph, float *sp, int width)
+    static inline
+    void sse2_deinterleave32(float* dpl, float* dph, float* sp, int width)
     {
       for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
       {
@@ -83,7 +82,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void sse2_interleave32(float *dp, float *spl, float *sph, int width)
+    static inline
+    void sse2_interleave32(float* dp, float* spl, float* sph, int width)                      \
     {
       for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
       {
@@ -97,7 +97,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void sse2_deinterleave64(double *dpl, double *dph, double *sp, int width)
+    static inline 
+    void sse2_deinterleave64(double* dpl, double* dph, double* sp, int width)
     {
       for (; width > 0; width -= 4, sp += 4, dpl += 2, dph += 2)
       {
@@ -108,10 +109,11 @@ namespace ojph
         _mm_store_pd(dpl, c);
         _mm_store_pd(dph, d);
       }
-    }
+    }    
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void sse2_interleave64(double *dp, double *spl, double *sph, int width)
+    static inline 
+    void sse2_interleave64(double* dp, double* spl, double* sph, int width)
     {
       for (; width > 0; width -= 4, dp += 4, spl += 2, sph += 2)
       {
@@ -125,18 +127,19 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void sse2_rev_vert_step32(const lifting_step *s, const line_buf *sig,
-                                     const line_buf *other, const line_buf *aug,
-                                     ui32 repeat, bool synthesis)
+    static
+    void sse2_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
+                              ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
       const si32 b = s->rev.Batk;
       const ui8 e = s->rev.Eatk;
       __m128i vb = _mm_set1_epi32(b);
 
-      si32 *dst = aug->i32;
-      const si32 *src1 = sig->i32, *src2 = other->i32;
-      // The general definition of the wavelet in Part 2 is slightly
+      si32* dst = aug->i32;
+      const si32* src1 = sig->i32, * src2 = other->i32;
+      // The general definition of the wavelet in Part 2 is slightly 
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -145,26 +148,26 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi32(s1, s2);
             __m128i v = _mm_add_epi32(vb, t);
             __m128i w = _mm_srai_epi32(v, e);
             d = _mm_sub_epi32(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi32(s1, s2);
             __m128i v = _mm_add_epi32(vb, t);
             __m128i w = _mm_srai_epi32(v, e);
             d = _mm_add_epi32(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
       }
       else if (a == -1 && b == 1 && e == 1)
@@ -173,24 +176,24 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi32(s1, s2);
             __m128i w = _mm_srai_epi32(t, e);
             d = _mm_add_epi32(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi32(s1, s2);
             __m128i w = _mm_srai_epi32(t, e);
             d = _mm_sub_epi32(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
       }
       else if (a == -1)
@@ -199,30 +202,29 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi32(s1, s2);
             __m128i v = _mm_sub_epi32(vb, t);
             __m128i w = _mm_srai_epi32(v, e);
             d = _mm_sub_epi32(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi32(s1, s2);
             __m128i v = _mm_sub_epi32(vb, t);
             __m128i w = _mm_srai_epi32(v, e);
             d = _mm_add_epi32(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
       }
-      else
-      { // general case
+      else { // general case
         // 32bit multiplication is not supported in sse2; we need sse4.1,
         // where we can use _mm_mullo_epi32, which multiplies 32bit x 32bit,
         // keeping the LSBs
@@ -236,9 +238,10 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void sse2_rev_vert_step64(const lifting_step *s, const line_buf *sig,
-                                     const line_buf *other, const line_buf *aug,
-                                     ui32 repeat, bool synthesis)
+    static
+    void sse2_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
+                              ui32 repeat, bool synthesis)
     {
       const si64 a = s->rev.Aatk;
       const si64 b = s->rev.Batk;
@@ -246,9 +249,9 @@ namespace ojph
       __m128i vb = _mm_set1_epi64x(b);
       __m128i ve = _mm_set1_epi64x(1LL << (63 - e));
 
-      si64 *dst = aug->i64;
-      const si64 *src1 = sig->i64, *src2 = other->i64;
-      // The general definition of the wavelet in Part 2 is slightly
+      si64* dst = aug->i64;
+      const si64* src1 = sig->i64, * src2 = other->i64;
+      // The general definition of the wavelet in Part 2 is slightly 
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -257,26 +260,26 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi64(s1, s2);
             __m128i v = _mm_add_epi64(vb, t);
             __m128i w = sse2_mm_srai_epi64(v, e, ve);
             d = _mm_sub_epi64(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
         else
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi64(s1, s2);
             __m128i v = _mm_add_epi64(vb, t);
             __m128i w = sse2_mm_srai_epi64(v, e, ve);
             d = _mm_add_epi64(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
       }
       else if (a == -1 && b == 1 && e == 1)
@@ -285,24 +288,24 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi64(s1, s2);
             __m128i w = sse2_mm_srai_epi64(t, e, ve);
             d = _mm_add_epi64(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
         else
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi64(s1, s2);
             __m128i w = sse2_mm_srai_epi64(t, e, ve);
             d = _mm_sub_epi64(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
       }
       else if (a == -1)
@@ -311,30 +314,29 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi64(s1, s2);
             __m128i v = _mm_sub_epi64(vb, t);
             __m128i w = sse2_mm_srai_epi64(v, e, ve);
             d = _mm_sub_epi64(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
         else
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            __m128i s1 = _mm_load_si128((__m128i *)src1);
-            __m128i s2 = _mm_load_si128((__m128i *)src2);
-            __m128i d = _mm_load_si128((__m128i *)dst);
+            __m128i s1 = _mm_load_si128((__m128i*)src1);
+            __m128i s2 = _mm_load_si128((__m128i*)src2);
+            __m128i d = _mm_load_si128((__m128i*)dst);
             __m128i t = _mm_add_epi64(s1, s2);
             __m128i v = _mm_sub_epi64(vb, t);
             __m128i w = sse2_mm_srai_epi64(v, e, ve);
             d = _mm_add_epi64(d, w);
-            _mm_store_si128((__m128i *)dst, d);
+            _mm_store_si128((__m128i*)dst, d);
           }
       }
-      else
-      { // general case
+      else { // general case
         // 64bit multiplication is not supported in sse2
         if (synthesis)
           for (ui32 i = repeat; i > 0; --i)
@@ -346,52 +348,53 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                            const line_buf *other, const line_buf *aug,
+    void sse2_rev_vert_step(const lifting_step* s, const line_buf* sig, 
+                            const line_buf* other, const line_buf* aug, 
                             ui32 repeat, bool synthesis)
     {
-      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
           ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
                (aug == NULL || aug->flags & line_buf::LFT_32BIT));
         sse2_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
       }
-      else
+      else 
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
                (aug == NULL || aug->flags & line_buf::LFT_64BIT));
         sse2_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void sse2_rev_horz_ana32(const param_atk *atk, const line_buf *ldst,
-                                    const line_buf *hdst, const line_buf *src,
-                                    ui32 width, bool even)
+    static
+    void sse2_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
+                             const line_buf* hdst, const line_buf* src, 
+                             ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          float *dpl = even ? ldst->f32 : hdst->f32;
-          float *dph = even ? hdst->f32 : ldst->f32;
-          float *sp = src->f32;
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp = src->f32;
           int w = (int)width;
           sse2_deinterleave32(dpl, dph, sp, w);
         }
 
-        si32 *hp = hdst->i32, *lp = ldst->i32;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si32* hp = hdst->i32, * lp = ldst->i32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
           // first lifting step
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -401,8 +404,8 @@ namespace ojph
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const si32 *sp = lp;
-          si32 *dp = hp;
+          const si32* sp = lp;
+          si32* dp = hp;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)h_width;
@@ -410,55 +413,55 @@ namespace ojph
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i v = _mm_add_epi32(vb, t);
                 __m128i w = _mm_srai_epi32(v, e);
                 d = _mm_add_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i v = _mm_add_epi32(vb, t);
                 __m128i w = _mm_srai_epi32(v, e);
                 d = _mm_add_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i w = _mm_srai_epi32(t, e);
                 d = _mm_sub_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i w = _mm_srai_epi32(t, e);
                 d = _mm_sub_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
           }
           else if (a == -1)
@@ -467,30 +470,29 @@ namespace ojph
             if (even)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i v = _mm_sub_epi32(vb, t);
                 __m128i w = _mm_srai_epi32(v, e);
                 d = _mm_add_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i v = _mm_sub_epi32(vb, t);
                 __m128i w = _mm_srai_epi32(v, e);
                 d = _mm_add_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
           }
-          else
-          {
+          else {
             // general case
             // 64bit multiplication is not supported in sse2
             if (even)
@@ -502,17 +504,12 @@ namespace ojph
           }
 
           // swap buffers
-          si32 *t = lp;
-          lp = hp;
-          hp = t;
+          si32* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->i32[0] = src->i32[0];
         else
@@ -521,29 +518,30 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void sse2_rev_horz_ana64(const param_atk *atk, const line_buf *ldst,
-                                    const line_buf *hdst, const line_buf *src,
-                                    ui32 width, bool even)
+    static
+    void sse2_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
+                             const line_buf* hdst, const line_buf* src, 
+                             ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          double *dpl = (double *)(even ? ldst->p : hdst->p);
-          double *dph = (double *)(even ? hdst->p : ldst->p);
-          double *sp = (double *)src->p;
+          double* dpl = (double*)(even ? ldst->p : hdst->p);
+          double* dph = (double*)(even ? hdst->p : ldst->p);
+          double* sp  = (double*)src->p;
           int w = (int)width;
           sse2_deinterleave64(dpl, dph, sp, w);
         }
 
-        si64 *hp = hdst->i64, *lp = ldst->i64;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si64* hp = hdst->i64, * lp = ldst->i64;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
           // first lifting step
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -554,8 +552,8 @@ namespace ojph
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const si64 *sp = lp;
-          si64 *dp = hp;
+          const si64* sp = lp;
+          si64* dp = hp;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)h_width;
@@ -563,55 +561,55 @@ namespace ojph
             {
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i v = _mm_add_epi64(vb, t);
                 __m128i w = sse2_mm_srai_epi64(v, e, ve);
                 d = _mm_add_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i v = _mm_add_epi64(vb, t);
                 __m128i w = sse2_mm_srai_epi64(v, e, ve);
                 d = _mm_add_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i w = sse2_mm_srai_epi64(t, e, ve);
                 d = _mm_sub_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i w = sse2_mm_srai_epi64(t, e, ve);
                 d = _mm_sub_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
           }
           else if (a == -1)
@@ -620,30 +618,29 @@ namespace ojph
             if (even)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i v = _mm_sub_epi64(vb, t);
                 __m128i w = sse2_mm_srai_epi64(v, e, ve);
                 d = _mm_add_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i v = _mm_sub_epi64(vb, t);
                 __m128i w = sse2_mm_srai_epi64(v, e, ve);
                 d = _mm_add_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
           }
-          else
-          {
+          else {
             // general case
             // 64bit multiplication is not supported in sse2
             if (even)
@@ -655,17 +652,12 @@ namespace ojph
           }
 
           // swap buffers
-          si64 *t = lp;
-          lp = hp;
-          hp = t;
+          si64* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->i64[0] = src->i64[0];
         else
@@ -674,40 +666,40 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                           const line_buf *hdst, const line_buf *src,
+    void sse2_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                           const line_buf* hdst, const line_buf* src, 
                            ui32 width, bool even)
     {
-      if (src->flags & line_buf::LFT_32BIT)
+      if (src->flags & line_buf::LFT_32BIT) 
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
                (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
         sse2_rev_horz_ana32(atk, ldst, hdst, src, width, even);
       }
-      else
+      else 
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
                (src == NULL || src->flags & line_buf::LFT_64BIT));
         sse2_rev_horz_ana64(atk, ldst, hdst, src, width, even);
       }
-    }
-
+    }    
+    
     //////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_syn32(const param_atk *atk, const line_buf *dst,
-                             const line_buf *lsrc, const line_buf *hsrc,
+    void sse2_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
+                             const line_buf* lsrc, const line_buf* hsrc, 
                              ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        si32 *oth = hsrc->i32, *aug = lsrc->i32;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si32* oth = hsrc->i32, * aug = lsrc->i32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -717,8 +709,8 @@ namespace ojph
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const si32 *sp = oth;
-          si32 *dp = aug;
+          const si32* sp = oth;
+          si32* dp = aug;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)aug_width;
@@ -726,55 +718,55 @@ namespace ojph
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i v = _mm_add_epi32(vb, t);
                 __m128i w = _mm_srai_epi32(v, e);
                 d = _mm_sub_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i v = _mm_add_epi32(vb, t);
                 __m128i w = _mm_srai_epi32(v, e);
                 d = _mm_sub_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i w = _mm_srai_epi32(t, e);
                 d = _mm_add_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i w = _mm_srai_epi32(t, e);
                 d = _mm_add_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
           }
           else if (a == -1)
@@ -783,30 +775,29 @@ namespace ojph
             if (ev)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i v = _mm_sub_epi32(vb, t);
                 __m128i w = _mm_srai_epi32(v, e);
                 d = _mm_sub_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi32(s1, s2);
                 __m128i v = _mm_sub_epi32(vb, t);
                 __m128i w = _mm_srai_epi32(v, e);
                 d = _mm_sub_epi32(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
           }
-          else
-          {
+          else {
             // general case
             // 32bit multiplication is not supported in sse2; we need sse4.1,
             // where we can use _mm_mullo_epi32, which multiplies
@@ -820,26 +811,21 @@ namespace ojph
           }
 
           // swap buffers
-          si32 *t = aug;
-          aug = oth;
-          oth = t;
+          si32* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          float *dp = dst->f32;
-          float *spl = even ? lsrc->f32 : hsrc->f32;
-          float *sph = even ? hsrc->f32 : lsrc->f32;
+          float* dp = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           sse2_interleave32(dp, spl, sph, w);
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->i32[0] = lsrc->i32[0];
         else
@@ -848,20 +834,20 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_syn64(const param_atk *atk, const line_buf *dst,
-                             const line_buf *lsrc, const line_buf *hsrc,
+    void sse2_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
+                             const line_buf* lsrc, const line_buf* hsrc, 
                              ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        si64 *oth = hsrc->i64, *aug = lsrc->i64;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si64* oth = hsrc->i64, * aug = lsrc->i64;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -872,8 +858,8 @@ namespace ojph
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const si64 *sp = oth;
-          si64 *dp = aug;
+          const si64* sp = oth;
+          si64* dp = aug;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)aug_width;
@@ -881,55 +867,55 @@ namespace ojph
             {
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i v = _mm_add_epi64(vb, t);
                 __m128i w = sse2_mm_srai_epi64(v, e, ve);
                 d = _mm_sub_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i v = _mm_add_epi64(vb, t);
                 __m128i w = sse2_mm_srai_epi64(v, e, ve);
                 d = _mm_sub_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i w = sse2_mm_srai_epi64(t, e, ve);
                 d = _mm_add_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i w = sse2_mm_srai_epi64(t, e, ve);
                 d = _mm_add_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
           }
           else if (a == -1)
@@ -938,30 +924,29 @@ namespace ojph
             if (ev)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp - 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp - 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i v = _mm_sub_epi64(vb, t);
                 __m128i w = sse2_mm_srai_epi64(v, e, ve);
                 d = _mm_sub_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                __m128i s1 = _mm_load_si128((__m128i *)sp);
-                __m128i s2 = _mm_loadu_si128((__m128i *)(sp + 1));
-                __m128i d = _mm_load_si128((__m128i *)dp);
+                __m128i s1 = _mm_load_si128((__m128i*)sp);
+                __m128i s2 = _mm_loadu_si128((__m128i*)(sp + 1));
+                __m128i d = _mm_load_si128((__m128i*)dp);
                 __m128i t = _mm_add_epi64(s1, s2);
                 __m128i v = _mm_sub_epi64(vb, t);
                 __m128i w = sse2_mm_srai_epi64(v, e, ve);
                 d = _mm_sub_epi64(d, w);
-                _mm_store_si128((__m128i *)dp, d);
+                _mm_store_si128((__m128i*)dp, d);
               }
           }
-          else
-          {
+          else {
             // general case
             // 64bit multiplication is not supported in sse2
             if (ev)
@@ -973,26 +958,21 @@ namespace ojph
           }
 
           // swap buffers
-          si64 *t = aug;
-          aug = oth;
-          oth = t;
+          si64* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          double *dp = (double *)dst->p;
-          double *spl = (double *)(even ? lsrc->p : hsrc->p);
-          double *sph = (double *)(even ? hsrc->p : lsrc->p);
+          double* dp  = (double*)dst->p;
+          double* spl = (double*)(even ? lsrc->p : hsrc->p);
+          double* sph = (double*)(even ? hsrc->p : lsrc->p);
           int w = (int)width;
           sse2_interleave64(dp, spl, sph, w);
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->i64[0] = lsrc->i64[0];
         else
@@ -1001,24 +981,24 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                           const line_buf *lsrc, const line_buf *hsrc,
+    void sse2_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
+                           const line_buf* lsrc, const line_buf* hsrc, 
                            ui32 width, bool even)
     {
-      if (dst->flags & line_buf::LFT_32BIT)
+      if (dst->flags & line_buf::LFT_32BIT) 
       {
-        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
                (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
         sse2_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
       }
-      else
+      else 
       {
         assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
                (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
         sse2_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
       }
-    }
+    }    
 
   } // !local
 } // !ojph

--- a/Native/Common/OpenJPH/transform/ojph_transform_wasm.cpp
+++ b/Native/Common/OpenJPH/transform/ojph_transform_wasm.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2021, Aous Naman
+// Copyright (c) 2021, Aous Naman 
 // Copyright (c) 2021, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2021, The University of New South Wales, Australia
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
+// 
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-//
+// 
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -47,13 +47,12 @@
 #include "ojph_transform.h"
 #include "ojph_transform_local.h"
 
-namespace ojph
-{
-  namespace local
-  {
+namespace ojph {
+  namespace local {
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void wasm_deinterleave32(float *dpl, float *dph, float *sp, int width)
+    static inline
+    void wasm_deinterleave32(float* dpl, float* dph, float* sp, int width)
     {
       for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
       {
@@ -69,7 +68,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void wasm_interleave32(float *dp, float *spl, float *sph, int width)
+    static inline
+    void wasm_interleave32(float* dp, float* spl, float* sph, int width)
     {
       for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
       {
@@ -85,7 +85,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void wasm_deinterleave64(double *dpl, double *dph, double *sp, int width)
+    static inline 
+    void wasm_deinterleave64(double* dpl, double* dph, double* sp, int width)
     {
       for (; width > 0; width -= 4, sp += 4, dpl += 2, dph += 2)
       {
@@ -96,10 +97,11 @@ namespace ojph
         wasm_v128_store(dpl, c);
         wasm_v128_store(dph, d);
       }
-    }
+    }    
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void wasm_interleave64(double *dp, double *spl, double *sph, int width)
+    static inline 
+    void wasm_interleave64(double* dp, double* spl, double* sph, int width)
     {
       for (; width > 0; width -= 4, dp += 4, spl += 2, sph += 2)
       {
@@ -110,10 +112,10 @@ namespace ojph
         wasm_v128_store(dp, c);
         wasm_v128_store(dp + 2, d);
       }
-    }
+    }    
 
     //////////////////////////////////////////////////////////////////////////
-    static inline void wasm_multiply_const(float *p, float f, int width)
+    static inline void wasm_multiply_const(float* p, float f, int width)
     {
       v128_t factor = wasm_f32x4_splat(f);
       for (; width > 0; width -= 4, p += 4)
@@ -124,8 +126,8 @@ namespace ojph
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_irv_vert_step(const lifting_step *s, const line_buf *sig,
-                            const line_buf *other, const line_buf *aug,
+    void wasm_irv_vert_step(const lifting_step* s, const line_buf* sig, 
+                            const line_buf* other, const line_buf* aug, 
                             ui32 repeat, bool synthesis)
     {
       float a = s->irv.Aatk;
@@ -134,57 +136,57 @@ namespace ojph
 
       v128_t factor = wasm_f32x4_splat(a);
 
-      float *dst = aug->f32;
-      const float *src1 = sig->f32, *src2 = other->f32;
+      float* dst = aug->f32;
+      const float* src1 = sig->f32, * src2 = other->f32;
       int i = (int)repeat;
-      for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+      for ( ; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
       {
         v128_t s1 = wasm_v128_load(src1);
         v128_t s2 = wasm_v128_load(src2);
-        v128_t d = wasm_v128_load(dst);
+        v128_t d  = wasm_v128_load(dst);
         d = wasm_f32x4_add(d, wasm_f32x4_mul(factor, wasm_f32x4_add(s1, s2)));
         wasm_v128_store(dst, d);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_irv_vert_times_K(float K, const line_buf *aug, ui32 repeat)
+    void wasm_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat)
     {
       wasm_multiply_const(aug->f32, K, (int)repeat);
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_irv_horz_ana(const param_atk *atk, const line_buf *ldst,
-                           const line_buf *hdst, const line_buf *src,
+    void wasm_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                           const line_buf* hdst, const line_buf* src, 
                            ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          float *dpl = even ? ldst->f32 : hdst->f32;
-          float *dph = even ? hdst->f32 : ldst->f32;
-          float *sp = src->f32;
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp = src->f32;
           int w = (int)width;
           wasm_deinterleave32(dpl, dph, sp, w);
-        }
+        }        
 
         // the actual horizontal transform
-        float *hp = hdst->f32, *lp = ldst->f32;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        float* hp = hdst->f32, * lp = ldst->f32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const float a = s->irv.Aatk;
 
           // extension
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const float *sp = lp;
-          float *dp = hp;
+          const float* sp = lp;
+          float* dp = hp;
           int i = (int)h_width;
           v128_t f = wasm_f32x4_splat(a);
           if (even)
@@ -211,13 +213,9 @@ namespace ojph
           }
 
           // swap buffers
-          float *t = lp;
-          lp = hp;
-          hp = t;
+          float* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
 
         { // multiply by K or 1/K
@@ -227,26 +225,25 @@ namespace ojph
           wasm_multiply_const(hp, K, (int)h_width);
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->f32[0] = src->f32[0];
         else
           hdst->f32[0] = src->f32[0] * 2.0f;
       }
     }
-
+    
     //////////////////////////////////////////////////////////////////////////
-    void wasm_irv_horz_syn(const param_atk *atk, const line_buf *dst,
-                           const line_buf *lsrc, const line_buf *hsrc,
+    void wasm_irv_horz_syn(const param_atk* atk, const line_buf* dst, 
+                           const line_buf* lsrc, const line_buf* hsrc, 
                            ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        float *oth = hsrc->f32, *aug = lsrc->f32;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        float* oth = hsrc->f32, * aug = lsrc->f32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
 
         { // multiply by K or 1/K
           float K = atk->get_K();
@@ -259,20 +256,20 @@ namespace ojph
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const float a = s->irv.Aatk;
 
           // extension
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const float *sp = oth;
-          float *dp = aug;
+          const float* sp = oth;
+          float* dp = aug;
           int i = (int)aug_width;
           v128_t f = wasm_f32x4_splat(a);
           if (ev)
           {
-            for (; i > 0; i -= 4, sp += 4, dp += 4)
+            for ( ; i > 0; i -= 4, sp += 4, dp += 4)
             {
               v128_t m = wasm_v128_load(sp);
               v128_t n = wasm_v128_load(sp - 1);
@@ -283,7 +280,7 @@ namespace ojph
           }
           else
           {
-            for (; i > 0; i -= 4, sp += 4, dp += 4)
+            for ( ; i > 0; i -= 4, sp += 4, dp += 4)
             {
               v128_t m = wasm_v128_load(sp);
               v128_t n = wasm_v128_load(sp + 1);
@@ -294,26 +291,21 @@ namespace ojph
           }
 
           // swap buffers
-          float *t = aug;
-          aug = oth;
-          oth = t;
+          float* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          float *dp = dst->f32;
-          float *spl = even ? lsrc->f32 : hsrc->f32;
-          float *sph = even ? hsrc->f32 : lsrc->f32;
+          float* dp = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           wasm_interleave32(dp, spl, sph, w);
-        }
+        }        
       }
-      else
-      {
+      else {
         if (even)
           dst->f32[0] = lsrc->f32[0];
         else
@@ -322,8 +314,8 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_vert_step32(const lifting_step *s, const line_buf *sig,
-                              const line_buf *other, const line_buf *aug,
+    void wasm_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
                               ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
@@ -332,9 +324,9 @@ namespace ojph
       v128_t va = wasm_i32x4_splat(a);
       v128_t vb = wasm_i32x4_splat(b);
 
-      si32 *dst = aug->i32;
-      const si32 *src1 = sig->i32, *src2 = other->i32;
-      // The general definition of the wavelet in Part 2 is slightly
+      si32* dst = aug->i32;
+      const si32* src1 = sig->i32, * src2 = other->i32;
+      // The general definition of the wavelet in Part 2 is slightly 
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -343,26 +335,26 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i32x4_add(s1, s2);
             v128_t v = wasm_i32x4_add(vb, t);
             v128_t w = wasm_i32x4_shr(v, e);
             d = wasm_i32x4_sub(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i32x4_add(s1, s2);
             v128_t v = wasm_i32x4_add(vb, t);
             v128_t w = wasm_i32x4_shr(v, e);
             d = wasm_i32x4_add(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
       }
       else if (a == -1 && b == 1 && e == 1)
@@ -371,24 +363,24 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i32x4_add(s1, s2);
             v128_t w = wasm_i32x4_shr(t, e);
             d = wasm_i32x4_add(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i32x4_add(s1, s2);
             v128_t w = wasm_i32x4_shr(t, e);
             d = wasm_i32x4_sub(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
       }
       else if (a == -1)
@@ -397,63 +389,63 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i32x4_add(s1, s2);
             v128_t v = wasm_i32x4_sub(vb, t);
             v128_t w = wasm_i32x4_shr(v, e);
             d = wasm_i32x4_sub(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i32x4_add(s1, s2);
             v128_t v = wasm_i32x4_sub(vb, t);
             v128_t w = wasm_i32x4_shr(v, e);
             d = wasm_i32x4_add(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
       }
-      else
+      else 
       { // general case
         int i = (int)repeat;
         if (synthesis)
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i32x4_add(s1, s2);
             v128_t u = wasm_i32x4_mul(va, t);
             v128_t v = wasm_i32x4_add(vb, u);
             v128_t w = wasm_i32x4_shr(v, e);
             d = wasm_i32x4_sub(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
         else
           for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i32x4_add(s1, s2);
             v128_t u = wasm_i32x4_mul(va, t);
             v128_t v = wasm_i32x4_add(vb, u);
             v128_t w = wasm_i32x4_shr(v, e);
             d = wasm_i32x4_add(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_vert_step64(const lifting_step *s, const line_buf *sig,
-                              const line_buf *other, const line_buf *aug,
+    void wasm_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
+                              const line_buf* other, const line_buf* aug, 
                               ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
@@ -462,9 +454,9 @@ namespace ojph
       v128_t va = wasm_i64x2_splat(a);
       v128_t vb = wasm_i64x2_splat(b);
 
-      si64 *dst = aug->i64;
-      const si64 *src1 = sig->i64, *src2 = other->i64;
-      // The general definition of the wavelet in Part 2 is slightly
+      si64* dst = aug->i64;
+      const si64* src1 = sig->i64, * src2 = other->i64;
+      // The general definition of the wavelet in Part 2 is slightly 
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -473,26 +465,26 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i64x2_add(s1, s2);
             v128_t v = wasm_i64x2_add(vb, t);
             v128_t w = wasm_i64x2_shr(v, e);
             d = wasm_i64x2_sub(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
         else
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i64x2_add(s1, s2);
             v128_t v = wasm_i64x2_add(vb, t);
             v128_t w = wasm_i64x2_shr(v, e);
             d = wasm_i64x2_add(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
       }
       else if (a == -1 && b == 1 && e == 1)
@@ -501,24 +493,24 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i64x2_add(s1, s2);
             v128_t w = wasm_i64x2_shr(t, e);
             d = wasm_i64x2_add(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
         else
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i64x2_add(s1, s2);
             v128_t w = wasm_i64x2_shr(t, e);
             d = wasm_i64x2_sub(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
       }
       else if (a == -1)
@@ -527,107 +519,108 @@ namespace ojph
         if (synthesis)
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i64x2_add(s1, s2);
             v128_t v = wasm_i64x2_sub(vb, t);
             v128_t w = wasm_i64x2_shr(v, e);
             d = wasm_i64x2_sub(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
         else
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i64x2_add(s1, s2);
             v128_t v = wasm_i64x2_sub(vb, t);
             v128_t w = wasm_i64x2_shr(v, e);
             d = wasm_i64x2_add(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
       }
-      else
+      else 
       { // general case
         int i = (int)repeat;
         if (synthesis)
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i64x2_add(s1, s2);
             v128_t u = wasm_i64x2_mul(va, t);
             v128_t v = wasm_i64x2_add(vb, u);
             v128_t w = wasm_i64x2_shr(v, e);
             d = wasm_i64x2_sub(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
         else
           for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
           {
-            v128_t s1 = wasm_v128_load((v128_t *)src1);
-            v128_t s2 = wasm_v128_load((v128_t *)src2);
-            v128_t d = wasm_v128_load((v128_t *)dst);
+            v128_t s1 = wasm_v128_load((v128_t*)src1);
+            v128_t s2 = wasm_v128_load((v128_t*)src2);
+            v128_t d = wasm_v128_load((v128_t*)dst);
             v128_t t = wasm_i64x2_add(s1, s2);
             v128_t u = wasm_i64x2_mul(va, t);
             v128_t v = wasm_i64x2_add(vb, u);
             v128_t w = wasm_i64x2_shr(v, e);
             d = wasm_i64x2_add(d, w);
-            wasm_v128_store((v128_t *)dst, d);
+            wasm_v128_store((v128_t*)dst, d);
           }
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_vert_step(const lifting_step *s, const line_buf *sig,
-                            const line_buf *other, const line_buf *aug,
+    void wasm_rev_vert_step(const lifting_step* s, const line_buf* sig, 
+                            const line_buf* other, const line_buf* aug, 
                             ui32 repeat, bool synthesis)
     {
-      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
           ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
                (aug == NULL || aug->flags & line_buf::LFT_32BIT));
         wasm_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
       }
-      else
+      else 
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
                (aug == NULL || aug->flags & line_buf::LFT_64BIT));
         wasm_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void wasm_rev_horz_ana32(const param_atk *atk, const line_buf *ldst,
-                                    const line_buf *hdst, const line_buf *src,
-                                    ui32 width, bool even)
+    static
+    void wasm_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
+                             const line_buf* hdst, const line_buf* src, 
+                             ui32 width, bool even)
     {
       if (width > 1)
       {
         // combine both lsrc and hsrc into dst
         {
-          float *dpl = even ? ldst->f32 : hdst->f32;
-          float *dph = even ? hdst->f32 : ldst->f32;
-          float *sp = src->f32;
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp = src->f32;
           int w = (int)width;
           wasm_deinterleave32(dpl, dph, sp, w);
-        }
+        }        
 
-        si32 *hp = hdst->i32, *lp = ldst->i32;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si32* hp = hdst->i32, * lp = ldst->i32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
           // first lifting step
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -638,8 +631,8 @@ namespace ojph
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const si32 *sp = lp;
-          si32 *dp = hp;
+          const si32* sp = lp;
+          si32* dp = hp;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)h_width;
@@ -647,55 +640,55 @@ namespace ojph
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t v = wasm_i32x4_add(vb, t);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t v = wasm_i32x4_add(vb, t);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t w = wasm_i32x4_shr(t, e);
                 d = wasm_i32x4_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t w = wasm_i32x4_shr(t, e);
                 d = wasm_i32x4_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
           else if (a == -1)
@@ -704,71 +697,66 @@ namespace ojph
             if (even)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t v = wasm_i32x4_sub(vb, t);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t v = wasm_i32x4_sub(vb, t);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
-          else
+          else 
           { // general case
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t u = wasm_i32x4_mul(va, t);
                 v128_t v = wasm_i32x4_add(vb, u);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
-                v128_t u = wasm_i32x4_mul(va, t);
+                v128_t u = wasm_i32x4_mul(va, t);                
                 v128_t v = wasm_i32x4_add(vb, u);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
 
           // swap buffers
-          si32 *t = lp;
-          lp = hp;
-          hp = t;
+          si32* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->i32[0] = src->i32[0];
         else
@@ -777,29 +765,30 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static void wasm_rev_horz_ana64(const param_atk *atk, const line_buf *ldst,
-                                    const line_buf *hdst, const line_buf *src,
-                                    ui32 width, bool even)
+    static
+    void wasm_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
+                             const line_buf* hdst, const line_buf* src, 
+                             ui32 width, bool even)
     {
       if (width > 1)
       {
         // combine both lsrc and hsrc into dst
         {
-          double *dpl = (double *)(even ? ldst->p : hdst->p);
-          double *dph = (double *)(even ? hdst->p : ldst->p);
-          double *sp = (double *)src->p;
+          double* dpl = (double*)(even ? ldst->p : hdst->p);
+          double* dph = (double*)(even ? hdst->p : ldst->p);
+          double* sp  = (double*)src->p;
           int w = (int)width;
           wasm_deinterleave64(dpl, dph, sp, w);
-        }
+        }        
 
-        si64 *hp = hdst->i64, *lp = ldst->i64;
-        ui32 l_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 h_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si64* hp = hdst->i64, * lp = ldst->i64;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = num_steps; j > 0; --j)
         {
           // first lifting step
-          const lifting_step *s = atk->get_step(j - 1);
+          const lifting_step* s = atk->get_step(j - 1);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -810,8 +799,8 @@ namespace ojph
           lp[-1] = lp[0];
           lp[l_width] = lp[l_width - 1];
           // lifting step
-          const si64 *sp = lp;
-          si64 *dp = hp;
+          const si64* sp = lp;
+          si64* dp = hp;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)h_width;
@@ -819,55 +808,55 @@ namespace ojph
             {
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t v = wasm_i64x2_add(vb, t);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t v = wasm_i64x2_add(vb, t);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t w = wasm_i64x2_shr(t, e);
                 d = wasm_i64x2_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t w = wasm_i64x2_shr(t, e);
                 d = wasm_i64x2_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
           else if (a == -1)
@@ -876,71 +865,66 @@ namespace ojph
             if (even)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t v = wasm_i64x2_sub(vb, t);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t v = wasm_i64x2_sub(vb, t);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
-          else
+          else 
           { // general case
             int i = (int)h_width;
             if (even)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t u = wasm_i64x2_mul(va, t);
                 v128_t v = wasm_i64x2_add(vb, u);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
-                v128_t u = wasm_i64x2_mul(va, t);
+                v128_t u = wasm_i64x2_mul(va, t);                
                 v128_t v = wasm_i64x2_add(vb, u);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
 
           // swap buffers
-          si64 *t = lp;
-          lp = hp;
-          hp = t;
+          si64* t = lp; lp = hp; hp = t;
           even = !even;
-          ui32 w = l_width;
-          l_width = h_width;
-          h_width = w;
+          ui32 w = l_width; l_width = h_width; h_width = w;
         }
       }
-      else
-      {
+      else {
         if (even)
           ldst->i64[0] = src->i64[0];
         else
@@ -949,40 +933,40 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_ana(const param_atk *atk, const line_buf *ldst,
-                           const line_buf *hdst, const line_buf *src,
+    void wasm_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
+                           const line_buf* hdst, const line_buf* src, 
                            ui32 width, bool even)
     {
-      if (src->flags & line_buf::LFT_32BIT)
+      if (src->flags & line_buf::LFT_32BIT) 
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
                (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
         wasm_rev_horz_ana32(atk, ldst, hdst, src, width, even);
       }
-      else
+      else 
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
                (src == NULL || src->flags & line_buf::LFT_64BIT));
         wasm_rev_horz_ana64(atk, ldst, hdst, src, width, even);
       }
-    }
+    } 
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_syn32(const param_atk *atk, const line_buf *dst,
-                             const line_buf *lsrc, const line_buf *hsrc,
+    void wasm_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
+                             const line_buf* lsrc, const line_buf* hsrc, 
                              ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        si32 *oth = hsrc->i32, *aug = lsrc->i32;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si32* oth = hsrc->i32, * aug = lsrc->i32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -993,8 +977,8 @@ namespace ojph
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const si32 *sp = oth;
-          si32 *dp = aug;
+          const si32* sp = oth;
+          si32* dp = aug;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)aug_width;
@@ -1002,55 +986,55 @@ namespace ojph
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t v = wasm_i32x4_add(vb, t);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t v = wasm_i32x4_add(vb, t);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t w = wasm_i32x4_shr(t, e);
                 d = wasm_i32x4_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t w = wasm_i32x4_shr(t, e);
                 d = wasm_i32x4_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
           else if (a == -1)
@@ -1059,102 +1043,97 @@ namespace ojph
             if (ev)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t v = wasm_i32x4_sub(vb, t);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t v = wasm_i32x4_sub(vb, t);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
-          else
+          else 
           { // general case
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
                 v128_t u = wasm_i32x4_mul(va, t);
                 v128_t v = wasm_i32x4_add(vb, u);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 4, sp += 4, dp += 4)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
-                v128_t u = wasm_i32x4_mul(va, t);
+                v128_t u = wasm_i32x4_mul(va, t);                
                 v128_t v = wasm_i32x4_add(vb, u);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
 
           // swap buffers
-          si32 *t = aug;
-          aug = oth;
-          oth = t;
+          si32* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          float *dp = dst->f32;
-          float *spl = even ? lsrc->f32 : hsrc->f32;
-          float *sph = even ? hsrc->f32 : lsrc->f32;
+          float* dp = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           wasm_interleave32(dp, spl, sph, w);
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->i32[0] = lsrc->i32[0];
         else
           dst->i32[0] = hsrc->i32[0] >> 1;
       }
     }
-
+    
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_syn64(const param_atk *atk, const line_buf *dst,
-                             const line_buf *lsrc, const line_buf *hsrc,
+    void wasm_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
+                             const line_buf* lsrc, const line_buf* hsrc, 
                              ui32 width, bool even)
     {
       if (width > 1)
       {
         bool ev = even;
-        si64 *oth = hsrc->i64, *aug = lsrc->i64;
-        ui32 aug_width = (width + (even ? 1 : 0)) >> 1; // low pass
-        ui32 oth_width = (width + (even ? 0 : 1)) >> 1; // high pass
+        si64* oth = hsrc->i64, * aug = lsrc->i64;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
         ui32 num_steps = atk->get_num_steps();
         for (ui32 j = 0; j < num_steps; ++j)
         {
-          const lifting_step *s = atk->get_step(j);
+          const lifting_step* s = atk->get_step(j);
           const si32 a = s->rev.Aatk;
           const si32 b = s->rev.Batk;
           const ui8 e = s->rev.Eatk;
@@ -1165,8 +1144,8 @@ namespace ojph
           oth[-1] = oth[0];
           oth[oth_width] = oth[oth_width - 1];
           // lifting step
-          const si64 *sp = oth;
-          si64 *dp = aug;
+          const si64* sp = oth;
+          si64* dp = aug;
           if (a == 1)
           { // 5/3 update and any case with a == 1
             int i = (int)aug_width;
@@ -1174,55 +1153,55 @@ namespace ojph
             {
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t v = wasm_i64x2_add(vb, t);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             }
             else
             {
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t v = wasm_i64x2_add(vb, t);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             }
           }
           else if (a == -1 && b == 1 && e == 1)
-          { // 5/3 predict
+          {  // 5/3 predict
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t w = wasm_i64x2_shr(t, e);
                 d = wasm_i64x2_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t w = wasm_i64x2_shr(t, e);
                 d = wasm_i64x2_add(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
           else if (a == -1)
@@ -1231,80 +1210,75 @@ namespace ojph
             if (ev)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t v = wasm_i64x2_sub(vb, t);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t v = wasm_i64x2_sub(vb, t);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
-          else
+          else 
           { // general case
             int i = (int)aug_width;
             if (ev)
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp - 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
                 v128_t u = wasm_i64x2_mul(va, t);
                 v128_t v = wasm_i64x2_add(vb, u);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
             else
               for (; i > 0; i -= 2, sp += 2, dp += 2)
               {
-                v128_t s1 = wasm_v128_load((v128_t *)sp);
-                v128_t s2 = wasm_v128_load((v128_t *)(sp + 1));
-                v128_t d = wasm_v128_load((v128_t *)dp);
+                v128_t s1 = wasm_v128_load((v128_t*)sp);
+                v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
+                v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
-                v128_t u = wasm_i64x2_mul(va, t);
+                v128_t u = wasm_i64x2_mul(va, t);                
                 v128_t v = wasm_i64x2_add(vb, u);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_sub(d, w);
-                wasm_v128_store((v128_t *)dp, d);
+                wasm_v128_store((v128_t*)dp, d);
               }
           }
 
           // swap buffers
-          si64 *t = aug;
-          aug = oth;
-          oth = t;
+          si64* t = aug; aug = oth; oth = t;
           ev = !ev;
-          ui32 w = aug_width;
-          aug_width = oth_width;
-          oth_width = w;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
         }
 
         // combine both lsrc and hsrc into dst
         {
-          double *dp = (double *)dst->p;
-          double *spl = (double *)(even ? lsrc->p : hsrc->p);
-          double *sph = (double *)(even ? hsrc->p : lsrc->p);
+          double* dp  = (double*)dst->p;
+          double* spl = (double*)(even ? lsrc->p : hsrc->p);
+          double* sph = (double*)(even ? hsrc->p : lsrc->p);
           int w = (int)width;
           wasm_interleave64(dp, spl, sph, w);
         }
       }
-      else
-      {
+      else {
         if (even)
           dst->i64[0] = lsrc->i64[0];
         else
@@ -1313,24 +1287,24 @@ namespace ojph
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_syn(const param_atk *atk, const line_buf *dst,
-                           const line_buf *lsrc, const line_buf *hsrc,
+    void wasm_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
+                           const line_buf* lsrc, const line_buf* hsrc, 
                            ui32 width, bool even)
     {
-      if (dst->flags & line_buf::LFT_32BIT)
+      if (dst->flags & line_buf::LFT_32BIT) 
       {
-        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
                (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
         wasm_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
       }
-      else
+      else 
       {
         assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
                (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
         wasm_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
       }
-    }
+    } 
 
   } // !local
 } // !ojph

--- a/Native/POSIX64/CMakeLists.txt
+++ b/Native/POSIX64/CMakeLists.txt
@@ -413,6 +413,7 @@ SET(OPJH_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/../Common/OpenJPH/others/ojph_arch.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../Common/OpenJPH/others/ojph_file.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../Common/OpenJPH/others/ojph_mem.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../Common/OpenJPH/others/ojph_mem_c.c
   ${CMAKE_CURRENT_SOURCE_DIR}/../Common/OpenJPH/others/ojph_message.cpp
 
   ${CMAKE_CURRENT_SOURCE_DIR}/../Common/OpenJPH/transform/ojph_colour.h

--- a/Native/Windows64/build_arm64/Dicom.Native.vcxproj
+++ b/Native/Windows64/build_arm64/Dicom.Native.vcxproj
@@ -387,6 +387,10 @@
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">false</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</CompileAsManaged>
     </ClCompile>
+    <ClCompile Include="..\..\Common\OpenJPH\others\ojph_mem_c.c">
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</CompileAsManaged>
+    </ClCompile>
     <ClCompile Include="..\..\Common\OpenJPH\others\ojph_message.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">false</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</CompileAsManaged>

--- a/Native/Windows64/build_x64/Dicom.Native.vcxproj
+++ b/Native/Windows64/build_x64/Dicom.Native.vcxproj
@@ -415,6 +415,10 @@
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
     </ClCompile>
+    <ClCompile Include="..\..\Common\OpenJPH\others\ojph_mem_c.c">
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
+    </ClCompile>
     <ClCompile Include="..\..\Common\OpenJPH\others\ojph_message.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>


### PR DESCRIPTION
Uplift OpenJPH 0.21.2 -> 0.29.0

Replace the vendored OpenJPH HTJ2K codec sources with pristine upstream
OpenJPH v0.29.0 (https://github.com/aous72/OpenJPH).

Why this matters / merge priority
---------------------------------
This codec decodes HTJ2K (JPEG 2000 Part 15) compressed pixel data that
originates from arbitrary, attacker-controllable DICOM inputs. Any memory-
safety or decoder-robustness defect in OpenJPH is therefore directly
exposed to untrusted data at the parsing boundary.

The vendored copy is pinned to OpenJPH 0.21.2, which is ~1.5 years behind
upstream. Every downstream consumer of fo-dicom.Codecs is stuck on that
stale revision and cannot pick up the bug fixes and decoder hardening that
have landed upstream since then. The local build-compat patches that
previously justified holding back are now redundant (they were adopted
upstream), so there is no longer a technical reason to stay on 0.21.2.

Landing this promptly:
- Closes the gap to current upstream so security and robustness fixes flow
  to all consumers instead of being blocked on a divergent local fork.
- Removes the maintenance burden / risk of carrying a hand-patched copy,
  which makes future security updates a clean drop-in rather than a manual
  re-patch.
- Unblocks downstream security remediation work that requires the current
  OpenJPH revision.

Why
---
The previously vendored OpenJPH 0.21.2 carried a set of local build-compat
patches (per-arch SIMD #if guards, MSVC ARM64 handling in ojph_arch.h).
Those changes have since been adopted upstream, so 0.29.0 builds cleanly in
this project's static, multi-arch configuration with no local patches. This
brings in ~1.5 years of upstream bug fixes and performance work and removes
the maintenance burden of the local fork.

What changed
------------
- Source: dropped in pristine upstream 0.29.0 for codestream/, coding/,
  others/, transform/, and the headers (upstream src/core/openjph/* map to
  the vendored flattened common/ directory; 0.29.0 uses bare includes so no
  include-path changes are needed).
- New header coding/ojph_block_encoder_avx2_apple.h (Apple AVX2 support).
- New C source others/ojph_mem_c.c: 0.29.0 moved the aligned_malloc/free
  implementations into a dedicated C translation unit (declared extern "C"
  in openjph/ojph_mem.h, called from others/ojph_file.cpp). It is added to
  the POSIX CMakeLists and both Windows vcxproj build lists. Its .c extension
  makes the toolchains compile it as C, matching the extern "C" linkage the
  C++ callers expect.
- No local build-compat shims are re-applied (all are upstream in 0.29.0).
- The vendor-specific interface/ shim (encoded_buffer.h, ojph_interface.{h,cpp})
  is unchanged; it uses only OpenJPH's stable public API.

Validation
----------
Native Dicom.Native builds clean on all six target platforms (win-x64,
win-arm64, linux-x64, linux-arm64, osx-x64, osx-arm64) via the project's
build files. Bit-exact codec correctness should be confirmed with the
maintainer's acceptance-test suite.
