### PR TITLE
#188: Copy the encoded/decoded frame out of the pooled array

### DIFF
--- a/Codec/DicomHtJpeg2000Codec.cs
+++ b/Codec/DicomHtJpeg2000Codec.cs
@@ -207,18 +207,23 @@ namespace FellowOakDicom.Imaging.NativeCodec
                                 throw new DicomCodecException("Error in HTJ2K encode stream => output buffer data has an incorrect size");
                             }
 
-                            pool.Resize(ref jpegHT2KData, (int)j2c_outinfo.size_outbuffer);
+                            // The pooled array is returned to the pool in the finally block below, so it
+                            // must not be handed over to the buffer: the array can be rented again and
+                            // overwritten while this dataset still points at it. Copy it out at its exact
+                            // size, the way DicomJpeg2000Codec already does.
+                            var encoded = new byte[j2c_outinfo.size_outbuffer];
+                            Buffer.BlockCopy(jpegHT2KData, 0, encoded, 0, (int)j2c_outinfo.size_outbuffer);
 
                             IByteBuffer buffer;
 
                             if (j2c_outinfo.size_outbuffer >= NativeTranscoderManager.MemoryBufferThreshold || oldPixelData.NumberOfFrames > 1)
                             {
-                                buffer = new TempFileBuffer(jpegHT2KData);
+                                buffer = new TempFileBuffer(encoded);
                                 buffer = EvenLengthBuffer.Create(buffer);
                             }
                             else
                             {
-                                buffer = new MemoryByteBuffer(jpegHT2KData);
+                                buffer = new MemoryByteBuffer(encoded);
                             }
 
                             if (oldPixelData.NumberOfFrames == 1)
@@ -296,13 +301,17 @@ namespace FellowOakDicom.Imaging.NativeCodec
                                 else
                                     InvokeHTJ2KDecode(ref raw_Outdata, (byte*)htjpeg2kArray.Pointer, (uint)htjpeg2kArray.Count); ;
 
-                                pool.Resize(ref frameData, (int)raw_Outdata.size_outbuffer);
+                                // Same reason as in Encode: copy out of the pooled array before it goes
+                                // back to the pool, and at the exact decoded size instead of the pool
+                                // bucket size.
+                                var decoded = new byte[raw_Outdata.size_outbuffer];
+                                Buffer.BlockCopy(frameData, 0, decoded, 0, (int)raw_Outdata.size_outbuffer);
 
                                 IByteBuffer buffer;
-                                if (frameData.Length >= (int)NativeTranscoderManager.MemoryBufferThreshold || oldPixelData.NumberOfFrames > 1)
-                                    buffer = new TempFileBuffer(frameData);
+                                if ((int)raw_Outdata.size_outbuffer >= (int)NativeTranscoderManager.MemoryBufferThreshold || oldPixelData.NumberOfFrames > 1)
+                                    buffer = new TempFileBuffer(decoded);
                                 else
-                                    buffer = new MemoryByteBuffer(frameData);
+                                    buffer = new MemoryByteBuffer(decoded);
 
                                 if (oldPixelData.NumberOfFrames == 1)
                                     buffer = EvenLengthBuffer.Create(buffer);

--- a/Codec/DicomJpegLsCodec.cs
+++ b/Codec/DicomJpegLsCodec.cs
@@ -293,18 +293,23 @@ namespace FellowOakDicom.Imaging.NativeCodec
                             else
                                 err = JpegLSEncode(jpegDataPointer, (uint)jpeglsData.Length, &jpegDataSize, (void*)frameArray.Pointer, (uint)frameArray.Count, ref jls, errorMessage);
 
-                            pool.Resize(ref jpeglsData, (int)jpegDataSize);
+                            // The pooled array is returned to the pool in the finally block below, so it
+                            // must not be handed over to the buffer: the array can be rented again and
+                            // overwritten while this dataset still points at it. Copy it out at its exact
+                            // size, the way DicomJpeg2000Codec already does.
+                            var encoded = new byte[jpegDataSize];
+                            Buffer.BlockCopy(jpeglsData, 0, encoded, 0, (int)jpegDataSize);
 
                             IByteBuffer buffer;
 
                             if (jpegDataSize >= NativeTranscoderManager.MemoryBufferThreshold || oldPixelData.NumberOfFrames > 1)
                             {
-                                buffer = new TempFileBuffer(jpeglsData);
+                                buffer = new TempFileBuffer(encoded);
                                 buffer = EvenLengthBuffer.Create(buffer);
                             }
                             else
                             {
-                                buffer = new MemoryByteBuffer(jpeglsData);
+                                buffer = new MemoryByteBuffer(encoded);
                             }
 
                             if (oldPixelData.NumberOfFrames == 1)
@@ -371,7 +376,8 @@ namespace FellowOakDicom.Imaging.NativeCodec
                 PinnedByteArray jpeglsArray = new PinnedByteArray(jpegData.Data);
 
                 var pool = ArrayPool<byte>.Shared;
-                byte[] frameData = pool.Rent(uncompressedSize > newPixelData.UncompressedFrameSize ? uncompressedSize : newPixelData.UncompressedFrameSize);
+                var frameSize = uncompressedSize > newPixelData.UncompressedFrameSize ? uncompressedSize : newPixelData.UncompressedFrameSize;
+                byte[] frameData = pool.Rent(frameSize);
                 PinnedByteArray frameArray = new PinnedByteArray(frameData);
 
                 try
