### PR TITLE
Fix process crash when decoding a JPEG that references an undefined Huffman table

### DIFF
--- a/Native/Dicom.Imaging.Codec.Jpeg.cpp
+++ b/Native/Dicom.Imaging.Codec.Jpeg.cpp
@@ -404,9 +404,13 @@ namespace Dicom
                 }
 
                 // Decode
-                // Returns 0 on success, non-zero on failure. On success *out_pixels points
-                // to a malloc-allocated buffer of *out_size bytes that the caller must
-                // release with DicomJpegFreeBuffer.
+                // Returns 0 on success, non-zero on failure.
+                //
+                // out_pixels is a CALLER-OWNED buffer of at least the decoded frame size;
+                // this function only writes into it and never takes ownership of it. In
+                // particular it must not be freed here on any path: the managed caller
+                // supplies a pinned byte[] rented from ArrayPool<byte>.Shared, which is
+                // not CRT-heap memory and is returned to the pool by the caller.
                 EXPORT_Jpeg int DicomJpegDecode(
                     const unsigned char *jpegData,
                     unsigned int jpegSize,
@@ -438,8 +442,6 @@ namespace Dicom
                     if (setjmp(jerr.setjmp_buffer))
                     {
                         jpeg_destroy_decompress(&dinfo);
-                        if (out_pixels != nullptr)
-                            free(out_pixels);
                         return 1;
                     }
 
@@ -544,7 +546,6 @@ namespace Dicom
                                 errorMessage[errorMessageSize - 1] = '\0';
                             }
 
-                            free(out_pixels);
                             jpeg_destroy_decompress(&dinfo);
                             return 3;
                         }

--- a/Tests/Unit/MalformedJpegUnitTest.cs
+++ b/Tests/Unit/MalformedJpegUnitTest.cs
@@ -1,0 +1,105 @@
+using System;
+using FellowOakDicom.Imaging.Codec;
+using FellowOakDicom.IO.Buffer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FellowOakDicom.Imaging.NativeCodec.Test
+{
+    /// <summary>
+    /// Regression coverage for a malformed JPEG codestream reaching the native
+    /// decoder. A JPEG whose scan references a Huffman table that was never
+    /// defined makes libjpeg raise JERR_NO_HUFF_TABLE, which unwinds through the
+    /// decoder's setjmp handler. That error path must report the failure to the
+    /// caller, not tear the process down.
+    /// </summary>
+    [TestClass]
+    public class MalformedJpegUnitTest
+    {
+        // Minimal lossless (Process 14, SV1) codestream, 64x64, 8-bit, 1 component.
+        // The two payloads below differ ONLY by the DHT segment.
+        private const string Soi = "FFD8";
+        private const string Sof3 = "FFC3000B080040004001011100";
+        private const string Dht = "FFC4001F0000010501010101010100000000000000000102030405060708090A10";
+        private const string Sos = "FFDA0008010100010000";
+        private const string Eoi = "FFD9";
+
+        [TestInitialize]
+        public void Initialization()
+        {
+            new DicomSetupBuilder()
+                .RegisterServices(s => s.AddFellowOakDicom().AddTranscoderManager<NativeTranscoderManager>())
+                .SkipValidation()
+                .Build();
+        }
+
+        private static byte[] BuildJpeg(bool includeHuffmanTable)
+        {
+            var hex = Soi + Sof3 + (includeHuffmanTable ? Dht : string.Empty) + Sos;
+            var header = Convert.FromHexString(hex);
+            var footer = Convert.FromHexString(Eoi);
+
+            var jpeg = new byte[header.Length + 128 + footer.Length];
+            Buffer.BlockCopy(header, 0, jpeg, 0, header.Length);
+            for (var i = 0; i < 128; i++)
+            {
+                jpeg[header.Length + i] = 0x55; // entropy-coded bytes
+            }
+            Buffer.BlockCopy(footer, 0, jpeg, header.Length + 128, footer.Length);
+            return jpeg;
+        }
+
+        private static DicomDataset BuildDataset(bool includeHuffmanTable)
+        {
+            var dataset = new DicomDataset(DicomTransferSyntax.JPEGProcess14SV1);
+            dataset.AddOrUpdate(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage);
+            dataset.AddOrUpdate(DicomTag.SOPInstanceUID, DicomUID.Generate());
+            dataset.AddOrUpdate(DicomTag.Rows, (ushort)64);
+            dataset.AddOrUpdate(DicomTag.Columns, (ushort)64);
+            dataset.AddOrUpdate(DicomTag.SamplesPerPixel, (ushort)1);
+            dataset.AddOrUpdate(DicomTag.PhotometricInterpretation, "MONOCHROME2");
+            dataset.AddOrUpdate(DicomTag.BitsAllocated, (ushort)8);
+            dataset.AddOrUpdate(DicomTag.BitsStored, (ushort)8);
+            dataset.AddOrUpdate(DicomTag.HighBit, (ushort)7);
+            dataset.AddOrUpdate(DicomTag.PixelRepresentation, (ushort)0);
+            dataset.AddOrUpdate(DicomTag.NumberOfFrames, 1);
+
+            var fragments = new DicomOtherByteFragment(DicomTag.PixelData);
+            fragments.Fragments.Add(new MemoryByteBuffer(BuildJpeg(includeHuffmanTable)));
+            dataset.AddOrUpdate(fragments);
+
+            return dataset;
+        }
+
+        private static DicomDataset Decode(DicomDataset dataset)
+        {
+            var transcoder = new DicomTranscoder(dataset.InternalTransferSyntax,
+                                                 DicomTransferSyntax.ExplicitVRLittleEndian);
+            return transcoder.Transcode(dataset);
+        }
+
+        [TestMethod]
+        public void DecodeJpegMissingHuffmanTableReportsErrorInsteadOfCrashing()
+        {
+            try
+            {
+                Decode(BuildDataset(includeHuffmanTable: false));
+                Assert.Fail("Expected a DicomCodecException for a scan referencing an undefined Huffman table.");
+            }
+            catch (DicomCodecException)
+            {
+                // Expected: the libjpeg diagnostic is surfaced and the process survives.
+            }
+        }
+
+        [TestMethod]
+        public void DecodeJpegWithHuffmanTableSucceeds()
+        {
+            // Positive control: identical codestream plus the DHT segment. Guards
+            // against "fixing" the crash by disabling the decode path outright.
+            var decoded = Decode(BuildDataset(includeHuffmanTable: true));
+
+            Assert.AreEqual(DicomTransferSyntax.ExplicitVRLittleEndian, decoded.InternalTransferSyntax);
+            Assert.IsTrue(decoded.Contains(DicomTag.PixelData));
+        }
+    }
+}


