### PR TITLE
Add SPDX SBOM for vendored native codec libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ As with any application, the temporary files won't be deleted in case of a crash
 
 ## Dependencies
 
+### Software Bill of Materials (SBOM)
+
+The native imaging codecs are provided by third-party C/C++ libraries that are
+*vendored* into this repository (their source lives under `Native/Common/` and
+is statically linked into the `Dicom.Native` binary). Because they are not
+NuGet packages, they are invisible to NuGet/Dependabot, so they are enumerated
+in an [SPDX 2.3](https://spdx.dev/) SBOM at
+[`fo-dicom.Codecs.spdx.json`](fo-dicom.Codecs.spdx.json) for supply-chain and
+license tracking. The vendored codecs are: libijg, OpenJPEG, CharLS, and
+OpenJPH. When a vendored codec is added, removed, or version-bumped, update the
+SBOM (and `LICENSE.txt`) to match.
+
 ### Windows
 It is required to have Visual C++ Redistributable v14 installed in the target Windows machine. Otherwise, it will throw a runtime error:
 

--- a/fo-dicom.Codecs.spdx.json
+++ b/fo-dicom.Codecs.spdx.json
@@ -1,0 +1,142 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "fo-dicom.Codecs",
+  "documentNamespace": "https://github.com/Efferent-Health/fo-dicom.Codecs/sbom/8f0a5d2c-3b6e-4a1d-9c77-2f1b6a4e0d31",
+  "creationInfo": {
+    "created": "2026-06-18T00:00:00Z",
+    "creators": [
+      "Tool: hand-authored",
+      "Organization: fo-dicom.Codecs contributors"
+    ],
+    "comment": "Software Bill of Materials for the fo-dicom.Codecs native imaging codec library. This SBOM primarily documents the third-party C/C++ codec libraries that are vendored (their source is copied into this repository, under Native/Common/, and statically linked into the Dicom.Native binary) rather than consumed as managed/binary package dependencies. Vendored components are not visible to NuGet/Dependabot, so they are enumerated here for supply-chain and license tracking."
+  },
+  "packages": [
+    {
+      "name": "fo-dicom.Codecs",
+      "SPDXID": "SPDXRef-Package-fo-dicom.Codecs",
+      "downloadLocation": "https://github.com/Efferent-Health/fo-dicom.Codecs",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MS-PL",
+      "licenseDeclared": "MS-PL",
+      "copyrightText": "Copyright (c) fo-dicom contributors",
+      "supplier": "Organization: Efferent Health",
+      "primaryPackagePurpose": "LIBRARY",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:nuget/fo-dicom.Codecs"
+        }
+      ]
+    },
+    {
+      "name": "libijg",
+      "SPDXID": "SPDXRef-Package-libijg",
+      "versionInfo": "6b",
+      "downloadLocation": "https://www.ijg.org/files/jpegsrc.v6b.tar.gz",
+      "filesAnalyzed": false,
+      "licenseConcluded": "IJG",
+      "licenseDeclared": "IJG",
+      "copyrightText": "Copyright (C) 1991-1998, Thomas G. Lane",
+      "supplier": "Organization: Independent JPEG Group",
+      "primaryPackagePurpose": "LIBRARY",
+      "comment": "Vendored (source copied into Native/Common/libijg8, Native/Common/libijg12, Native/Common/libijg16 and statically linked). Independent JPEG Group libjpeg 6b with the DCMTK lossless-JPEG extension; provides the JPEG baseline/extended/lossless processes. Built three times for 8/12/16-bit sample precision.",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/libijg@6b?download_url=https://www.ijg.org/files/jpegsrc.v6b.tar.gz"
+        }
+      ]
+    },
+    {
+      "name": "openjpeg",
+      "SPDXID": "SPDXRef-Package-openjpeg",
+      "versionInfo": "2.5.4",
+      "downloadLocation": "https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.5.4.tar.gz",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-2-Clause",
+      "licenseDeclared": "BSD-2-Clause",
+      "copyrightText": "Copyright (c) 2002-2014, Universite catholique de Louvain (UCL), Belgium; Copyright (c) 2002-2014, Professor Benoit Macq, and others",
+      "supplier": "Organization: Universite catholique de Louvain (UCL)",
+      "primaryPackagePurpose": "LIBRARY",
+      "comment": "Vendored (source copied into Native/Common/OpenJPEG and statically linked). Provides the JPEG 2000 codec.",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:github/uclouvain/openjpeg@v2.5.4"
+        }
+      ]
+    },
+    {
+      "name": "charls",
+      "SPDXID": "SPDXRef-Package-charls",
+      "versionInfo": "2.4.2",
+      "downloadLocation": "https://github.com/team-charls/charls/archive/refs/tags/2.4.2.tar.gz",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "copyrightText": "Copyright (c) Team CharLS",
+      "supplier": "Organization: Team CharLS",
+      "primaryPackagePurpose": "LIBRARY",
+      "comment": "Vendored (source copied into Native/Common/CharLS and statically linked). Provides the JPEG-LS codec.",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:github/team-charls/charls@2.4.2"
+        }
+      ]
+    },
+    {
+      "name": "openjph",
+      "SPDXID": "SPDXRef-Package-openjph",
+      "versionInfo": "0.21.2",
+      "downloadLocation": "https://github.com/aous72/OpenJPH/archive/refs/tags/0.21.2.tar.gz",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-2-Clause",
+      "licenseDeclared": "BSD-2-Clause",
+      "copyrightText": "Copyright (c) 2019, Aous Naman; Copyright (c) 2019, Kakadu Software Pty Ltd, Australia; Copyright (c) 2019, The University of New South Wales, Australia",
+      "supplier": "Organization: Aous Naman / Kakadu Software Pty Ltd",
+      "primaryPackagePurpose": "LIBRARY",
+      "comment": "Vendored (source copied into Native/Common/OpenJPH and statically linked). Provides the High Throughput JPEG 2000 (HTJ2K) codec.",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:github/aous72/OpenJPH@0.21.2"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-fo-dicom.Codecs"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fo-dicom.Codecs",
+      "relationshipType": "STATIC_LINK",
+      "relatedSpdxElement": "SPDXRef-Package-libijg"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fo-dicom.Codecs",
+      "relationshipType": "STATIC_LINK",
+      "relatedSpdxElement": "SPDXRef-Package-openjpeg"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fo-dicom.Codecs",
+      "relationshipType": "STATIC_LINK",
+      "relatedSpdxElement": "SPDXRef-Package-charls"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fo-dicom.Codecs",
+      "relationshipType": "STATIC_LINK",
+      "relatedSpdxElement": "SPDXRef-Package-openjph"
+    }
+  ]
+}


### PR DESCRIPTION
The native imaging codecs are provided by third-party C/C++ libraries whose source is vendored into this repository (under Native/Common/) and statically linked into the Dicom.Native binary. Because they are not NuGet packages, they are invisible to NuGet/Dependabot and were previously only tracked informally in LICENSE.txt.

Add a machine-readable SPDX 2.3 SBOM (fo-dicom.Codecs.spdx.json) that enumerates the vendored codecs with their versions, source download locations, SPDX license identifiers, suppliers, package URLs (purl), and a STATIC_LINK relationship to the top-level package:

- libijg 6b (IJG License)
- OpenJPEG 2.5.4 (BSD-2-Clause)
- CharLS 2.4.2 (BSD-3-Clause)
- OpenJPH 0.21.2 (BSD-2-Clause)

SPDX is an open ISO/IEC 5962 standard, so the file is consumable by standard SBOM/SCA tooling without any repository-specific integration. A README note points to the SBOM and asks contributors to keep it (and LICENSE.txt) in sync when a vendored codec is added, removed, or version-bumped.