### PR TITLE
Reject a JPEG 2000 codestream that does not fit the declared pixel buffer

### DIFF
--- a/Codec/DicomJpeg2000Codec.cs
+++ b/Codec/DicomJpeg2000Codec.cs
@@ -1107,6 +1107,14 @@ namespace FellowOakDicom.Imaging.NativeCodec
                                 pixelCount = (int)(image->x1 * image->y1);
                             }
 
+                            //The extraction below writes numcomps samples per pixel over an extent taken from
+                            //the codestream, into a buffer sized from the geometry the dataset declares.
+                            //Compare against what was actually allocated rather than recomputing that size,
+                            //so the check holds even where the sizing arithmetic above overflows. Only the
+                            //larger-than case is rejected, so a smaller codestream decodes as it always has.
+                            if ((ulong)image->x1 * image->y1 * image->numcomps * (ulong)oldPixelData.BytesAllocated > (ulong)destArray.Count)
+                                throw new DicomCodecException("Error in JPEG 2000 decode stream => output image is larger than the pixel buffer the dataset declares");
+
                             for (int c = 0; c < image->numcomps; c++)
                             {
                                 opj_image_comp_t* comp = &image->comps[c];

--- a/Tests/Unit/Jpeg2000GeometryUnitTest.cs
+++ b/Tests/Unit/Jpeg2000GeometryUnitTest.cs
@@ -1,0 +1,206 @@
+using FellowOakDicom.Imaging.Codec;
+using FellowOakDicom.IO.Buffer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FellowOakDicom.Imaging.NativeCodec.Test
+{
+    /// <summary>
+    /// Regression coverage for a JPEG 2000 codestream whose extent disagrees with
+    /// the geometry the dataset declares. Decode sizes its destination buffer from
+    /// Rows/Columns/BitsAllocated/SamplesPerPixel, but drives the extraction loop
+    /// from the codestream's own x1/y1. The two were never compared, so a
+    /// codestream covering a larger extent than the declared geometry wrote past
+    /// the end of the buffer.
+    /// </summary>
+    [TestClass]
+    public class Jpeg2000GeometryUnitTest
+    {
+        // Side of the image handed to the encoder, and therefore the extent the
+        // resulting codestream reports. The declared geometry is rewritten
+        // afterwards, so it can differ from this in either direction.
+        private const ushort CodestreamSide = 64;
+
+        [TestInitialize]
+        public void Initialization()
+        {
+            new DicomSetupBuilder()
+                .RegisterServices(s => s.AddFellowOakDicom().AddTranscoderManager<NativeTranscoderManager>())
+                .SkipValidation()
+                .Build();
+        }
+
+        /// <summary>
+        /// Encodes a square image with the JPEG 2000 encoder, then rewrites Rows and
+        /// Columns on the encapsulated dataset. The codestream is left untouched, so
+        /// its extent no longer matches the geometry the dataset declares.
+        /// </summary>
+        private static DicomDataset BuildEncoded(ushort bitsAllocated, ushort declaredSide)
+        {
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
+            dataset.AddOrUpdate(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage);
+            dataset.AddOrUpdate(DicomTag.SOPInstanceUID, DicomUID.Generate());
+            dataset.AddOrUpdate(DicomTag.Rows, CodestreamSide);
+            dataset.AddOrUpdate(DicomTag.Columns, CodestreamSide);
+            dataset.AddOrUpdate(DicomTag.SamplesPerPixel, (ushort)1);
+            dataset.AddOrUpdate(DicomTag.PhotometricInterpretation, "MONOCHROME2");
+            dataset.AddOrUpdate(DicomTag.BitsAllocated, bitsAllocated);
+            dataset.AddOrUpdate(DicomTag.BitsStored, bitsAllocated);
+            dataset.AddOrUpdate(DicomTag.HighBit, (ushort)(bitsAllocated - 1));
+            dataset.AddOrUpdate(DicomTag.PixelRepresentation, (ushort)0);
+            dataset.AddOrUpdate(DicomTag.NumberOfFrames, 1);
+
+            var pixels = new byte[CodestreamSide * CodestreamSide * (bitsAllocated / 8)];
+            for (var i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = (byte)(i & 0xFF);
+            }
+
+            DicomPixelData.Create(dataset, true).AddFrame(new MemoryByteBuffer(pixels));
+
+            var encoded = dataset.Clone(DicomTransferSyntax.JPEG2000Lossless);
+            encoded.AddOrUpdate(DicomTag.Rows, declaredSide);
+            encoded.AddOrUpdate(DicomTag.Columns, declaredSide);
+            return encoded;
+        }
+
+        /// <summary>
+        /// Builds a 3-component (RGB) codestream and then declares SamplesPerPixel=1
+        /// on the encapsulated dataset. Rows and Columns are left agreeing with the
+        /// codestream, so the per-pixel extent matches and only the samples-per-pixel
+        /// factor is wrong.
+        /// </summary>
+        private static DicomDataset BuildEncodedWithComponentMismatch(ushort bitsAllocated)
+        {
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
+            dataset.AddOrUpdate(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage);
+            dataset.AddOrUpdate(DicomTag.SOPInstanceUID, DicomUID.Generate());
+            dataset.AddOrUpdate(DicomTag.Rows, CodestreamSide);
+            dataset.AddOrUpdate(DicomTag.Columns, CodestreamSide);
+            dataset.AddOrUpdate(DicomTag.SamplesPerPixel, (ushort)3);
+            dataset.AddOrUpdate(DicomTag.PhotometricInterpretation, "RGB");
+            dataset.AddOrUpdate(DicomTag.PlanarConfiguration, (ushort)0);
+            dataset.AddOrUpdate(DicomTag.BitsAllocated, bitsAllocated);
+            dataset.AddOrUpdate(DicomTag.BitsStored, bitsAllocated);
+            dataset.AddOrUpdate(DicomTag.HighBit, (ushort)(bitsAllocated - 1));
+            dataset.AddOrUpdate(DicomTag.PixelRepresentation, (ushort)0);
+
+            var pixels = new byte[CodestreamSide * CodestreamSide * 3 * (bitsAllocated / 8)];
+            for (var i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = (byte)(i & 0xFF);
+            }
+
+            DicomPixelData.Create(dataset, true).AddFrame(new MemoryByteBuffer(pixels));
+
+            var encoded = dataset.Clone(DicomTransferSyntax.JPEG2000Lossless);
+            encoded.AddOrUpdate(DicomTag.SamplesPerPixel, (ushort)1);
+            encoded.AddOrUpdate(DicomTag.PhotometricInterpretation, "MONOCHROME2");
+            return encoded;
+        }
+
+        [TestMethod]
+        [DataRow((ushort)8)]
+        [DataRow((ushort)16)]
+        public void DecodeJpeg2000LargerThanDeclaredGeometryReportsErrorInsteadOfOverrunning(ushort bitsAllocated)
+        {
+            // A 64x64 codestream against a dataset declaring 8x8: extraction would
+            // write 4096 pixels into a buffer sized for 64 of them.
+            var encoded = BuildEncoded(bitsAllocated, 8);
+
+            try
+            {
+                encoded.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
+                Assert.Fail("Expected a DicomCodecException for a codestream larger than the declared geometry.");
+            }
+            catch (DicomCodecException e)
+            {
+                // Assert on the message, not just the type. The 8-bit extractor writes
+                // through a bounds-checked managed array and already surfaced a wrapped
+                // IndexOutOfRangeException before this guard existed, so a bare
+                // catch(DicomCodecException) would pass with or without the fix.
+                StringAssert.Contains(e.Message, "larger than the pixel buffer");
+            }
+        }
+
+        [TestMethod]
+        [DataRow((ushort)8)]
+        [DataRow((ushort)16)]
+        public void DecodeJpeg2000MoreComponentsThanDeclaredReportsErrorInsteadOfOverrunning(ushort bitsAllocated)
+        {
+            // Same pixel extent, three samples per pixel in the codestream against a
+            // dataset declaring one. Comparing pixel counts alone misses this: the
+            // buffer holds Width*Height samples while extraction writes three times
+            // that, so the geometry check has to carry the samples-per-pixel factor.
+            var encoded = BuildEncodedWithComponentMismatch(bitsAllocated);
+
+            try
+            {
+                encoded.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
+                Assert.Fail("Expected a DicomCodecException for a codestream with more components than declared.");
+            }
+            catch (DicomCodecException e)
+            {
+                StringAssert.Contains(e.Message, "larger than the pixel buffer");
+            }
+        }
+
+        [TestMethod]
+        public void DecodeJpeg2000GeometryOverflowingTheSizeComputationReportsErrorInsteadOfOverrunning()
+        {
+            // Rows*Columns*SamplesPerPixel*BytesAllocated is computed in int, so this
+            // geometry wraps to a small positive buffer (1,830,704 bytes) rather than
+            // the ~4.3 GB it names. A check that recomputes the declared size instead
+            // of measuring the buffer compares against the unwrapped value, passes,
+            // and the extraction then overruns the real allocation.
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
+            dataset.AddOrUpdate(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage);
+            dataset.AddOrUpdate(DicomTag.SOPInstanceUID, DicomUID.Generate());
+            dataset.AddOrUpdate(DicomTag.Rows, (ushort)2048);
+            dataset.AddOrUpdate(DicomTag.Columns, (ushort)2048);
+            dataset.AddOrUpdate(DicomTag.SamplesPerPixel, (ushort)1);
+            dataset.AddOrUpdate(DicomTag.PhotometricInterpretation, "MONOCHROME2");
+            dataset.AddOrUpdate(DicomTag.BitsAllocated, (ushort)16);
+            dataset.AddOrUpdate(DicomTag.BitsStored, (ushort)16);
+            dataset.AddOrUpdate(DicomTag.HighBit, (ushort)15);
+            dataset.AddOrUpdate(DicomTag.PixelRepresentation, (ushort)0);
+
+            var pixels = new byte[2048 * 2048 * 2];
+            for (var i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = (byte)(i & 0xFF);
+            }
+
+            DicomPixelData.Create(dataset, true).AddFrame(new MemoryByteBuffer(pixels));
+
+            var encoded = dataset.Clone(DicomTransferSyntax.JPEG2000Lossless);
+            encoded.AddOrUpdate(DicomTag.Rows, (ushort)33000);
+            encoded.AddOrUpdate(DicomTag.Columns, (ushort)65103);
+
+            try
+            {
+                encoded.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
+                Assert.Fail("Expected a DicomCodecException for geometry whose size computation overflows.");
+            }
+            catch (DicomCodecException e)
+            {
+                StringAssert.Contains(e.Message, "larger than the pixel buffer");
+            }
+        }
+
+        [TestMethod]
+        [DataRow((ushort)8)]
+        [DataRow((ushort)16)]
+        public void DecodeJpeg2000SmallerThanDeclaredGeometrySucceeds(ushort bitsAllocated)
+        {
+            // Positive control: over-declared geometry leaves spare room in the
+            // destination buffer and has always decoded, so the check stays
+            // one-sided instead of demanding an exact match.
+            var encoded = BuildEncoded(bitsAllocated, 128);
+
+            var decoded = encoded.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
+
+            Assert.AreEqual(DicomTransferSyntax.ExplicitVRLittleEndian, decoded.InternalTransferSyntax);
+            Assert.AreEqual(128 * 128 * (bitsAllocated / 8), DicomPixelData.Create(decoded).GetFrame(0).Data.Length);
+        }
+    }
+}


### PR DESCRIPTION
`DicomJpeg2000NativeCodec.Decode` sizes its destination buffer from the dataset's declared geometry, but drives the extraction loop from the codestream's own extent and component count. The two are never compared, so a file whose codestream covers more samples than the declared geometry writes past the end of the buffer.

`newPixelData.Width` appears exactly once in the file today — in the sizing expression — so there is no geometry comparison anywhere in the decode path.

### Why it is a heap corruption rather than an exception

The 8-bit extractor writes through the managed indexer `destData.Data[offsetAcumulator]`, so the CLR bounds-checks it and the surrounding `catch` turns it into a `DicomCodecException`. The 16-bit extractor writes through a raw `ushort*` (`ExtractDataLineByLinefor16bit`), which is unchecked — that path corrupts the heap and takes the process down with `Internal CLR error (0x80131506)` or an `AccessViolationException`, neither of which managed code can catch.

### The check

```csharp
if ((ulong)image->x1 * image->y1 * image->numcomps * (ulong)oldPixelData.BytesAllocated > (ulong)destArray.Count)
    throw new DicomCodecException("Error in JPEG 2000 decode stream => output image is larger than the pixel buffer the dataset declares");
```

Three things about the shape, since none of them are obvious:

- **It compares against `destArray.Count`, not against a recomputed declared size.** The sizing expression is `int` arithmetic and can wrap: `Rows=33000, Columns=65103, SamplesPerPixel=1, BitsAllocated=16` names ~4.3 GB but allocates 1,830,704 bytes. A bound that recomputes the declared size compares against the unwrapped value, passes, and the extraction still overruns. Measuring the allocation is immune to that.
- **It carries the component factor.** The write region is `numcomps * pixelCount` samples (interleaved uses `pos=c, offset=numcomps`; planar uses `pos=c*pixelCount, offset=1` — both top out at the same index), while the buffer holds `Width*Height*SamplesPerPixel`. Comparing pixel counts alone leaves a 3-component codestream in a dataset declaring `SamplesPerPixel=1` still overrunning.
- **It uses `oldPixelData.BytesAllocated`**, which is the same value that selects the 8-bit vs 16-bit extractor branch below, so the element size in the check matches the element size actually written.

It is deliberately one-sided. A codestream *smaller* than the declared geometry decodes as it always has and leaves the tail of the frame untouched, so nothing that works today starts failing.

### Verification

- Unit `66/66`, acceptance `300/300`.
- The acceptance corpus includes the PM5644-960x540 JPEG2000 RGB files, which sit exactly on the boundary (`960*540*3*1`), so they confirm the check is not off by one in the strict direction.
- Over-declared geometry still decodes, measured: `Columns=513` → 525,312 bytes, `Columns=1024` → 1,048,576, `Rows=65534` → 67,106,816.
- Each new negative test was run against unpatched `master` and fails there — the 16-bit rows by aborting the test host, which is the signature being fixed. They assert on the message text rather than just the exception type, because the 8-bit path already threw `DicomCodecException` (wrapping `IndexOutOfRangeException`) and a bare `catch` would pass with or without this change.

### Scope

Decode only, and only `DicomJpeg2000NativeCodec`. `DicomHtJpeg2000Codec` has a structurally similar unguarded surface — it sizes a pooled buffer with the same expression and hands the bare pointer to native code — but it is a separate class that never reaches these extractors, so it is left alone here.

Two related things I did not fold in, to keep this reviewable:

- The `int` arithmetic in the sizing expression can also wrap *negative*, in which case `new PinnedByteArray(...)` throws a raw `OverflowException` from outside the `try`, so it escapes `Decode` unwrapped instead of as a `DicomCodecException`. Memory-safe, but inconsistent. Widening that expression to `long` would fix it and is a bigger change than this.
- `pixelCount` is still `(int)(image->x1 * image->y1)`, a `uint` multiply that wraps before the cast. The guard is conservative with respect to it in every case, so it is not reachable now.

Happy to split, reshape, or drop any of it — including making the check strict rather than one-sided if you would rather reject over-declared geometry too, though that would change behaviour for files that decode today.