### PR DESCRIPTION
`DicomJpegDecode` calls `free()` on `out_pixels`, which is a caller-owned buffer:

- `Native/Dicom.Imaging.Codec.Jpeg.cpp:442` — the `setjmp` landing pad
- `Native/Dicom.Imaging.Codec.Jpeg.cpp:547` — `jpeg_read_scanlines` returning 0

On the managed side that buffer is rented from `ArrayPool<byte>.Shared`
(`Codec/DicomJpegCodec.cs:545-548`) and the P/Invoke declares it as `byte[]`
(`Codec/DicomJpegCodec.cs:325`), so the native side receives a pinned pointer into
the GC heap. The caller returns it to the pool in its `finally` block
(`Codec/DicomJpegCodec.cs:616-621`). Releasing that pointer with the CRT allocator
is undefined behaviour, so the failure terminates the process rather than being
reported to the caller.

### Trigger

Any JPEG whose scan references a Huffman table that was never defined. libjpeg
raises `JERR_NO_HUFF_TABLE` — the check in `jdlhuff.c` is correct and present —
which unwinds through the `setjmp` handler and into the `free()`. A 64x64 lossless
(Process 14) codestream of about 156 bytes is enough. The decode loop is never
reached, which is why valid images are unaffected and only malformed input faults.

Against the release CRT:

```
Fatal error. System.AccessViolationException: Attempted to read or write protected memory.
   at FellowOakDicom.Imaging.NativeCodec.Jpeg.JpegCodec.DicomJpegDecode_win(...)
   at FellowOakDicom.Imaging.NativeCodec.Jpeg.JpegCodec.Decode(...)
   at FellowOakDicom.Imaging.Codec.DicomTranscoder.Transcode(...)
```

Building `Dicom.Native` against the debug CRT reports the same input as
`_CrtIsValidHeapPointer(block)` in `debug_heap.cpp`, which identifies the bad free
directly.

### Change

Both `free()` calls are removed, since the decoder never allocates `out_pixels`.

The doc comment above `DicomJpegDecode` still described an earlier contract in
which the buffer was allocated internally and released with `DicomJpegFreeBuffer`.
That comment is what makes the frees look intentional, so it is updated to state
the ownership rule instead.

With the change the same input produces a catchable
`DicomCodecException: Unable to JPEG decode pixel data: Huffman table 0x00 was not defined`.

### Verification

Windows x64, MSVC v143, in both Debug and Release configurations:

- `Tests/Unit/MalformedJpegUnitTest.cs` (added) crashes the test host before the
  change and passes after it. It builds both codestreams in code — they differ
  only by the DHT segment — so the positive control guards against regressing the
  fix into a disabled decode path.
- `Tests/Unit` 59/59 and `Tests/Acceptance` 300/300 pass.

Introduced in 68e7cff; present on master and in the 6.0.0 tag.

### One open question

The encode path has the same shape. `encoded` starts as the caller's `out_buffer`
(`:273`) and is freed on the error path (`:289`), while `jpeg_memory_destination`
may also have adopted it as `dest->newbuffer` (`:238`), which
`empty_mem_output_buffer` frees on the first growth (`:174`). I left it untouched
because the existing encode tests pass and I could not produce a failing case. Is
the intent there that `out_buffer` is handed over to the destination manager?