@@ -389,11 +395,16 @@ namespace FellowOakDicom.Imaging.NativeCodec
                         else
                             err = JpegLSDecode((void*)frameArray.Pointer, frameData.Length, (void*)jpeglsArray.Pointer, Convert.ToUInt32(jpegData.Size), ref jls, errorMessage);
 
+                        // Same reason as in Encode: copy out of the pooled array before it goes back
+                        // to the pool, and at the exact frame size instead of the pool bucket size.
+                        var decoded = new byte[frameSize];
+                        Buffer.BlockCopy(frameData, 0, decoded, 0, frameSize);
+
                         IByteBuffer buffer;
-                        if (frameData.Length >= (int)NativeTranscoderManager.MemoryBufferThreshold || oldPixelData.NumberOfFrames > 1)
-                            buffer = new TempFileBuffer(frameData);
+                        if (frameSize >= (int)NativeTranscoderManager.MemoryBufferThreshold || oldPixelData.NumberOfFrames > 1)
+                            buffer = new TempFileBuffer(decoded);
                         else
-                            buffer = new MemoryByteBuffer(frameData);
+                            buffer = new MemoryByteBuffer(decoded);
 
                         if (oldPixelData.NumberOfFrames == 1)
                             buffer = EvenLengthBuffer.Create(buffer);


### PR DESCRIPTION
# Copy the encoded/decoded frame out of the pooled array

NB: this is originally an IA commit, but I think it is worth posting it here

Fixes the frame corruption described in #188 — the one that survived the #133 fix.

## What is wrong

`DicomJpegLsCodec` and `DicomHtJpeg2000Codec` hand the `ArrayPool<byte>.Shared` array **itself** to the `IByteBuffer` stored in the dataset, then return that same array to the pool in their `finally` block:

```csharp
var jpeglsData = pool.Rent((int)frameData.Size);
try
{
    ...
    pool.Resize(ref jpeglsData, (int)jpegDataSize);
    buffer = new MemoryByteBuffer(jpeglsData);   // the pooled array itself
    newPixelData.AddFrame(buffer);
}
finally
{
    pool.Return(jpeglsData);                     // handed back while still referenced
}
```

The dataset then points at memory that belongs to the pool again, and the next tenant of that array overwrites the frame.

`pool.Resize` does not protect anything: it is the `CommunityToolkit.HighPerformance` extension, which rents a *new* array from the next bucket and copies into it. The buffer handed to the dataset is therefore bucket-sized — 65536, 131072, 262144 … — and the bytes past the encoded stream are whatever the previous tenant left there.

Removing the duplicate `pool.Return` in 5.16.5 addressed a real bug, but not this one. The corruption reproduces unchanged on 5.16.7 and on 6.0.0-beta1.

`DicomJpeg2000Codec` already carries the right pattern — the pooled path is commented out in favour of an exact-size copy. This PR applies the same treatment to the two codecs that were left behind.

## What this changes

For each of the four sites (`Encode` and `Decode` in both codecs):

- copy the frame out of the pooled array at its **exact** size, before the `finally` returns it;
- hand the copy to `TempFileBuffer` / `MemoryByteBuffer`;
- drop the `pool.Resize` call, now pointless;
- compare the threshold against the real size rather than `array.Length`.

`Rent` / `Return` stay symmetric, and the pooled array never leaves the method. 35 lines added, 14 removed, no public API change, no native code involved.

Side effect worth noting: fragments are no longer padded to the pool bucket size. On a 269-instance study the stored volume dropped by 63 %.

## Verification

Environment: .NET 8, Linux x64, `fo-dicom` 5.2.5 / 5.2.6, MR images 512×512, `BitsAllocated` 16, signed, MONOCHROME2.

**Your unit tests.** With the official 5.16.7 native binary in place, `Tests/Unit` passes **57/57** on the 5.16.7 tag, both before and after the patch. On `master` the same suite gives 25 failures out of 59 both before and after, because the 5.16.7 native library does not match what master expects — unchanged by this PR either way.

**Reproduction from the issue.** 8 instances decoded to Explicit VR Little Endian and saved to disk, then re-encoded to JPEG-LS Lossless, reading the frames either immediately or once the batch is over. Distinct fragments out of 8:

| build | sequential, read now | parallel, read now | sequential, read later | parallel, read later | fragment length |
|---|---|---|---|---|---|
| 5.16.7 as published | 8/8 | 8/8 | **1/8** | **4/8** | power of two, 1 048 576 bytes total |
| 5.16.7 + this patch | 8/8 | 8/8 | **8/8** | **8/8** | exact, 775 046 bytes for 775 043 useful |
| 5.12.0, last unaffected release | 8/8 | 8/8 | 8/8 | 8/8 | exact |

**Round trip across transfer syntaxes**, patched build, encode then decode, compared against the original pixels:

| transfer syntax | encoded size | round trip |
|---|---|---|
| JPEG-LS Lossless `.80` | 89 184 | pixels identical |
| JPEG-LS Near-lossless `.81` | 36 750 | decodes |
| JPEG 2000 Lossless `.90` | 80 036 | pixels identical |
| JPEG 2000 Lossy `.91` | 26 182 | decodes |
| JPEG Lossless SV1 `.70` | 135 474 | pixels identical |
| RLE Lossless | 249 606 | pixels identical |

HT JPEG 2000 could not be exercised here — no HTJ2K data set at hand. Its two sites received the identical treatment, so review is welcome there.
