### PR TITLE
Reject an HTJ2K codestream that does not fit the declared pixel buffer

### DIFF
--- a/Codec/DicomHtJpeg2000Codec.cs
+++ b/Codec/DicomHtJpeg2000Codec.cs
@@ -124,6 +124,62 @@ namespace FellowOakDicom.Imaging.NativeCodec
         [DllImport("Dicom.Native", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall, EntryPoint = "InvokeHTJ2KDecode")]
         public static extern unsafe void InvokeHTJ2KDecode(ref Raw_outdata raw_outinfo, byte* source, ulong sourceLength);
 
+        /// <summary>
+        /// Reads the decoded size the native decoder will produce, from the codestream's own
+        /// SIZ marker. Mirrors HTJpeg2000DecodeStream term for term: width and height are the
+        /// image extent minus the image offset, multiplied by the component count and by the
+        /// bytes per sample taken from component zero's precision.
+        /// </summary>
+        /// <returns>
+        /// false when the header cannot be read, in which case the caller must not reject:
+        /// a guard that turned an unreadable header into a refusal would fail files the decoder
+        /// handles today, which is a worse regression than the one it is closing.
+        /// </returns>
+        private static bool TryGetCodestreamLength(byte[] codestream, out ulong length)
+        {
+            length = 0;
+
+            //SOC then SIZ, at fixed offsets. The native side hands these bytes straight to
+            //ojph::codestream::read_headers, which expects a raw codestream laid out exactly
+            //this way, so anything else is not something this decoder would have decoded.
+            //Searching for the marker instead would risk matching 0xFF51 inside arbitrary
+            //data and computing a size from it, which could refuse a perfectly good file.
+            //43 bytes is the smallest prefix that still carries component zero's Ssiz, which
+            //sits at 42; anything shorter cannot be read without going out of bounds here.
+            if (codestream == null || codestream.Length < 43)
+                return false;
+            if (codestream[0] != 0xFF || codestream[1] != 0x4F)
+                return false;
+            if (codestream[2] != 0xFF || codestream[3] != 0x51)
+                return false;
+
+            //Big-endian, per the JPEG 2000 codestream syntax. Offsets are from the SIZ marker
+            //at 2: Lsiz 4, Rsiz 6, Xsiz 8, Ysiz 12, XOsiz 16, YOsiz 20, then the four tile
+            //fields, Csiz at 40 and component zero's Ssiz at 42.
+            uint xsiz = ReadUInt32(codestream, 8);
+            uint ysiz = ReadUInt32(codestream, 12);
+            uint xosiz = ReadUInt32(codestream, 16);
+            uint yosiz = ReadUInt32(codestream, 20);
+            ushort csiz = (ushort)((codestream[40] << 8) | codestream[41]);
+
+            if (xsiz <= xosiz || ysiz <= yosiz || csiz == 0)
+                return false;
+
+            //Ssiz carries the precision less one in its low seven bits; the high bit is the
+            //sign flag and does not change the byte width.
+            int bitsPerSample = (codestream[42] & 0x7F) + 1;
+            ulong bytesPerSample = (ulong)((bitsPerSample + 8 - 1) / 8);
+
+            length = (ulong)(xsiz - xosiz) * (ysiz - yosiz) * csiz * bytesPerSample;
+            return true;
+        }
+
+        private static uint ReadUInt32(byte[] data, int offset)
+        {
+            return ((uint)data[offset] << 24) | ((uint)data[offset + 1] << 16) |
+                   ((uint)data[offset + 2] << 8) | data[offset + 3];
+        }
+
         public override unsafe void Encode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters)
         {
             unsafe
@@ -287,6 +343,19 @@ namespace FellowOakDicom.Imaging.NativeCodec
 
                     try
                     {
+                        //The native decoder sizes its own output from the codestream's SIZ marker and
+                        //memcpy's that many bytes into frameData, which was rented from the geometry the
+                        //dataset declares. Neither side compares the two, so a codestream covering a
+                        //larger extent than the declared geometry writes past the end of the rented array.
+                        //Reject before the call rather than after, since by then the write has happened.
+                        //Compare against the rented length rather than recomputing the declared size, so
+                        //the check holds even where the sizing arithmetic above overflows. Only the
+                        //larger-than case is rejected, and only when the extent was positively read, so a
+                        //smaller codestream and an unparsable header both decode as they always have.
+                        if (TryGetCodestreamLength(htjpeg2kData.Data, out ulong required) &&
+                            required > (ulong)frameData.Length)
+                            throw new DicomCodecException("Error in HTJ2K decode stream => output image is larger than the pixel buffer the dataset declares");
+
                         Raw_outdata raw_Outdata;
 
                         unsafe

--- a/Tests/Unit/HtJpeg2000GeometryUnitTest.cs
+++ b/Tests/Unit/HtJpeg2000GeometryUnitTest.cs
@@ -1,0 +1,139 @@
+using FellowOakDicom.Imaging.Codec;
+using FellowOakDicom.IO.Buffer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FellowOakDicom.Imaging.NativeCodec.Test
+{
+    /// <summary>
+    /// Regression coverage for an HTJ2K codestream whose extent disagrees with the
+    /// geometry the dataset declares. Decode rents its destination buffer from
+    /// Rows/Columns/SamplesPerPixel/BitsAllocated, while the native decoder sizes its
+    /// own output from the codestream's SIZ marker and memcpy's that many bytes into
+    /// it. Neither side compared the two, so a codestream covering a larger extent
+    /// than the declared geometry wrote past the end of the rented array.
+    ///
+    /// This is the same defect Jpeg2000GeometryUnitTest covers for the classic
+    /// decoder. The guard there does not apply here: it sits in DicomJpeg2000Codec,
+    /// and the HTJ2K codecs are a separate IDicomCodec registered by reflection for
+    /// transfer syntaxes 1.2.840.10008.1.2.4.201 / .202 / .203.
+    /// </summary>
+    [TestClass]
+    public class HtJpeg2000GeometryUnitTest
+    {
+        // Side of the image handed to the encoder, and therefore the extent the
+        // resulting codestream reports. The declared geometry is rewritten
+        // afterwards, so it can differ from this in either direction.
+        private const ushort CodestreamSide = 64;
+
+        private static readonly DicomTransferSyntax HtJ2KLossless =
+            DicomTransferSyntax.Parse("1.2.840.10008.1.2.4.201");
+
+        [TestInitialize]
+        public void Initialization()
+        {
+            new DicomSetupBuilder()
+                .RegisterServices(s => s.AddFellowOakDicom().AddTranscoderManager<NativeTranscoderManager>())
+                .SkipValidation()
+                .Build();
+        }
+
+        /// <summary>
+        /// Encodes a square image with the HTJ2K encoder, then rewrites Rows and
+        /// Columns on the encapsulated dataset. The codestream is left untouched, so
+        /// its extent no longer matches the geometry the dataset declares.
+        /// </summary>
+        private static DicomDataset BuildEncoded(ushort bitsAllocated, ushort declaredSide)
+        {
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
+            dataset.AddOrUpdate(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage);
+            dataset.AddOrUpdate(DicomTag.SOPInstanceUID, DicomUID.Generate());
+            dataset.AddOrUpdate(DicomTag.Rows, CodestreamSide);
+            dataset.AddOrUpdate(DicomTag.Columns, CodestreamSide);
+            dataset.AddOrUpdate(DicomTag.SamplesPerPixel, (ushort)1);
+            dataset.AddOrUpdate(DicomTag.PhotometricInterpretation, "MONOCHROME2");
+            dataset.AddOrUpdate(DicomTag.BitsAllocated, bitsAllocated);
+            dataset.AddOrUpdate(DicomTag.BitsStored, bitsAllocated);
+            dataset.AddOrUpdate(DicomTag.HighBit, (ushort)(bitsAllocated - 1));
+            dataset.AddOrUpdate(DicomTag.PixelRepresentation, (ushort)0);
+            dataset.AddOrUpdate(DicomTag.NumberOfFrames, 1);
+
+            var pixels = new byte[CodestreamSide * CodestreamSide * (bitsAllocated / 8)];
+            for (var i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = (byte)(i & 0xFF);
+            }
+
+            DicomPixelData.Create(dataset, true).AddFrame(new MemoryByteBuffer(pixels));
+
+            var encoded = dataset.Clone(HtJ2KLossless);
+            encoded.AddOrUpdate(DicomTag.Rows, declaredSide);
+            encoded.AddOrUpdate(DicomTag.Columns, declaredSide);
+            return encoded;
+        }
+
+        [TestMethod]
+        [DataRow((ushort)8)]
+        [DataRow((ushort)16)]
+        public void DecodeHtJpeg2000LargerThanDeclaredGeometryReportsErrorInsteadOfOverrunning(ushort bitsAllocated)
+        {
+            // A 64x64 codestream against a dataset declaring 8x8: the native decoder
+            // produces 4096 pixels for a buffer rented to hold 64 of them.
+            var encoded = BuildEncoded(bitsAllocated, 8);
+
+            try
+            {
+                encoded.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
+                Assert.Fail("Expected a DicomCodecException for a codestream larger than the declared geometry.");
+            }
+            catch (DicomCodecException e)
+            {
+                // Assert on the message, not just the type. Without the guard this
+                // input still ends in a DicomCodecException: the native memcpy
+                // overruns the rented array first, and the Buffer.BlockCopy that
+                // follows then throws because the decoded size exceeds it. A bare
+                // catch(DicomCodecException) therefore passes with or without the
+                // fix, while the write it is meant to prevent has already happened.
+                // At larger extents the same input instead kills the process outright
+                // (Fatal error 0x80131506, the runtime failing inside its own
+                // exception path because the heap is already damaged), which is why
+                // this test uses the smaller one that reports rather than terminates.
+                StringAssert.Contains(e.Message, "larger than the pixel buffer");
+            }
+        }
+
+        /// <summary>
+        /// The control that keeps the guard honest. Only the larger-than case may be
+        /// rejected: a codestream smaller than the declared geometry fits the rented
+        /// buffer and has always decoded, so rejecting it would be a regression
+        /// dressed up as a fix.
+        /// </summary>
+        [TestMethod]
+        [DataRow((ushort)8)]
+        [DataRow((ushort)16)]
+        public void DecodeHtJpeg2000SmallerThanDeclaredGeometryStillDecodes(ushort bitsAllocated)
+        {
+            var encoded = BuildEncoded(bitsAllocated, 128);
+
+            var decoded = encoded.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
+
+            Assert.IsNotNull(DicomPixelData.Create(decoded).GetFrame(0));
+        }
+
+        /// <summary>
+        /// The other half of the control: a codestream that agrees with the declared
+        /// geometry must be untouched by the guard.
+        /// </summary>
+        [TestMethod]
+        [DataRow((ushort)8)]
+        [DataRow((ushort)16)]
+        public void DecodeHtJpeg2000MatchingGeometryStillDecodes(ushort bitsAllocated)
+        {
+            var encoded = BuildEncoded(bitsAllocated, CodestreamSide);
+
+            var decoded = encoded.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
+
+            var frame = DicomPixelData.Create(decoded).GetFrame(0);
+            Assert.AreEqual(CodestreamSide * CodestreamSide * (bitsAllocated / 8), frame.Size);
+        }
+    }
+}


### PR DESCRIPTION
`DicomHtJpeg2000NativeCodec.Decode` rents its destination buffer from the geometry the
dataset declares, while the native decoder sizes its own output from the codestream's SIZ
marker and copies that many bytes into it. Nothing compares the two, so a codestream
covering a larger extent than the declared geometry writes past the end of the rented
array.

Same shape as #190, different decoder. That guard sits in `DicomJpeg2000Codec`, and the
HTJ2K codecs are a separate `IDicomCodec` that `NativeTranscoderManager` registers by
reflection for `1.2.840.10008.1.2.4.201` / `.202` / `.203`, so they never reach it.

This is the overflow item from #145, which is still open. `cf0cfa35` addressed the
`uint` -> `ulong` marshalling in that issue; the size check is the part still missing.

### What the guard does

It reads the extent from the codestream's own SIZ marker and mirrors
`HTJpeg2000DecodeStream` term for term -- `(Xsiz - XOsiz) * (Ysiz - YOsiz) * Csiz`, times
the bytes per sample from component zero's precision -- then refuses when that exceeds the
rented array.

Two things it deliberately does not do:

- It compares against the **rented length** rather than recomputing the declared size, so
  the check still holds where the sizing arithmetic above it overflows.
- It rejects **only when the extent was positively read**. Fields are taken at fixed
  offsets after SOC, which is the layout `ojph::codestream::read_headers` requires;
  anything else falls through to current behaviour rather than becoming a refusal. A guard
  that failed files the decoder handles today would be a worse regression than the one it
  closes.

### Measured

A 64x64 codestream in a dataset declaring 8x8: before, the native copy writes 8192 bytes
into a 128-byte rented array, and the `Buffer.BlockCopy` that follows reports the mismatch
only afterwards -- detection after the write, not prevention. At 512x512 the same input
terminates the process instead, the runtime failing inside its own exception path because
the heap is already damaged. Both now raise `DicomCodecException` before any copy happens.

### Tests

`Tests/Unit/HtJpeg2000GeometryUnitTest.cs`, 6 cases across 8- and 16-bit, built from the
library's own encoder rather than a committed binary sample.

The oversized cases assert on the message rather than the exception type on purpose: the
unguarded path also ends in `DicomCodecException`, so a bare `catch` would pass either
way. Two controls keep the guard honest -- a codestream smaller than the declared geometry,
and one matching it exactly, both of which must still decode.

Removing the guard does not merely fail those tests; it aborts the test host. Full unit
suite is 72/72 locally with the native library present.

Is there a reason the HTJ2K path was left out of #190's scope, or would you rather the
check live on the native side of the boundary instead? Happy to move it if that fits the
v6.0 shape better.
